### PR TITLE
net: re-enable Miri for TCP tests which previously failed due to Miri bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   rust_stable: stable
   rust_nightly: nightly-2025-10-12
   # Pin a specific miri version
-  rust_miri_nightly: nightly-2026-05-30
+  rust_miri_nightly: nightly-2026-06-29
   rust_clippy: '1.88'
   # When updating this, also update:
   # - README.md

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -89,7 +89,6 @@ async fn test_transfer_after_close() {
 }
 
 #[tokio::test]
-#[cfg_attr(miri, ignore)] // Miri sometimes fails to establish the tcp connection
 async fn blocking_one_side_does_not_block_other() {
     symmetric(|handle, mut a, mut b| async move {
         block_write(&mut a).await;

--- a/tokio/tests/rt_common.rs
+++ b/tokio/tests/rt_common.rs
@@ -1155,7 +1155,6 @@ rt_test! {
 
     #[cfg(not(target_os = "wasi"))] // Wasi does not support bind
     #[test]
-    #[cfg_attr(miri, ignore)] // Miri sometimes fails to establish the tcp connection
     fn local_set_client_server_block_on() {
         let rt = rt();
         let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
Hi,

This pull request re-enables the tests which were disabled in https://github.com/tokio-rs/tokio/pull/8205.
The latest nightly version of Miri contains a fix which no longer removes the readable readiness for a socket after a short read when it's read end already has been closed.

