### PR TITLE
Stabilize tracing feature

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -28,7 +28,7 @@ once_cell = "1.5.2"
 libc = "0.2"
 
 [target.'cfg(all(tokio_unstable, target_os = "linux"))'.dev-dependencies]
-tokio = { version = "1.0.0", path = "../tokio", features = ["full", "tracing", "taskdump"] }
+tokio = { version = "1.0.0", path = "../tokio", features = ["full", "taskdump"] }
 
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = "0.61"

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Changed
+
+- tracing: stabilize the `tracing` feature flag, removing the requirement for `tokio_unstable`
+
 # 1.52.3 (May 8th, 2026)
 
 ### Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -100,14 +100,10 @@ pin-project-lite = "0.2.11"
 bytes = { version = "1.2.1", optional = true }
 mio = { version = "1.2.0", optional = true, default-features = false }
 parking_lot = { version = "0.12.0", optional = true }
+tracing = { version = "0.1.29", default-features = false, features = ["std"], optional = true } # Not in full
 
 [target.'cfg(any(not(target_family = "wasm"), all(target_os = "wasi", not(target_env = "p1"))))'.dependencies]
 socket2 = { version = "0.6.3", optional = true, features = ["all"] }
-
-# Currently unstable. The API exposed by these features may be broken at any time.
-# Requires `--cfg tokio_unstable` to enable.
-[target.'cfg(tokio_unstable)'.dependencies]
-tracing = { version = "0.1.29", default-features = false, features = ["std"], optional = true } # Not in full
 
 # Currently unstable. The API exposed by these features may be broken at any time.
 # Requires `--cfg tokio_unstable` to enable.
@@ -170,7 +166,7 @@ mio-aio = { version = "2", features = ["tokio"] }
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7", features = ["futures", "checkpoint"] }
 
-[target.'cfg(all(tokio_unstable, target_has_atomic = "64"))'.dev-dependencies]
+[target.'cfg(target_has_atomic = "64")'.dev-dependencies]
 tracing-mock = "= 0.1.0-beta.1"
 
 [package.metadata.docs.rs]

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -353,7 +353,6 @@
 //!
 //! Some feature flags are only available when specifying the `tokio_unstable` flag:
 //!
-//! - `tracing`: Enables tracing events.
 //! - `schedule-latency`: Allows measurement of task scheduling latencies.
 //! - `io-uring`: Enables `io-uring` (Linux only).
 //! - `taskdump`: Enables `taskdump` (Linux only).

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -596,8 +596,8 @@ macro_rules! cfg_not_time {
 macro_rules! cfg_trace {
     ($($item:item)*) => {
         $(
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
-            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+            #[cfg(feature = "tracing")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
             $item
         )*
     };
@@ -616,7 +616,7 @@ macro_rules! cfg_unstable {
 macro_rules! cfg_not_trace {
     ($($item:item)*) => {
         $(
-            #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+            #[cfg(not(feature = "tracing"))]
             $item
         )*
     }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -364,7 +364,7 @@ impl Handle {
         ))]
         let future = super::task::trace::Trace::root(future);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let future =
             crate::util::trace::task(future, "block_on", _meta, super::task::Id::next().as_u64());
 
@@ -395,7 +395,7 @@ impl Handle {
             )
         ))]
         let future = super::task::trace::Trace::root(future);
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let future = crate::util::trace::task(future, "task", meta, id.as_u64());
         self.inner.spawn(future, id, meta.spawned_at)
     }
@@ -429,7 +429,7 @@ impl Handle {
             )
         ))]
         let future = super::task::trace::Trace::root(future);
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let future = crate::util::trace::task(future, "task", meta, id.as_u64());
         unsafe { self.inner.spawn_local(future, id, meta.spawned_at) }
     }

