### PR TITLE
docs: fix missing brace in `reactor-refactor.md`

### DIFF
--- a/tokio/docs/reactor-refactor.md
+++ b/tokio/docs/reactor-refactor.md
@@ -52,6 +52,7 @@ impl Registration {
 
     /// Clears resource level readiness represented by the specified `ReadyEvent`
     async fn clear_readiness(&self, ready_event: ReadyEvent);
+}
 ```
 
 A new registration is created for a `T: mio::Evented` and a `interest`. This


### PR DESCRIPTION
Add the missing closing `}` in the `impl Registration` code block in
`tokio/docs/reactor-refactor.md`

## Motivation

The `impl Registration` code block in `tokio/docs/reactor-refactor.md` is
missing a closing `}`.

## Solution

Add the missing closing brace after `async fn clear_readiness`.
