### PR TITLE
fs: add File::read_at and File::write_at for positional I/O

### DIFF
--- a/.github/workflows/uring-kernel-version-test.yml
+++ b/.github/workflows/uring-kernel-version-test.yml
@@ -82,7 +82,8 @@ jobs:
           mkdir -p /tmp && mount -t tmpfs -o mode=1777 tmpfs /tmp
           for f in /bin/tests/*; do RUST_BACKTRACE=1 "$f" ; done
           EOF
-          chmod +x initramfs/init
+          ch
+          +x initramfs/init
 
           # Pack into a CPIO archive
           (cd initramfs && find . -print0 \

--- a/.github/workflows/uring-kernel-version-test.yml
+++ b/.github/workflows/uring-kernel-version-test.yml
@@ -82,8 +82,7 @@ jobs:
           mkdir -p /tmp && mount -t tmpfs -o mode=1777 tmpfs /tmp
           for f in /bin/tests/*; do RUST_BACKTRACE=1 "$f" ; done
           EOF
-          ch
-          +x initramfs/init
+          chmod +x initramfs/init
 
           # Pack into a CPIO archive
           (cd initramfs && find . -print0 \

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -7,7 +7,7 @@ use crate::io::blocking::{Buf, DEFAULT_MAX_BUF_SIZE};
 use crate::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 use crate::sync::Mutex;
 
-use std::{cmp, vec};
+use std::cmp;
 use std::fmt;
 use std::fs::{Metadata, Permissions};
 use std::future::Future;
@@ -16,6 +16,8 @@ use std::path::Path;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{ready, Context, Poll};
+#[cfg(unix)]
+use std::vec;
 
 #[cfg(test)]
 use super::mocks::JoinHandle;
@@ -632,20 +634,72 @@ impl File {
     #[cfg_attr(docsrs, doc(cfg(unix)))]
     pub async fn read_at(&self, buf: &mut [u8], offset: u64) -> Result<usize, io::Error> {
         use std::os::unix::fs::FileExt;
-        
+
         let file = Arc::clone(&self.std);
         let buf_len = buf.len();
-        
+
         let (n, tmp) = asyncify(move || {
             let mut tmp: Vec<u8> = vec![0; buf_len];
             let n = file.read_at(&mut tmp, offset)?;
-            
-             Ok::<_, io::Error>((n, tmp))
-        }).await?;
+
+            Ok::<_, io::Error>((n, tmp))
+        })
+        .await?;
 
         buf[..n].copy_from_slice(&tmp[..n]);
-        
+
         Ok(n)
+    }
+
+    /// Writes a number of bytes starting from a given offset.
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// The offset is independent from the current cursor. The current
+    /// file cursor is not affected by this function.
+    ///
+    /// When writing beyond the end of the file, the file is appropriately
+    /// extended and the intermediate bytes are initialized with the value 0.
+    ///
+    /// This corresponds to the [`write_at`] method on
+    /// [`std::os::unix::fs::FileExt`].
+    ///
+    /// [`write_at`]: std::os::unix::fs::FileExt::write_at
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if called from outside of the
+    /// Tokio runtime or if the underlying `pwrite` call results in an error.
+    ///
+    /// # Bugs
+    ///
+    /// On some systems, `write_at` uses `pwrite64`, which has a bug where
+    /// files opened with `.append(true)` ignore the given offset and always
+    /// write at the end of the file.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::fs::File;
+    ///
+    /// # async fn dox() -> std::io::Result<()> {
+    /// let file = File::create("foo.txt").await?;
+    ///
+    /// let n = file.write_at(b"some bytes", 0).await?;
+    ///
+    /// println!("wrote {} bytes", n);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    pub async fn write_at(&self, buf: &[u8], offset: u64) -> Result<usize, io::Error> {
+        use std::os::unix::fs::FileExt;
+
+        let file = Arc::clone(&self.std);
+        let buf = buf.to_vec();
+
+        asyncify(move || file.write_at(&buf, offset)).await
     }
 }
 

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -7,7 +7,7 @@ use crate::io::blocking::{Buf, DEFAULT_MAX_BUF_SIZE};
 use crate::io::{AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
 use crate::sync::Mutex;
 
-use std::cmp;
+use std::{cmp, vec};
 use std::fmt;
 use std::fs::{Metadata, Permissions};
 use std::future::Future;
@@ -590,6 +590,62 @@ impl File {
     /// Get the maximum buffer size for the underlying [`AsyncRead`] / [`AsyncWrite`] operation.
     pub fn max_buf_size(&self) -> usize {
         self.max_buf_size
+    }
+
+    /// Reads a number of bytes starting from a given offset.
+    ///
+    /// Returns the number of bytes read.
+    ///
+    /// The offset is independent from the current cursor. The current
+    /// file cursor is not affected by this function.
+    ///
+    /// This corresponds to the [`read_at`] method on
+    /// [`std::os::unix::fs::FileExt`].
+    ///
+    /// Note that similar to [`File::read`], it is not an error to return with
+    /// a short read.
+    ///
+    /// [`read_at`]: std::os::unix::fs::FileExt::read_at
+    /// [`File::read`]: fn@crate::io::AsyncReadExt::read
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if called from outside of the
+    /// Tokio runtime or if the underlying `pread` call results in an error.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use tokio::fs::File;
+    ///
+    /// # async fn dox() -> std::io::Result<()> {
+    /// let file = File::open("foo.txt").await?;
+    ///
+    /// let mut buf = [0; 10];
+    /// let n = file.read_at(&mut buf, 0).await?;
+    ///
+    /// println!("The bytes: {:?}", &buf[..n]);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(unix)]
+    #[cfg_attr(docsrs, doc(cfg(unix)))]
+    pub async fn read_at(&self, buf: &mut [u8], offset: u64) -> Result<usize, io::Error> {
+        use std::os::unix::fs::FileExt;
+        
+        let file = Arc::clone(&self.std);
+        let buf_len = buf.len();
+        
+        let (n, tmp) = asyncify(move || {
+            let mut tmp: Vec<u8> = vec![0; buf_len];
+            let n = file.read_at(&mut tmp, offset)?;
+            
+             Ok::<_, io::Error>((n, tmp))
+        }).await?;
+
+        buf[..n].copy_from_slice(&tmp[..n]);
+        
+        Ok(n)
     }
 }
 

--- a/tokio/src/fs/mocks.rs
+++ b/tokio/src/fs/mocks.rs
@@ -54,6 +54,12 @@ mock! {
     impl std::os::unix::io::FromRawFd for File {
         unsafe fn from_raw_fd(h: std::os::unix::io::RawFd) -> Self;
     }
+
+    #[cfg(unix)]
+    impl std::os::unix::fs::FileExt for File {
+        fn read_at(&self, buf: &mut [u8], offset: u64) -> io::Result<usize>;
+        fn write_at(&self, buf: &[u8], offset: u64) -> io::Result<usize>;
+    }
 }
 
 impl Read for MockFile {

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -2,7 +2,6 @@
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // WASI does not support all fs operations
 
 use futures::future::FutureExt;
-use std::io::prelude::*;
 use std::io::IoSlice;
 use tempfile::NamedTempFile;
 use tokio::fs::File;
@@ -286,12 +285,21 @@ async fn read_at_reads_correct_bytes_at_offset() {
 
     let file = File::open(temp_file.path()).await.unwrap();
 
-    let offset = 1;
-    let mut buf = [0u8; 4];
-    let n = file.read_at(&mut buf, offset).await.unwrap();
+    let offset = 1u64;
+    let want = &HELLO[offset as usize..offset as usize + 4];
+    let mut buf = vec![0u8; want.len()];
+    let mut filled = 0;
 
-    assert_eq!(n, buf.len());
-    assert_eq!(&buf[..n], &HELLO[offset as usize..offset as usize + n]);
+    while filled < buf.len() {
+        let n = file
+            .read_at(&mut buf[filled..], offset + filled as u64)
+            .await
+            .unwrap();
+        assert!(n > 0, "unexpected EOF before buffer was filled");
+        filled += n;
+    }
+
+    assert_eq!(&buf[..], want);
 }
 
 #[tokio::test]
@@ -320,10 +328,27 @@ async fn read_at_short_read_at_eof() {
     let len = HELLO.len();
 
     let mut buf = vec![0u8; len + 10]; // buffer larger than remaining data
-    let n = file.read_at(&mut buf, 0).await.unwrap();
+    let mut filled = 0;
 
-    assert_eq!(n, len, "short read at EOF must return Ok(n) with n < buf.len(), not an error");
-    assert_eq!(&buf[..n], HELLO);
+    while filled < buf.len() {
+        let n = file
+            .read_at(&mut buf[filled..], filled as u64)
+            .await
+            .unwrap();
+
+        // it's expected a short read here.
+        if n == 0 {
+            break;
+        }
+
+        filled += n;
+    }
+
+    assert_eq!(
+        filled, len,
+        "short read at EOF must return Ok(n) with n < buf.len(), not an error"
+    );
+    assert_eq!(&buf[..filled], HELLO);
 }
 
 #[tokio::test]
@@ -379,16 +404,224 @@ async fn read_at_calls_can_run_concurrently() {
 
     let mut buf_a = vec![0u8; mid];
     let mut buf_b = vec![0u8; HELLO.len() - mid];
+    let mut filled_a = 0;
+    let mut filled_b = 0;
 
-    let (ra, rb) = tokio::join!(
-        file.read_at(&mut buf_a, 0),
-        file.read_at(&mut buf_b, mid as u64),
-    );
+    while filled_a < buf_a.len() || filled_b < buf_b.len() {
+        let fut_a = async {
+            if filled_a < buf_a.len() {
+                Some(file.read_at(&mut buf_a[filled_a..], filled_a as u64).await)
+            } else {
+                None
+            }
+        };
 
-    assert_eq!(ra.unwrap(), mid);
-    assert_eq!(rb.unwrap(), HELLO.len() - mid);
+        let fut_b = async {
+            if filled_b < buf_b.len() {
+                Some(
+                    file.read_at(&mut buf_b[filled_b..], mid as u64 + filled_b as u64)
+                        .await,
+                )
+            } else {
+                None
+            }
+        };
+
+        let (ra, rb) = tokio::join!(fut_a, fut_b,);
+
+        if let Some(a) = ra {
+            let a = a.unwrap();
+            assert!(a > 0, "unexpected EOF before buffer was filled");
+            filled_a += a;
+        }
+
+        if let Some(b) = rb {
+            let b = b.unwrap();
+            assert!(b > 0, "unexpected EOF before buffer was filled");
+            filled_b += b;
+        }
+    }
+
+    assert_eq!(filled_a, mid);
+    assert_eq!(filled_b, HELLO.len() - mid);
     assert_eq!(buf_a, &HELLO[..mid]);
     assert_eq!(buf_b, &HELLO[mid..]);
+}
+
+use std::io::Write;
+#[cfg(unix)]
+use tokio::fs::OpenOptions;
+
+#[tokio::test]
+#[cfg(unix)]
+async fn write_at_overwrites_in_place_without_truncating() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let file = OpenOptions::new()
+        .write(true)
+        .open(temp_file.path())
+        .await
+        .unwrap();
+
+    let patch: &[u8] = &[0xAA, 0xBB, 0xCC];
+    let offset = 1usize;
+    assert!(
+        offset + patch.len() < HELLO.len(),
+        "test setup: patch must leave trailing bytes untouched"
+    );
+
+    let mut written = 0;
+
+    while written < patch.len() {
+        let n = file
+            .write_at(&patch[written..], offset as u64 + written as u64)
+            .await
+            .unwrap();
+        assert!(n > 0, "unexpected zero write before buffer was flushed");
+        written += n;
+    }
+
+    assert_eq!(written, patch.len());
+    let on_disk = std::fs::read(temp_file.path()).unwrap();
+    assert_eq!(
+        on_disk.len(),
+        HELLO.len(),
+        "write_at must not change file length when writing inside existing bounds"
+    );
+
+    assert_eq!(&on_disk[..offset], &HELLO[..offset]);
+    assert_eq!(&on_disk[offset..offset + patch.len()], patch);
+    assert_eq!(
+        &on_disk[offset + patch.len()..],
+        &HELLO[offset + patch.len()..]
+    );
+
+    let n = file.write_at(patch, offset as u64).await.unwrap();
+    assert_eq!(n, patch.len());
+
+    let on_disk = std::fs::read(temp_file.path()).unwrap();
+    assert_eq!(
+        on_disk.len(),
+        HELLO.len(),
+        "write_at must not change file length when writing inside existing bounds"
+    );
+    assert_eq!(&on_disk[..offset], &HELLO[..offset]);
+    assert_eq!(&on_disk[offset..offset + patch.len()], patch);
+    assert_eq!(
+        &on_disk[offset + patch.len()..],
+        &HELLO[offset + patch.len()..]
+    );
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn write_at_does_not_move_cursor() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(temp_file.path())
+        .await
+        .unwrap();
+
+    file.seek(SeekFrom::Start(4)).await.unwrap();
+
+    file.write_at(&[9, 9, 9], 0).await.unwrap();
+
+    let pos = file.seek(SeekFrom::Current(0)).await.unwrap();
+    assert_eq!(pos, 4, "write_at must not affect the file's cursor");
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn write_at_extends_file_and_zero_fills_gap() {
+    let temp_file = tempfile();
+
+    let file = OpenOptions::new()
+        .write(true)
+        .open(temp_file.path())
+        .await
+        .unwrap();
+
+    let data = b"end";
+    let offset = 5u64;
+    let mut written = 0;
+
+    while written < data.len() {
+        let n = file
+            .write_at(&data[written..], offset + written as u64)
+            .await
+            .unwrap();
+        assert!(n > 0, "unexpected zero write before buffer was flushed");
+        written += n;
+    }
+
+    assert_eq!(written, data.len());
+    let on_disk = std::fs::read(temp_file.path()).unwrap();
+    assert_eq!(on_disk.len(), offset as usize + data.len());
+    assert_eq!(&on_disk[..offset as usize], &[0u8; 5]);
+    assert_eq!(&on_disk[offset as usize..], data);
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn write_at_with_empty_buffer_returns_zero() {
+    let temp_file = tempfile();
+
+    let file = OpenOptions::new()
+        .write(true)
+        .open(temp_file.path())
+        .await
+        .unwrap();
+
+    let n = file.write_at(&[], 0).await.unwrap();
+    assert_eq!(n, 0);
+
+    let on_disk = std::fs::read(temp_file.path()).unwrap();
+    assert!(
+        on_disk.is_empty(),
+        "writing an empty buffer must not extend the file"
+    );
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn write_at_calls_can_run_concurrently() {
+    let temp_file = tempfile();
+
+    let file = OpenOptions::new()
+        .write(true)
+        .open(temp_file.path())
+        .await
+        .unwrap();
+
+    let expect_bytes = 4;
+    let mut filled_a = 0;
+    let mut filled_b = 0;
+
+    while filled_a < expect_bytes || filled_b < expect_bytes {
+        let buffer_a = b"AAAA";
+        let buffer_b = b"BBBB";
+
+        let (ra, rb) = tokio::join!(
+            file.write_at(&buffer_a[filled_a..], filled_a as u64),
+            file.write_at(&buffer_b[filled_b..], 4 + filled_b as u64)
+        );
+        let ra = ra.unwrap();
+        let rb = rb.unwrap();
+
+        filled_a += ra;
+        filled_b += rb;
+    }
+
+    assert_eq!(filled_a, expect_bytes);
+    assert_eq!(filled_b, expect_bytes);
+
+    let on_disk = std::fs::read(temp_file.path()).unwrap();
+    assert_eq!(&on_disk[..4], b"AAAA");
+    assert_eq!(&on_disk[4..8], b"BBBB");
 }
 
 #[tokio::test]

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -279,6 +279,119 @@ async fn read_file_from_unix_fd() {
 }
 
 #[tokio::test]
+#[cfg(unix)]
+async fn read_at_reads_correct_bytes_at_offset() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let file = File::open(temp_file.path()).await.unwrap();
+
+    let offset = 1;
+    let mut buf = [0u8; 4];
+    let n = file.read_at(&mut buf, offset).await.unwrap();
+
+    assert_eq!(n, buf.len());
+    assert_eq!(&buf[..n], &HELLO[offset as usize..offset as usize + n]);
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn read_at_does_not_move_the_cursor() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let mut file = File::open(temp_file.path()).await.unwrap();
+    file.seek(SeekFrom::Start(3)).await.unwrap();
+
+    let mut buf = [0u8; 2];
+    file.read_at(&mut buf, 0).await.unwrap();
+
+    let pos = file.seek(SeekFrom::Current(0)).await.unwrap();
+    assert_eq!(pos, 3, "read_at must not affect the file's cursor");
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn read_at_short_read_at_eof() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let file = File::open(temp_file.path()).await.unwrap();
+    let len = HELLO.len();
+
+    let mut buf = vec![0u8; len + 10]; // buffer larger than remaining data
+    let n = file.read_at(&mut buf, 0).await.unwrap();
+
+    assert_eq!(n, len, "short read at EOF must return Ok(n) with n < buf.len(), not an error");
+    assert_eq!(&buf[..n], HELLO);
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn read_at_offset_at_eof_returns_zero() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let file = File::open(temp_file.path()).await.unwrap();
+    let mut buf = [0u8; 4];
+    let n = file.read_at(&mut buf, HELLO.len() as u64).await.unwrap();
+
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn read_at_offset_past_eof_returns_zero() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let file = File::open(temp_file.path()).await.unwrap();
+    let mut buf = [0u8; 4];
+    let n = file
+        .read_at(&mut buf, HELLO.len() as u64 + 100)
+        .await
+        .unwrap();
+
+    assert_eq!(n, 0, "pread(2) past EOF returns 0, not an error");
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn read_at_with_empty_buffer_returns_zero() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let file = File::open(temp_file.path()).await.unwrap();
+    let mut buf: [u8; 0] = [];
+    let n = file.read_at(&mut buf, 0).await.unwrap();
+
+    assert_eq!(n, 0);
+}
+
+#[tokio::test]
+#[cfg(unix)]
+async fn read_at_calls_can_run_concurrently() {
+    let mut temp_file = tempfile();
+    temp_file.write_all(HELLO).unwrap();
+
+    let file = File::open(temp_file.path()).await.unwrap();
+    let mid = HELLO.len() / 2;
+
+    let mut buf_a = vec![0u8; mid];
+    let mut buf_b = vec![0u8; HELLO.len() - mid];
+
+    let (ra, rb) = tokio::join!(
+        file.read_at(&mut buf_a, 0),
+        file.read_at(&mut buf_b, mid as u64),
+    );
+
+    assert_eq!(ra.unwrap(), mid);
+    assert_eq!(rb.unwrap(), HELLO.len() - mid);
+    assert_eq!(buf_a, &HELLO[..mid]);
+    assert_eq!(buf_b, &HELLO[mid..]);
+}
+
+#[tokio::test]
 #[cfg(windows)]
 async fn windows_handle() {
     use std::os::windows::io::AsRawHandle;


### PR DESCRIPTION
Closes #1529.

Adds positional read/write methods to tokio::fs::File on Unix, backed by std::os::unix::fs::FileExt::{read_at,write_at} via spawn_blocking. Bypasses the existing Idle/Busy buffering state machine since pread/pwrite don't interact with the file's logical cursor.

Windows is not addressed in this PR. Open to filing a follow-up issue for ReadFile/WriteFile-based positional I/O on Windows if maintainers want it tracked separately.

Tests added in tokio/tests/fs_file.rs covering offset/cursor independence, short reads/writes at EOF, zero-fill on write extension, and concurrent calls.