--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -243,7 +243,7 @@ impl LocalRuntime {
         ))]
         let future = crate::runtime::task::trace::Trace::root(future);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let future = crate::util::trace::task(
             future,
             "block_on",

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -362,7 +362,7 @@ impl Runtime {
         ))]
         let future = super::task::trace::Trace::root(future);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let future = crate::util::trace::task(
             future,
             "block_on",

--- a/tokio/src/runtime/task/core.rs
+++ b/tokio/src/runtime/task/core.rs
@@ -190,7 +190,7 @@ pub(crate) struct Header {
     pub(super) owner_id: UnsafeCell<Option<NonZeroU64>>,
 
     /// The tracing ID for this instrumented task.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) tracing_id: Option<tracing::Id>,
 
     /// The last time this task was scheduled. Used to measure schedule latency.
@@ -242,20 +242,20 @@ impl<T: Future, S: Schedule> Cell<T, S> {
         fn new_header(
             state: State,
             vtable: &'static Vtable,
-            #[cfg(all(tokio_unstable, feature = "tracing"))] tracing_id: Option<tracing::Id>,
+            #[cfg(feature = "tracing")] tracing_id: Option<tracing::Id>,
         ) -> Header {
             Header {
                 state,
                 queue_next: UnsafeCell::new(None),
                 vtable,
                 owner_id: UnsafeCell::new(None),
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 tracing_id,
                 scheduled_at: UnsafeCell::new(ScheduleLatencyInstant::new(None)),
             }
         }
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let tracing_id = future.id();
         let vtable = raw::vtable::<T, S>();
         let result = Box::new(Cell {
@@ -263,7 +263,7 @@ impl<T: Future, S: Schedule> Cell<T, S> {
             header: new_header(
                 state,
                 vtable,
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 tracing_id,
             ),
             core: Core {
@@ -535,7 +535,7 @@ impl Header {
     /// # Safety
     ///
     /// The provided raw pointer must point at the header of a task.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) unsafe fn get_tracing_id(me: &NonNull<Header>) -> Option<&tracing::Id> {
         me.as_ref().tracing_id.as_ref()
     }

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -637,9 +637,9 @@ unsafe impl<S> sharded_list::ShardedListItem for Task<S> {
     }
 }
 
-/// Wrapper around [`std::panic::Location`] that's conditionally compiled out
-/// when `tokio_unstable` is not enabled.
-#[cfg(tokio_unstable)]
+/// Wrapper around [`std::panic::Location`] that stores the caller location when
+/// the `tracing` feature or `tokio_unstable` is enabled, and is zero-sized otherwise.
+#[cfg(any(feature = "tracing", tokio_unstable))]
 mod spawn_location {
 
     use std::panic::Location;
@@ -654,7 +654,7 @@ mod spawn_location {
     }
 }
 
-#[cfg(not(tokio_unstable))]
+#[cfg(not(any(feature = "tracing", tokio_unstable)))]
 mod spawn_location {
     use std::panic::Location;
 

--- a/tokio/src/runtime/task/waker.rs
+++ b/tokio/src/runtime/task/waker.rs
@@ -70,7 +70,7 @@ cfg_not_trace! {
 unsafe fn clone_waker(ptr: *const ()) -> RawWaker {
     // Safety: `ptr` was created from a `Header` pointer in function `waker_ref`.
     let header = unsafe { NonNull::new_unchecked(ptr as *mut Header) };
-    #[cfg_attr(not(all(tokio_unstable, feature = "tracing")), allow(unused_unsafe))]
+    #[cfg_attr(not(feature = "tracing"), allow(unused_unsafe))]
     unsafe {
         trace!(header, "waker.clone");
     }
@@ -82,7 +82,7 @@ unsafe fn drop_waker(ptr: *const ()) {
     // Safety: `ptr` was created from a `Header` pointer in function `waker_ref`.
     let ptr = unsafe { NonNull::new_unchecked(ptr as *mut Header) };
     // TODO; replace to #[expect(unused_unsafe)] after bumping MSRV to 1.81.0.
-    #[cfg_attr(not(all(tokio_unstable, feature = "tracing")), allow(unused_unsafe))]
+    #[cfg_attr(not(feature = "tracing"), allow(unused_unsafe))]
     unsafe {
         trace!(ptr, "waker.drop");
     }
@@ -94,7 +94,7 @@ unsafe fn wake_by_val(ptr: *const ()) {
     // Safety: `ptr` was created from a `Header` pointer in function `waker_ref`.
     let ptr = unsafe { NonNull::new_unchecked(ptr as *mut Header) };
     // TODO; replace to #[expect(unused_unsafe)] after bumping MSRV to 1.81.0.
-    #[cfg_attr(not(all(tokio_unstable, feature = "tracing")), allow(unused_unsafe))]
+    #[cfg_attr(not(feature = "tracing"), allow(unused_unsafe))]
     unsafe {
         trace!(ptr, "waker.wake");
     }
@@ -107,7 +107,7 @@ unsafe fn wake_by_ref(ptr: *const ()) {
     // Safety: `ptr` was created from a `Header` pointer in function `waker_ref`.
     let ptr = unsafe { NonNull::new_unchecked(ptr as *mut Header) };
     // TODO; replace to #[expect(unused_unsafe)] after bumping MSRV to 1.81.0.
-    #[cfg_attr(not(all(tokio_unstable, feature = "tracing")), allow(unused_unsafe))]
+    #[cfg_attr(not(feature = "tracing"), allow(unused_unsafe))]
     unsafe {
         trace!(ptr, "waker.wake_by_ref");
     }

--- a/tokio/src/runtime/tests/mod.rs
+++ b/tokio/src/runtime/tests/mod.rs
@@ -32,7 +32,7 @@ mod unowned_wrapper {
     use crate::runtime::task::{Id, JoinHandle, Notified, SpawnLocation};
     use crate::runtime::tests::NoopSchedule;
 
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     #[track_caller]
     pub(crate) fn unowned<T>(task: T) -> (Notified<NoopSchedule>, JoinHandle<T::Output>)
     where
@@ -47,7 +47,7 @@ mod unowned_wrapper {
         (task.into_notified(), handle)
     }
 
-    #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+    #[cfg(not(all(feature = "tracing")))]
     #[track_caller]
     pub(crate) fn unowned<T>(task: T) -> (Notified<NoopSchedule>, JoinHandle<T::Output>)
     where

--- a/tokio/src/sync/barrier.rs
+++ b/tokio/src/sync/barrier.rs
@@ -1,6 +1,6 @@
 use crate::loom::sync::Mutex;
 use crate::sync::watch;
-#[cfg(all(tokio_unstable, feature = "tracing"))]
+#[cfg(feature = "tracing")]
 use crate::util::trace;
 
 /// A barrier enables multiple tasks to synchronize the beginning of some computation.
@@ -43,7 +43,7 @@ pub struct Barrier {
     state: Mutex<BarrierState>,
     wait: watch::Receiver<usize>,
     n: usize,
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
 }
 
@@ -70,7 +70,7 @@ impl Barrier {
             n = 1;
         }
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = {
             let location = std::panic::Location::caller();
             let resource_span = tracing::trace_span!(
@@ -105,7 +105,7 @@ impl Barrier {
             }),
             n,
             wait,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span,
         }
     }
@@ -123,7 +123,7 @@ impl Barrier {
     ///
     /// This method is not cancel safe.
     pub async fn wait(&self) -> BarrierWaitResult {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         return trace::async_op(
             || self.wait_internal(),
             self.resource_span.clone(),
@@ -133,7 +133,7 @@ impl Barrier {
         )
         .await;
 
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         return self.wait_internal().await;
     }
     async fn wait_internal(&self) -> BarrierWaitResult {
@@ -150,19 +150,19 @@ impl Barrier {
             let mut state = self.state.lock();
             let generation = state.generation;
             state.arrived += 1;
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             tracing::trace!(
                 target: "runtime::resource::state_update",
                 arrived = 1,
                 arrived.op = "add",
             );
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             tracing::trace!(
                 target: "runtime::resource::async_op::state_update",
                 arrived = true,
             );
             if state.arrived == self.n {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 tracing::trace!(
                     target: "runtime::resource::async_op::state_update",
                     is_leader = true,

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -19,7 +19,7 @@ use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::{Mutex, MutexGuard};
 use crate::util::linked_list::{self, LinkedList};
-#[cfg(all(tokio_unstable, feature = "tracing"))]
+#[cfg(feature = "tracing")]
 use crate::util::trace;
 use crate::util::WakeList;
 
@@ -36,7 +36,7 @@ pub(crate) struct Semaphore {
     waiters: Mutex<Waitlist>,
     /// The current number of available permits in the semaphore.
     permits: AtomicUsize,
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
 }
 
@@ -104,7 +104,7 @@ struct Waiter {
     /// use `UnsafeCell` internally.
     pointers: linked_list::Pointers<Waiter>,
 
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     ctx: trace::AsyncOpTracingCtx,
 
     /// Should not be `Unpin`.
@@ -144,7 +144,7 @@ impl Semaphore {
             Self::MAX_PERMITS
         );
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = {
             let resource_span = tracing::trace_span!(
                 parent: None,
@@ -170,7 +170,7 @@ impl Semaphore {
                 queue: LinkedList::new(),
                 closed: false,
             }),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span,
         }
     }
@@ -188,7 +188,7 @@ impl Semaphore {
                 queue: LinkedList::new(),
                 closed: false,
             }),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -201,7 +201,7 @@ impl Semaphore {
                 queue: LinkedList::new(),
                 closed: true,
             }),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -215,7 +215,7 @@ impl Semaphore {
                 queue: LinkedList::new(),
                 closed: true,
             }),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -349,7 +349,7 @@ impl Semaphore {
                 );
 
                 // add remaining permits back
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 self.resource_span.in_scope(|| {
                     tracing::trace!(
                     target: "runtime::resource::state_update",
@@ -447,7 +447,7 @@ impl Semaphore {
                     acquired += acq;
                     if remaining == 0 {
                         if !queued {
-                            #[cfg(all(tokio_unstable, feature = "tracing"))]
+                            #[cfg(feature = "tracing")]
                             self.resource_span.in_scope(|| {
                                 tracing::trace!(
                                     target: "runtime::resource::state_update",
@@ -476,7 +476,7 @@ impl Semaphore {
             return Poll::Ready(Err(AcquireError::closed()));
         }
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -531,15 +531,12 @@ impl fmt::Debug for Semaphore {
 }
 
 impl Waiter {
-    fn new(
-        num_permits: usize,
-        #[cfg(all(tokio_unstable, feature = "tracing"))] ctx: trace::AsyncOpTracingCtx,
-    ) -> Self {
+    fn new(num_permits: usize, #[cfg(feature = "tracing")] ctx: trace::AsyncOpTracingCtx) -> Self {
         Waiter {
             waker: UnsafeCell::new(None),
             state: AtomicUsize::new(num_permits),
             pointers: linked_list::Pointers::new(),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             ctx,
             _p: PhantomPinned,
         }
@@ -556,7 +553,7 @@ impl Waiter {
             match self.state.compare_exchange(curr, next, AcqRel, Acquire) {
                 Ok(_) => {
                     *n -= assign;
-                    #[cfg(all(tokio_unstable, feature = "tracing"))]
+                    #[cfg(feature = "tracing")]
                     self.ctx.async_op_span.in_scope(|| {
                         tracing::trace!(
                             target: "runtime::resource::async_op::state_update",
@@ -578,23 +575,23 @@ impl Future for Acquire<'_> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         ready!(crate::trace::trace_leaf());
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _resource_span = self.node.ctx.resource_span.clone().entered();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _async_op_span = self.node.ctx.async_op_span.clone().entered();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _async_op_poll_span = self.node.ctx.async_op_poll_span.clone().entered();
 
         let (node, semaphore, needed, queued) = self.project();
 
         // First, ensure the current task has enough budget to proceed.
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let coop = ready!(trace_poll_op!(
             "poll_acquire",
             crate::task::coop::poll_proceed(cx),
         ));
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 
         let result = match semaphore.poll_acquire(cx, needed, node, *queued) {
@@ -610,17 +607,17 @@ impl Future for Acquire<'_> {
             }
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         return trace_poll_op!("poll_acquire", result);
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         return result;
     }
 }
 
 impl<'a> Acquire<'a> {
     fn new(semaphore: &'a Semaphore, num_permits: usize) -> Self {
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         return Self {
             node: Waiter::new(num_permits),
             semaphore,
@@ -628,7 +625,7 @@ impl<'a> Acquire<'a> {
             queued: false,
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         return semaphore.resource_span.in_scope(|| {
             let async_op_span =
                 tracing::trace_span!("runtime.resource.async_op", source = "Acquire::new");

--- a/tokio/src/sync/mutex.rs
+++ b/tokio/src/sync/mutex.rs
@@ -1,7 +1,7 @@
 #![cfg_attr(not(feature = "sync"), allow(unreachable_pub, dead_code))]
 
 use crate::sync::batch_semaphore as semaphore;
-#[cfg(all(tokio_unstable, feature = "tracing"))]
+#[cfg(feature = "tracing")]
 use crate::util::trace;
 
 use std::cell::UnsafeCell;
@@ -131,7 +131,7 @@ use std::{fmt, mem, ptr};
 /// [`Send`]: trait@std::marker::Send
 /// [`lock`]: method@Mutex::lock
 pub struct Mutex<T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     s: semaphore::Semaphore,
     c: UnsafeCell<T>,
@@ -151,7 +151,7 @@ pub struct Mutex<T: ?Sized> {
 pub struct MutexGuard<'a, T: ?Sized> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     lock: &'a Mutex<T>,
 }
@@ -175,7 +175,7 @@ pub struct MutexGuard<'a, T: ?Sized> {
 pub struct OwnedMutexGuard<T: ?Sized> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     lock: Arc<Mutex<T>>,
 }
@@ -190,7 +190,7 @@ pub struct OwnedMutexGuard<T: ?Sized> {
 pub struct MappedMutexGuard<'a, T: ?Sized> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     s: &'a semaphore::Semaphore,
     data: *mut T,
@@ -209,7 +209,7 @@ pub struct MappedMutexGuard<'a, T: ?Sized> {
 pub struct OwnedMappedMutexGuard<T: ?Sized, U: ?Sized = T> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     data: *mut U,
     lock: Arc<Mutex<T>>,
@@ -219,7 +219,7 @@ pub struct OwnedMappedMutexGuard<T: ?Sized, U: ?Sized = T> {
 /// Drop implementation.
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct MutexGuardInner<'a, T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     lock: &'a Mutex<T>,
 }
@@ -227,7 +227,7 @@ struct MutexGuardInner<'a, T: ?Sized> {
 /// A helper type used when taking apart a `OwnedMutexGuard` without running
 /// its Drop implementation.
 struct OwnedMutexGuardInner<T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     lock: Arc<Mutex<T>>,
 }
@@ -236,7 +236,7 @@ struct OwnedMutexGuardInner<T: ?Sized> {
 /// its Drop implementation.
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct MappedMutexGuardInner<'a, T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     s: &'a semaphore::Semaphore,
     data: *mut T,
@@ -246,7 +246,7 @@ struct MappedMutexGuardInner<'a, T: ?Sized> {
 /// its Drop implementation.
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct OwnedMappedMutexGuardInner<T: ?Sized, U: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     data: *mut U,
     lock: Arc<Mutex<T>>,
@@ -339,7 +339,7 @@ impl<T: ?Sized> Mutex<T> {
     where
         T: Sized,
     {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = {
             let location = std::panic::Location::caller();
 
@@ -354,7 +354,7 @@ impl<T: ?Sized> Mutex<T> {
             )
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let s = resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -363,13 +363,13 @@ impl<T: ?Sized> Mutex<T> {
             semaphore::Semaphore::new(1)
         });
 
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         let s = semaphore::Semaphore::new(1);
 
         Self {
             c: UnsafeCell::new(t),
             s,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span,
         }
     }
@@ -399,7 +399,7 @@ impl<T: ?Sized> Mutex<T> {
         Self {
             c: UnsafeCell::new(t),
             s: semaphore::Semaphore::const_new(1),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -437,12 +437,12 @@ impl<T: ?Sized> Mutex<T> {
 
             MutexGuard {
                 lock: self,
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: self.resource_span.clone(),
             }
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let acquire_fut = trace::async_op(
             move || acquire_fut,
             self.resource_span.clone(),
@@ -454,7 +454,7 @@ impl<T: ?Sized> Mutex<T> {
         #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -616,20 +616,20 @@ impl<T: ?Sized> Mutex<T> {
     ///
     /// [`Arc`]: std::sync::Arc
     pub async fn lock_owned(self: Arc<Self>) -> OwnedMutexGuard<T> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = self.resource_span.clone();
 
         let acquire_fut = async {
             self.acquire().await;
 
             OwnedMutexGuard {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: self.resource_span.clone(),
                 lock: self,
             }
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let acquire_fut = trace::async_op(
             move || acquire_fut,
             resource_span,
@@ -641,7 +641,7 @@ impl<T: ?Sized> Mutex<T> {
         #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -684,11 +684,11 @@ impl<T: ?Sized> Mutex<T> {
             Ok(()) => {
                 let guard = MutexGuard {
                     lock: self,
-                    #[cfg(all(tokio_unstable, feature = "tracing"))]
+                    #[cfg(feature = "tracing")]
                     resource_span: self.resource_span.clone(),
                 };
 
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 self.resource_span.in_scope(|| {
                     tracing::trace!(
                         target: "runtime::resource::state_update",
@@ -751,12 +751,12 @@ impl<T: ?Sized> Mutex<T> {
         match self.s.try_acquire(1) {
             Ok(()) => {
                 let guard = OwnedMutexGuard {
-                    #[cfg(all(tokio_unstable, feature = "tracing"))]
+                    #[cfg(feature = "tracing")]
                     resource_span: self.resource_span.clone(),
                     lock: self,
                 };
 
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 guard.resource_span.in_scope(|| {
                     tracing::trace!(
                         target: "runtime::resource::state_update",
@@ -829,7 +829,7 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
         // SAFETY: This duplicates the `resource_span` and then forgets the
         // original. In the end, we have not duplicated or forgotten any values.
         MutexGuardInner {
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: unsafe { std::ptr::read(&me.resource_span) },
             lock: me.lock,
         }
@@ -877,7 +877,7 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
             s: &inner.lock.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         }
     }
@@ -929,7 +929,7 @@ impl<'a, T: ?Sized> MutexGuard<'a, T> {
             s: &inner.lock.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         })
     }
@@ -965,7 +965,7 @@ impl<T: ?Sized> Drop for MutexGuard<'_, T> {
     fn drop(&mut self) {
         self.lock.s.release(1);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -1010,7 +1010,7 @@ impl<T: ?Sized> OwnedMutexGuard<T> {
         unsafe {
             OwnedMutexGuardInner {
                 lock: ptr::read(&me.lock),
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: ptr::read(&me.resource_span),
             }
         }
@@ -1058,7 +1058,7 @@ impl<T: ?Sized> OwnedMutexGuard<T> {
         OwnedMappedMutexGuard {
             data,
             lock: inner.lock,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         }
     }
@@ -1110,7 +1110,7 @@ impl<T: ?Sized> OwnedMutexGuard<T> {
         Ok(OwnedMappedMutexGuard {
             data,
             lock: inner.lock,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         })
     }
@@ -1147,7 +1147,7 @@ impl<T: ?Sized> Drop for OwnedMutexGuard<T> {
     fn drop(&mut self) {
         self.lock.s.release(1);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -1190,7 +1190,7 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
         MappedMutexGuardInner {
             s: me.s,
             data: me.data,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: unsafe { std::ptr::read(&me.resource_span) },
         }
     }
@@ -1214,7 +1214,7 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
             s: inner.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         }
     }
@@ -1242,7 +1242,7 @@ impl<'a, T: ?Sized> MappedMutexGuard<'a, T> {
             s: inner.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         })
     }
@@ -1252,7 +1252,7 @@ impl<'a, T: ?Sized> Drop for MappedMutexGuard<'a, T> {
     fn drop(&mut self) {
         self.s.release(1);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -1298,7 +1298,7 @@ impl<T: ?Sized, U: ?Sized> OwnedMappedMutexGuard<T, U> {
             OwnedMappedMutexGuardInner {
                 data: me.data,
                 lock: ptr::read(&me.lock),
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: ptr::read(&me.resource_span),
             }
         }
@@ -1322,7 +1322,7 @@ impl<T: ?Sized, U: ?Sized> OwnedMappedMutexGuard<T, U> {
         OwnedMappedMutexGuard {
             data,
             lock: inner.lock,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         }
     }
@@ -1350,7 +1350,7 @@ impl<T: ?Sized, U: ?Sized> OwnedMappedMutexGuard<T, U> {
         Ok(OwnedMappedMutexGuard {
             data,
             lock: inner.lock,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: inner.resource_span,
         })
     }
@@ -1360,7 +1360,7 @@ impl<T: ?Sized, U: ?Sized> Drop for OwnedMappedMutexGuard<T, U> {
     fn drop(&mut self) {
         self.lock.s.release(1);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
                 target: "runtime::resource::state_update",

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -126,7 +126,7 @@
 use crate::loom::cell::UnsafeCell;
 use crate::loom::sync::atomic::AtomicUsize;
 use crate::loom::sync::Arc;
-#[cfg(all(tokio_unstable, feature = "tracing"))]
+#[cfg(feature = "tracing")]
 use crate::util::trace;
 
 use std::fmt;
@@ -221,7 +221,7 @@ use std::task::{ready, Context, Poll, Waker};
 #[derive(Debug)]
 pub struct Sender<T> {
     inner: Option<Arc<Inner<T>>>,
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
 }
 
@@ -328,11 +328,11 @@ pub struct Sender<T> {
 #[derive(Debug)]
 pub struct Receiver<T> {
     inner: Option<Arc<Inner<T>>>,
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     async_op_span: tracing::Span,
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     async_op_poll_span: tracing::Span,
 }
 
@@ -495,7 +495,7 @@ struct State(usize);
 /// ```
 #[track_caller]
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     let resource_span = {
         let location = std::panic::Location::caller();
 
@@ -553,25 +553,25 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 
     let tx = Sender {
         inner: Some(inner.clone()),
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         resource_span: resource_span.clone(),
     };
 
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     let async_op_span = resource_span
         .in_scope(|| tracing::trace_span!("runtime.resource.async_op", source = "Receiver::await"));
 
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     let async_op_poll_span =
         async_op_span.in_scope(|| tracing::trace_span!("runtime.resource.async_op.poll"));
 
     let rx = Receiver {
         inner: Some(inner),
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         resource_span,
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         async_op_span,
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         async_op_poll_span,
     };
 
@@ -645,7 +645,7 @@ impl<T> Sender<T> {
             }
         }
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -727,9 +727,9 @@ impl<T> Sender<T> {
     pub async fn closed(&mut self) {
         use std::future::poll_fn;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = self.resource_span.clone();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let closed = trace::async_op(
             || poll_fn(|cx| self.poll_closed(cx)),
             resource_span,
@@ -737,7 +737,7 @@ impl<T> Sender<T> {
             "poll_closed",
             false,
         );
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         let closed = poll_fn(|cx| self.poll_closed(cx));
 
         closed.await;
@@ -872,7 +872,7 @@ impl<T> Drop for Sender<T> {
     fn drop(&mut self) {
         if let Some(inner) = self.inner.as_ref() {
             inner.complete();
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             self.resource_span.in_scope(|| {
                 tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -947,7 +947,7 @@ impl<T> Receiver<T> {
     pub fn close(&mut self) {
         if let Some(inner) = self.inner.as_ref() {
             inner.close();
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             self.resource_span.in_scope(|| {
                 tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -1180,7 +1180,7 @@ impl<T> Receiver<T> {
                 // cell.
                 match unsafe { inner.consume_value() } {
                     Some(value) => {
-                        #[cfg(all(tokio_unstable, feature = "tracing"))]
+                        #[cfg(feature = "tracing")]
                         self.resource_span.in_scope(|| {
                             tracing::trace!(
                             target: "runtime::resource::state_update",
@@ -1253,7 +1253,7 @@ impl<T> Drop for Receiver<T> {
                 drop(unsafe { inner.consume_value() });
             }
 
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             self.resource_span.in_scope(|| {
                 tracing::trace!(
                 target: "runtime::resource::state_update",
@@ -1271,19 +1271,19 @@ impl<T> Future for Receiver<T> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _res_span = this.resource_span.enter();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _ao_span = this.async_op_span.enter();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _ao_poll_span = this.async_op_poll_span.enter();
 
         // If `inner` is `None`, then `poll()` has already completed.
         let ret = if let Some(inner) = this.inner.as_ref() {
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             let res = ready!(trace_poll_op!("poll_recv", inner.poll_recv(cx)));
 
-            #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+            #[cfg(not(feature = "tracing"))]
             let res = ready!(inner.poll_recv(cx));
 
             res

--- a/tokio/src/sync/rwlock.rs
+++ b/tokio/src/sync/rwlock.rs
@@ -1,6 +1,6 @@
 use crate::sync::batch_semaphore::{Semaphore, TryAcquireError};
 use crate::sync::mutex::TryLockError;
-#[cfg(all(tokio_unstable, feature = "tracing"))]
+#[cfg(feature = "tracing")]
 use crate::util::trace;
 use std::cell::UnsafeCell;
 use std::marker;
@@ -85,7 +85,7 @@ const MAX_READS: u32 = 10;
 /// [`Send`]: trait@std::marker::Send
 /// [_write-preferring_]: https://en.wikipedia.org/wiki/Readers%E2%80%93writer_lock#Priority_policies
 pub struct RwLock<T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
 
     // maximum number of concurrent readers
@@ -204,7 +204,7 @@ impl<T: ?Sized> RwLock<T> {
     where
         T: Sized,
     {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = {
             let location = std::panic::Location::caller();
             let resource_span = tracing::trace_span!(
@@ -237,17 +237,17 @@ impl<T: ?Sized> RwLock<T> {
             resource_span
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let s = resource_span.in_scope(|| Semaphore::new(MAX_READS as usize));
 
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         let s = Semaphore::new(MAX_READS as usize);
 
         RwLock {
             mr: MAX_READS,
             c: UnsafeCell::new(value),
             s,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span,
         }
     }
@@ -277,7 +277,7 @@ impl<T: ?Sized> RwLock<T> {
             "a RwLock may not be created with more than {MAX_READS} readers"
         );
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = {
             let location = std::panic::Location::caller();
 
@@ -311,17 +311,17 @@ impl<T: ?Sized> RwLock<T> {
             resource_span
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let s = resource_span.in_scope(|| Semaphore::new(max_reads as usize));
 
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         let s = Semaphore::new(max_reads as usize);
 
         RwLock {
             mr: max_reads,
             c: UnsafeCell::new(value),
             s,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span,
         }
     }
@@ -352,7 +352,7 @@ impl<T: ?Sized> RwLock<T> {
             mr: MAX_READS,
             c: UnsafeCell::new(value),
             s: Semaphore::const_new(MAX_READS as usize),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -383,7 +383,7 @@ impl<T: ?Sized> RwLock<T> {
             mr: max_reads,
             c: UnsafeCell::new(value),
             s: Semaphore::const_new(max_reads as usize),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -445,12 +445,12 @@ impl<T: ?Sized> RwLock<T> {
                 s: &self.s,
                 data: self.c.get(),
                 marker: PhantomData,
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: self.resource_span.clone(),
             }
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let acquire_fut = trace::async_op(
             move || acquire_fut,
             self.resource_span.clone(),
@@ -462,7 +462,7 @@ impl<T: ?Sized> RwLock<T> {
         #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -582,7 +582,7 @@ impl<T: ?Sized> RwLock<T> {
     ///}
     /// ```
     pub async fn read_owned(self: Arc<Self>) -> OwnedRwLockReadGuard<T> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = self.resource_span.clone();
 
         let acquire_fut = async {
@@ -593,7 +593,7 @@ impl<T: ?Sized> RwLock<T> {
             });
 
             OwnedRwLockReadGuard {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: self.resource_span.clone(),
                 data: self.c.get(),
                 lock: self,
@@ -601,7 +601,7 @@ impl<T: ?Sized> RwLock<T> {
             }
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let acquire_fut = trace::async_op(
             move || acquire_fut,
             resource_span,
@@ -613,7 +613,7 @@ impl<T: ?Sized> RwLock<T> {
         #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -668,11 +668,11 @@ impl<T: ?Sized> RwLock<T> {
             s: &self.s,
             data: self.c.get(),
             marker: marker::PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: self.resource_span.clone(),
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -730,14 +730,14 @@ impl<T: ?Sized> RwLock<T> {
         }
 
         let guard = OwnedRwLockReadGuard {
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: self.resource_span.clone(),
             data: self.c.get(),
             lock: self,
             _p: PhantomData,
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -791,12 +791,12 @@ impl<T: ?Sized> RwLock<T> {
                 s: &self.s,
                 data: self.c.get(),
                 marker: marker::PhantomData,
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: self.resource_span.clone(),
             }
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let acquire_fut = trace::async_op(
             move || acquire_fut,
             self.resource_span.clone(),
@@ -808,7 +808,7 @@ impl<T: ?Sized> RwLock<T> {
         #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -914,7 +914,7 @@ impl<T: ?Sized> RwLock<T> {
     ///}
     /// ```
     pub async fn write_owned(self: Arc<Self>) -> OwnedRwLockWriteGuard<T> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = self.resource_span.clone();
 
         let acquire_fut = async {
@@ -926,7 +926,7 @@ impl<T: ?Sized> RwLock<T> {
             });
 
             OwnedRwLockWriteGuard {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: self.resource_span.clone(),
                 permits_acquired: self.mr,
                 data: self.c.get(),
@@ -935,7 +935,7 @@ impl<T: ?Sized> RwLock<T> {
             }
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let acquire_fut = trace::async_op(
             move || acquire_fut,
             resource_span,
@@ -947,7 +947,7 @@ impl<T: ?Sized> RwLock<T> {
         #[allow(clippy::let_and_return)] // this lint triggers when disabling tracing
         let guard = acquire_fut.await;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -995,11 +995,11 @@ impl<T: ?Sized> RwLock<T> {
             s: &self.s,
             data: self.c.get(),
             marker: marker::PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: self.resource_span.clone(),
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -1050,7 +1050,7 @@ impl<T: ?Sized> RwLock<T> {
         }
 
         let guard = OwnedRwLockWriteGuard {
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: self.resource_span.clone(),
             permits_acquired: self.mr,
             data: self.c.get(),
@@ -1058,7 +1058,7 @@ impl<T: ?Sized> RwLock<T> {
             _p: PhantomData,
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",

--- a/tokio/src/sync/rwlock/owned_read_guard.rs
+++ b/tokio/src/sync/rwlock/owned_read_guard.rs
@@ -15,7 +15,7 @@ use std::{fmt, mem, ops, ptr};
 pub struct OwnedRwLockReadGuard<T: ?Sized, U: ?Sized = T> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) resource_span: tracing::Span,
     pub(super) lock: Arc<RwLock<T>>,
     pub(super) data: *const U,
@@ -24,7 +24,7 @@ pub struct OwnedRwLockReadGuard<T: ?Sized, U: ?Sized = T> {
 
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<T: ?Sized, U: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     lock: Arc<RwLock<T>>,
     data: *const U,
@@ -37,7 +37,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
         // forgets the originals, so in the end no value is duplicated.
         unsafe {
             Inner {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: ptr::read(&me.resource_span),
                 lock: ptr::read(&me.lock),
                 data: me.data,
@@ -84,7 +84,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         }
     }
@@ -134,7 +134,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockReadGuard<T, U> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         })
     }
@@ -196,7 +196,7 @@ impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockReadGuard<T, U> {
     fn drop(&mut self) {
         self.lock.s.release(1);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",

--- a/tokio/src/sync/rwlock/owned_write_guard.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard.rs
@@ -17,7 +17,7 @@ use std::{fmt, mem, ops, ptr};
 pub struct OwnedRwLockWriteGuard<T: ?Sized> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
     pub(super) lock: Arc<RwLock<T>>,
@@ -27,7 +27,7 @@ pub struct OwnedRwLockWriteGuard<T: ?Sized> {
 
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     permits_acquired: u32,
     lock: Arc<RwLock<T>>,
@@ -41,7 +41,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         // forgets the originals, so in the end no value is duplicated.
         unsafe {
             Inner {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: ptr::read(&me.resource_span),
                 permits_acquired: me.permits_acquired,
                 lock: ptr::read(&me.lock),
@@ -95,7 +95,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         }
     }
@@ -142,7 +142,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         };
 
@@ -150,7 +150,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         let to_release = (this.permits_acquired - 1) as usize;
         guard.lock.s.release(to_release);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -159,7 +159,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -225,7 +225,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         })
     }
@@ -282,7 +282,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         };
 
@@ -290,7 +290,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         let to_release = (this.permits_acquired - 1) as usize;
         guard.lock.s.release(to_release);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -299,7 +299,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -362,7 +362,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             lock: this.lock,
             data: this.data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         };
 
@@ -370,7 +370,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
         let to_release = (this.permits_acquired - 1) as usize;
         guard.lock.s.release(to_release);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -379,7 +379,7 @@ impl<T: ?Sized> OwnedRwLockWriteGuard<T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -448,7 +448,7 @@ impl<T: ?Sized> Drop for OwnedRwLockWriteGuard<T> {
     fn drop(&mut self) {
         self.lock.s.release(self.permits_acquired as usize);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",

--- a/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/owned_write_guard_mapped.rs
@@ -16,7 +16,7 @@ use std::{fmt, mem, ops, ptr};
 pub struct OwnedRwLockMappedWriteGuard<T: ?Sized, U: ?Sized = T> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
     pub(super) lock: Arc<RwLock<T>>,
@@ -26,7 +26,7 @@ pub struct OwnedRwLockMappedWriteGuard<T: ?Sized, U: ?Sized = T> {
 
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<T: ?Sized, U: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     permits_acquired: u32,
     lock: Arc<RwLock<T>>,
@@ -40,7 +40,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
         // forgets the originals, so in the end no value is duplicated.
         unsafe {
             Inner {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 resource_span: ptr::read(&me.resource_span),
                 permits_acquired: me.permits_acquired,
                 lock: ptr::read(&me.lock),
@@ -94,7 +94,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         }
     }
@@ -151,7 +151,7 @@ impl<T: ?Sized, U: ?Sized> OwnedRwLockMappedWriteGuard<T, U> {
             lock: this.lock,
             data,
             _p: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         })
     }
@@ -218,7 +218,7 @@ impl<T: ?Sized, U: ?Sized> Drop for OwnedRwLockMappedWriteGuard<T, U> {
     fn drop(&mut self) {
         self.lock.s.release(self.permits_acquired as usize);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",

--- a/tokio/src/sync/rwlock/read_guard.rs
+++ b/tokio/src/sync/rwlock/read_guard.rs
@@ -15,7 +15,7 @@ use std::{fmt, mem, ops};
 pub struct RwLockReadGuard<'a, T: ?Sized> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) resource_span: tracing::Span,
     pub(super) s: &'a Semaphore,
     pub(super) data: *const T,
@@ -24,7 +24,7 @@ pub struct RwLockReadGuard<'a, T: ?Sized> {
 
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<'a, T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     s: &'a Semaphore,
     data: *const T,
@@ -36,7 +36,7 @@ impl<'a, T: ?Sized> RwLockReadGuard<'a, T> {
         // SAFETY: This duplicates the values in every field of the guard, then
         // forgets the originals, so in the end no value is duplicated.
         Inner {
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: unsafe { std::ptr::read(&me.resource_span) },
             s: me.s,
             data: me.data,
@@ -88,7 +88,7 @@ impl<'a, T: ?Sized> RwLockReadGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         }
     }
@@ -143,7 +143,7 @@ impl<'a, T: ?Sized> RwLockReadGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         })
     }
@@ -179,7 +179,7 @@ impl<'a, T: ?Sized> Drop for RwLockReadGuard<'a, T> {
     fn drop(&mut self) {
         self.s.release(1);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",

--- a/tokio/src/sync/rwlock/write_guard.rs
+++ b/tokio/src/sync/rwlock/write_guard.rs
@@ -17,7 +17,7 @@ use std::{fmt, mem, ops};
 pub struct RwLockWriteGuard<'a, T: ?Sized> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
     pub(super) s: &'a Semaphore,
@@ -27,7 +27,7 @@ pub struct RwLockWriteGuard<'a, T: ?Sized> {
 
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<'a, T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     permits_acquired: u32,
     s: &'a Semaphore,
@@ -40,7 +40,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
         // SAFETY: This duplicates the values in every field of the guard, then
         // forgets the originals, so in the end no value is duplicated.
         Inner {
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: unsafe { std::ptr::read(&me.resource_span) },
             permits_acquired: me.permits_acquired,
             s: me.s,
@@ -97,7 +97,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         }
     }
@@ -150,7 +150,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         };
 
@@ -158,7 +158,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
         let to_release = (this.permits_acquired - 1) as usize;
         this.s.release(to_release);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -167,7 +167,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -237,7 +237,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         })
     }
@@ -297,7 +297,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         };
 
@@ -305,7 +305,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
         let to_release = (this.permits_acquired - 1) as usize;
         this.s.release(to_release);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -314,7 +314,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -379,7 +379,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             s: this.s,
             data: this.data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         };
 
@@ -387,7 +387,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
         let to_release = (this.permits_acquired - 1) as usize;
         this.s.release(to_release);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -396,7 +396,7 @@ impl<'a, T: ?Sized> RwLockWriteGuard<'a, T> {
             )
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         guard.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",
@@ -445,7 +445,7 @@ impl<'a, T: ?Sized> Drop for RwLockWriteGuard<'a, T> {
     fn drop(&mut self) {
         self.s.release(self.permits_acquired as usize);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",

--- a/tokio/src/sync/rwlock/write_guard_mapped.rs
+++ b/tokio/src/sync/rwlock/write_guard_mapped.rs
@@ -15,7 +15,7 @@ use std::{fmt, mem, ops};
 pub struct RwLockMappedWriteGuard<'a, T: ?Sized> {
     // When changing the fields in this struct, make sure to update the
     // `skip_drop` method.
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     pub(super) resource_span: tracing::Span,
     pub(super) permits_acquired: u32,
     pub(super) s: &'a Semaphore,
@@ -25,7 +25,7 @@ pub struct RwLockMappedWriteGuard<'a, T: ?Sized> {
 
 #[allow(dead_code)] // Unused fields are still used in Drop.
 struct Inner<'a, T: ?Sized> {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
     permits_acquired: u32,
     s: &'a Semaphore,
@@ -38,7 +38,7 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
         // SAFETY: This duplicates the values in every field of the guard, then
         // forgets the originals, so in the end no value is duplicated.
         Inner {
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: unsafe { std::ptr::read(&me.resource_span) },
             permits_acquired: me.permits_acquired,
             s: me.s,
@@ -94,7 +94,7 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         }
     }
@@ -156,7 +156,7 @@ impl<'a, T: ?Sized> RwLockMappedWriteGuard<'a, T> {
             s: this.s,
             data,
             marker: PhantomData,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: this.resource_span,
         })
     }
@@ -201,7 +201,7 @@ impl<'a, T: ?Sized> Drop for RwLockMappedWriteGuard<'a, T> {
     fn drop(&mut self) {
         self.s.release(self.permits_acquired as usize);
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         self.resource_span.in_scope(|| {
             tracing::trace!(
             target: "runtime::resource::state_update",

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -1,6 +1,6 @@
 use super::batch_semaphore as ll; // low level implementation
 use super::{AcquireError, TryAcquireError};
-#[cfg(all(tokio_unstable, feature = "tracing"))]
+#[cfg(feature = "tracing")]
 use crate::util::trace;
 use std::sync::Arc;
 
@@ -398,7 +398,7 @@ use std::sync::Arc;
 pub struct Semaphore {
     /// The low level semaphore
     ll_sem: ll::Semaphore,
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
 }
 
@@ -454,7 +454,7 @@ impl Semaphore {
     /// Panics if `permits` exceeds [`Semaphore::MAX_PERMITS`].
     #[track_caller]
     pub fn new(permits: usize) -> Self {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = {
             let location = std::panic::Location::caller();
 
@@ -470,15 +470,15 @@ impl Semaphore {
             )
         };
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let ll_sem = resource_span.in_scope(|| ll::Semaphore::new(permits));
 
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         let ll_sem = ll::Semaphore::new(permits);
 
         Self {
             ll_sem,
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span,
         }
     }
@@ -504,7 +504,7 @@ impl Semaphore {
     pub const fn const_new(permits: usize) -> Self {
         Self {
             ll_sem: ll::Semaphore::const_new(permits),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -513,7 +513,7 @@ impl Semaphore {
     pub(crate) fn new_closed() -> Self {
         Self {
             ll_sem: ll::Semaphore::new_closed(),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -523,7 +523,7 @@ impl Semaphore {
     pub(crate) const fn const_new_closed() -> Self {
         Self {
             ll_sem: ll::Semaphore::const_new_closed(),
-            #[cfg(all(tokio_unstable, feature = "tracing"))]
+            #[cfg(feature = "tracing")]
             resource_span: tracing::Span::none(),
         }
     }
@@ -583,7 +583,7 @@ impl Semaphore {
     /// [`AcquireError`]: crate::sync::AcquireError
     /// [`SemaphorePermit`]: crate::sync::SemaphorePermit
     pub async fn acquire(&self) -> Result<SemaphorePermit<'_>, AcquireError> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let inner = trace::async_op(
             || self.ll_sem.acquire(1),
             self.resource_span.clone(),
@@ -591,7 +591,7 @@ impl Semaphore {
             "poll",
             true,
         );
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         let inner = self.ll_sem.acquire(1);
 
         inner.await?;
@@ -630,7 +630,7 @@ impl Semaphore {
     /// [`AcquireError`]: crate::sync::AcquireError
     /// [`SemaphorePermit`]: crate::sync::SemaphorePermit
     pub async fn acquire_many(&self, n: u32) -> Result<SemaphorePermit<'_>, AcquireError> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         trace::async_op(
             || self.ll_sem.acquire(n as usize),
             self.resource_span.clone(),
@@ -640,7 +640,7 @@ impl Semaphore {
         )
         .await?;
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         self.ll_sem.acquire(n as usize).await?;
 
         Ok(SemaphorePermit {
@@ -765,7 +765,7 @@ impl Semaphore {
     /// [`AcquireError`]: crate::sync::AcquireError
     /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
     pub async fn acquire_owned(self: Arc<Self>) -> Result<OwnedSemaphorePermit, AcquireError> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let inner = trace::async_op(
             || self.ll_sem.acquire(1),
             self.resource_span.clone(),
@@ -773,7 +773,7 @@ impl Semaphore {
             "poll",
             true,
         );
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         let inner = self.ll_sem.acquire(1);
 
         inner.await?;
@@ -829,7 +829,7 @@ impl Semaphore {
         self: Arc<Self>,
         n: u32,
     ) -> Result<OwnedSemaphorePermit, AcquireError> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let inner = trace::async_op(
             || self.ll_sem.acquire(n as usize),
             self.resource_span.clone(),
@@ -837,7 +837,7 @@ impl Semaphore {
             "poll",
             true,
         );
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         let inner = self.ll_sem.acquire(n as usize);
 
         inner.await?;

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -59,7 +59,7 @@ use std::{future::Future, io, mem};
 /// [`spawn`]: Builder::spawn
 /// [`spawn_blocking`]: Builder::spawn_blocking
 #[derive(Default, Debug)]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 pub struct Builder<'a> {
     name: Option<&'a str>,
 }

--- a/tokio/src/task/join_set.rs
+++ b/tokio/src/task/join_set.rs
@@ -69,8 +69,8 @@ pub struct JoinSet<T> {
 /// than on the current default runtime.
 ///
 /// [`task::Builder`]: crate::task::Builder
-#[cfg(all(tokio_unstable, feature = "tracing"))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg(feature = "tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 #[must_use = "builders do nothing unless used to spawn a task"]
 pub struct Builder<'a, T> {
     joinset: &'a mut JoinSet<T>,
@@ -117,8 +117,8 @@ impl<T: 'static> JoinSet<T> {
     ///     Ok(())
     /// }
     /// ```
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
-    #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+    #[cfg(feature = "tracing")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
     pub fn build_task(&mut self) -> Builder<'_, T> {
         Builder {
             builder: super::Builder::new(),
@@ -696,8 +696,8 @@ where
 
 // === impl Builder ===
 
-#[cfg(all(tokio_unstable, feature = "tracing"))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg(feature = "tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 impl<'a, T: 'static> Builder<'a, T> {
     /// Assigns a name to the task which will be spawned.
     pub fn name(self, name: &'a str) -> Self {
@@ -839,8 +839,8 @@ impl<'a, T: 'static> Builder<'a, T> {
 
 // Manual `Debug` impl so that `Builder` is `Debug` regardless of whether `T` is
 // `Debug`.
-#[cfg(all(tokio_unstable, feature = "tracing"))]
-#[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "tracing"))))]
+#[cfg(feature = "tracing")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tracing")))]
 impl<'a, T> fmt::Debug for Builder<'a, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("join_set::Builder")

--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -110,13 +110,13 @@ pub fn interval_at(start: Instant, period: Duration) -> Interval {
     internal_interval_at(start, period, trace::caller_location())
 }
 
-#[cfg_attr(not(all(tokio_unstable, feature = "tracing")), allow(unused_variables))]
+#[cfg_attr(not(all(feature = "tracing")), allow(unused_variables))]
 fn internal_interval_at(
     start: Instant,
     period: Duration,
     location: Option<&'static Location<'static>>,
 ) -> Interval {
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     let resource_span = {
         let location = location.expect("should have location if tracing");
 
@@ -135,7 +135,7 @@ fn internal_interval_at(
         delay: Box::pin(sleep_until(start)),
         period,
         missed_tick_behavior: MissedTickBehavior::default(),
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         resource_span,
     }
 }
@@ -393,7 +393,7 @@ pub struct Interval {
     /// The strategy `Interval` should use when a tick is missed.
     missed_tick_behavior: MissedTickBehavior,
 
-    #[cfg(all(tokio_unstable, feature = "tracing"))]
+    #[cfg(feature = "tracing")]
     resource_span: tracing::Span,
 }
 
@@ -426,9 +426,9 @@ impl Interval {
     /// # }
     /// ```
     pub async fn tick(&mut self) -> Instant {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let resource_span = self.resource_span.clone();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let instant = trace::async_op(
             || poll_fn(|cx| self.poll_tick(cx)),
             resource_span,
@@ -436,7 +436,7 @@ impl Interval {
             "poll_tick",
             false,
         );
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         let instant = poll_fn(|cx| self.poll_tick(cx));
 
         instant.await

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -245,7 +245,7 @@ cfg_not_trace! {
 }
 
 impl Sleep {
-    #[cfg_attr(not(all(tokio_unstable, feature = "tracing")), allow(unused_variables))]
+    #[cfg_attr(not(all(feature = "tracing")), allow(unused_variables))]
     #[track_caller]
     pub(crate) fn new_timeout(
         deadline: Instant,
@@ -254,7 +254,7 @@ impl Sleep {
         let handle = scheduler::Handle::current();
         // Panic if the time driver is not enabled (backwards compat)
         _ = handle.driver().time();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let inner = {
             let location = location.expect("should have location if tracing");
             let resource_span = tracing::trace_span!(
@@ -285,7 +285,7 @@ impl Sleep {
             Inner { ctx }
         };
 
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         let inner = Inner {};
 
         Sleep {
@@ -347,7 +347,7 @@ impl Sleep {
 
         let handle = this.driver;
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         {
             let _resource_enter = this.inner.ctx.resource_span.enter();
             this.inner.ctx.async_op_span =
@@ -392,21 +392,21 @@ impl Sleep {
         ready!(crate::trace::trace_leaf());
         let mut this = self.project();
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _res_span = this.inner.ctx.resource_span.enter();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _ao_span = this.inner.ctx.async_op_span.enter();
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let _ao_poll_span = this.inner.ctx.async_op_poll_span.enter();
 
         // Keep track of task budget
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         let coop = ready!(trace_poll_op!(
             "poll_elapsed",
             crate::task::coop::poll_proceed(cx),
         ));
 
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 
         let timer = match this.timer.as_mut().as_pin_mut() {
@@ -414,7 +414,7 @@ impl Sleep {
             None => {
                 let handle = this.driver;
 
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 {
                     let clock = handle.driver().clock();
                     let time_source = handle.driver().time().time_source();
@@ -441,10 +441,10 @@ impl Sleep {
             r
         });
 
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         return trace_poll_op!("poll_elapsed", result);
 
-        #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
+        #[cfg(not(feature = "tracing"))]
         return result;
     }
 }

--- a/tokio/src/util/trace.rs
+++ b/tokio/src/util/trace.rs
@@ -4,22 +4,19 @@ cfg_rt! {
     #[derive(Copy, Clone)]
     pub(crate) struct SpawnMeta<'a> {
         /// The name of the task
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         pub(crate) name: Option<&'a str>,
         /// The original size of the future or function being spawned
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         pub(crate) original_size: usize,
         /// The source code location where the task was spawned.
-        ///
-        /// This is wrapped in a type that may be empty when `tokio_unstable` is
-        /// not enabled.
         pub(crate) spawned_at: crate::runtime::task::SpawnLocation,
         _pd: PhantomData<&'a ()>,
     }
 
     impl<'a> SpawnMeta<'a> {
         /// Create new spawn meta with a name and original size (before possible auto-boxing)
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         #[track_caller]
         pub(crate) fn new(name: Option<&'a str>, original_size: usize) -> Self {
             Self {
@@ -33,13 +30,13 @@ cfg_rt! {
         /// Create a new unnamed spawn meta with the original size (before possible auto-boxing)
         #[track_caller]
         pub(crate) fn new_unnamed(original_size: usize) -> Self {
-            #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+            #[cfg(not(all(feature = "tracing")))]
             let _original_size = original_size;
 
             Self {
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 name: None,
-                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                #[cfg(feature = "tracing")]
                 original_size,
                 spawned_at: crate::runtime::task::SpawnLocation::capture(),
                 _pd: PhantomData,
@@ -183,9 +180,9 @@ cfg_rt! {
 cfg_time! {
     #[track_caller]
     pub(crate) fn caller_location() -> Option<&'static std::panic::Location<'static>> {
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
         return Some(std::panic::Location::caller());
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+        #[cfg(not(all(feature = "tracing")))]
         None
     }
 }

--- a/tokio/tests/task_builder.rs
+++ b/tokio/tests/task_builder.rs
@@ -1,4 +1,4 @@
-#![cfg(all(tokio_unstable, feature = "tracing"))]
+#![cfg(feature = "tracing")]
 
 use std::rc::Rc;
 use tokio::task::{Builder, LocalSet};

--- a/tokio/tests/tracing_sync.rs
+++ b/tokio/tests/tracing_sync.rs
@@ -3,7 +3,7 @@
 //! These tests ensure that the instrumentation for tokio
 //! synchronization primitives is correct.
 #![warn(rust_2018_idioms)]
-#![cfg(all(tokio_unstable, feature = "tracing", target_has_atomic = "64"))]
+#![cfg(all(feature = "tracing", target_has_atomic = "64"))]
 
 use tokio::sync;
 use tracing_mock::{expect, subscriber};

--- a/tokio/tests/tracing_task.rs
+++ b/tokio/tests/tracing_task.rs
@@ -3,7 +3,7 @@
 //! These tests ensure that the instrumentation for task spawning and task
 //! lifecycles is correct.
 #![warn(rust_2018_idioms)]
-#![cfg(all(tokio_unstable, feature = "tracing", target_has_atomic = "64"))]
+#![cfg(all(feature = "tracing", target_has_atomic = "64"))]
 
 use std::{mem, time::Duration};
 

--- a/tokio/tests/tracing_time.rs
+++ b/tokio/tests/tracing_time.rs
@@ -3,7 +3,7 @@
 //! These tests ensure that the instrumentation for tokio
 //! synchronization primitives is correct.
 #![warn(rust_2018_idioms)]
-#![cfg(all(tokio_unstable, feature = "tracing", target_has_atomic = "64"))]
+#![cfg(all(feature = "tracing", target_has_atomic = "64"))]
 
 use std::time::Duration;
 


### PR DESCRIPTION
**Commits**
- Remove all attributes requiring `tokio_unstable` in combination with `tracing`.
- Attributes that required only `tokio_unstable` and requires tracing code now requires either tokio_unstable or feature tracing
- Update Changelog
- Fix Cargo.toml's

**LLM usage** 
For bulk refactor, I have used an LLM to change `cfg` attributes: 

```
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
+        #[cfg(feature = "tracing")]
```

I did manually verify all changes (twice) and all tests pass. I verified the dump example to make sure the unstable features still work as intended.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
I'm a library author that is creating a logger library as alternative to `tokio-tracing` which acts a little bit different. Without the tracing feature, lib authors can't do proper book keeping. I want to intercept the creation of tasks, so when a log is intercepted I can properly trace back the original span it is related to.

Now often logs can become orphaned because the task::id is a child task of the original task.   

## Solution
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
My library can use this feature to properly track relationships between tasks, and I don't have to burden the end users by enabling unstable features. 