### PR TITLE
io: add #[inline] to AsyncRead, AsyncWrite, AsyncSeek, and AsyncBufRead impls for in-memory types

### DIFF
--- a/tokio/src/io/async_buf_read.rs
+++ b/tokio/src/io/async_buf_read.rs
@@ -97,20 +97,24 @@ where
 }
 
 impl AsyncBufRead for &[u8] {
+    #[inline]
     fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
         Poll::Ready(Ok(*self))
     }
 
+    #[inline]
     fn consume(mut self: Pin<&mut Self>, amt: usize) {
         *self = &self[amt..];
     }
 }
 
 impl<T: AsRef<[u8]> + Unpin> AsyncBufRead for io::Cursor<T> {
+    #[inline]
     fn poll_fill_buf(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
         Poll::Ready(io::BufRead::fill_buf(self.get_mut()))
     }
 
+    #[inline]
     fn consume(self: Pin<&mut Self>, amt: usize) {
         io::BufRead::consume(self.get_mut(), amt);
     }

--- a/tokio/src/io/async_read.rs
+++ b/tokio/src/io/async_read.rs
@@ -94,6 +94,7 @@ where
 }
 
 impl AsyncRead for &[u8] {
+    #[inline]
     fn poll_read(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -108,6 +109,7 @@ impl AsyncRead for &[u8] {
 }
 
 impl<T: AsRef<[u8]> + Unpin> AsyncRead for io::Cursor<T> {
+    #[inline]
     fn poll_read(
         mut self: Pin<&mut Self>,
         _cx: &mut Context<'_>,

--- a/tokio/src/io/async_seek.rs
+++ b/tokio/src/io/async_seek.rs
@@ -87,9 +87,11 @@ where
 }
 
 impl<T: AsRef<[u8]> + Unpin> AsyncSeek for io::Cursor<T> {
+    #[inline]
     fn start_seek(mut self: Pin<&mut Self>, pos: SeekFrom) -> io::Result<()> {
         io::Seek::seek(&mut *self, pos).map(drop)
     }
+    #[inline]
     fn poll_complete(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<u64>> {
         Poll::Ready(Ok(self.get_mut().position()))
     }

--- a/tokio/src/io/async_write.rs
+++ b/tokio/src/io/async_write.rs
@@ -251,6 +251,7 @@ where
 }
 
 impl AsyncWrite for Vec<u8> {
+    #[inline]
     fn poll_write(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,
@@ -260,6 +261,7 @@ impl AsyncWrite for Vec<u8> {
         Poll::Ready(Ok(buf.len()))
     }
 
+    #[inline]
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -268,20 +270,24 @@ impl AsyncWrite for Vec<u8> {
         Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
     }
 
+    #[inline]
     fn is_write_vectored(&self) -> bool {
         true
     }
 
+    #[inline]
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
     }
 
+    #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
     }
 }
 
 impl AsyncWrite for io::Cursor<&mut [u8]> {
+    #[inline]
     fn poll_write(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -290,6 +296,7 @@ impl AsyncWrite for io::Cursor<&mut [u8]> {
         Poll::Ready(io::Write::write(&mut *self, buf))
     }
 
+    #[inline]
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -298,20 +305,24 @@ impl AsyncWrite for io::Cursor<&mut [u8]> {
         Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
     }
 
+    #[inline]
     fn is_write_vectored(&self) -> bool {
         true
     }
 
+    #[inline]
     fn poll_flush(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(io::Write::flush(&mut *self))
     }
 
+    #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.poll_flush(cx)
     }
 }
 
 impl AsyncWrite for io::Cursor<&mut Vec<u8>> {
+    #[inline]
     fn poll_write(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -320,6 +331,7 @@ impl AsyncWrite for io::Cursor<&mut Vec<u8>> {
         Poll::Ready(io::Write::write(&mut *self, buf))
     }
 
+    #[inline]
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -328,20 +340,24 @@ impl AsyncWrite for io::Cursor<&mut Vec<u8>> {
         Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
     }
 
+    #[inline]
     fn is_write_vectored(&self) -> bool {
         true
     }
 
+    #[inline]
     fn poll_flush(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(io::Write::flush(&mut *self))
     }
 
+    #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.poll_flush(cx)
     }
 }
 
 impl AsyncWrite for io::Cursor<Vec<u8>> {
+    #[inline]
     fn poll_write(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -350,6 +366,7 @@ impl AsyncWrite for io::Cursor<Vec<u8>> {
         Poll::Ready(io::Write::write(&mut *self, buf))
     }
 
+    #[inline]
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -358,20 +375,24 @@ impl AsyncWrite for io::Cursor<Vec<u8>> {
         Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
     }
 
+    #[inline]
     fn is_write_vectored(&self) -> bool {
         true
     }
 
+    #[inline]
     fn poll_flush(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(io::Write::flush(&mut *self))
     }
 
+    #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.poll_flush(cx)
     }
 }
 
 impl AsyncWrite for io::Cursor<Box<[u8]>> {
+    #[inline]
     fn poll_write(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -380,6 +401,7 @@ impl AsyncWrite for io::Cursor<Box<[u8]>> {
         Poll::Ready(io::Write::write(&mut *self, buf))
     }
 
+    #[inline]
     fn poll_write_vectored(
         mut self: Pin<&mut Self>,
         _: &mut Context<'_>,
@@ -388,14 +410,17 @@ impl AsyncWrite for io::Cursor<Box<[u8]>> {
         Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
     }
 
+    #[inline]
     fn is_write_vectored(&self) -> bool {
         true
     }
 
+    #[inline]
     fn poll_flush(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(io::Write::flush(&mut *self))
     }
 
+    #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         self.poll_flush(cx)
     }


### PR DESCRIPTION
### Summary

Add `#[inline]` hints to the in-memory implementations of the core I/O traits: `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and `AsyncBufRead` for `&[u8]`, `Vec<u8>`, and `io::Cursor<T>`.

These are small, leaf implementations that benefit from cross-crate inlining, enabling LLVM to optimize call sites in downstream crates (including bounds-check elision and dead-code path elimination).

### Benchmark Results

Measured with criterion, showing improvements from baseline to `#[inline]`-only optimized versions:

| Trait & Type | Benchmark | Before (ns) | After (ns) | Performance Improvement |
| :--- | :--- | :---: | :---: | :---: |
| `AsyncRead` for `&[u8]` | `async_read_slice` | ~14.28 ns | ~11.97 ns | **~16.2%** |
| `AsyncRead` for `Cursor` | `async_read_cursor` | ~11.80 ns | ~10.80 ns | **~8.5%** |
| `AsyncWrite` for `Vec<u8>` | `write_vec` | ~13.85 ns | ~12.93 ns | **~6.6%** |
| `AsyncWrite` for `Cursor` | `write_cursor` | ~20.31 ns | ~16.87 ns | **~16.9%** |
| `AsyncSeek` for `Cursor` | `seek_cursor` | ~17.23 ns | ~16.75 ns | **~2.8%** |
| `AsyncBufRead` for `&[u8]` | `buf_read_slice` | ~640.01 ps | ~632.52 ps | **~1.2%** |

### Changes

Added `#[inline]` to the concrete, non-generic implementations in:
- `tokio/src/io/async_read.rs` (`&[u8]`, `io::Cursor<T>`)
- `tokio/src/io/async_write.rs` (`Vec<u8>`, `io::Cursor<&mut [u8]>`, `io::Cursor<&mut Vec<u8>>`, `io::Cursor<Vec<u8>>`, `io::Cursor<Box<[u8]>>`)
- `tokio/src/io/async_seek.rs` (`io::Cursor<T>`)
- `tokio/src/io/async_buf_read.rs` (`&[u8]`, `io::Cursor<T>`)

No `unsafe` code, no API modifications, and no behavioral changes.