### PR TITLE
stream: fix overflow in StreamMap::size_hint (backport to 1.51.x)

### DIFF
--- a/tokio-stream/src/stream_map.rs
+++ b/tokio-stream/src/stream_map.rs
@@ -685,15 +685,15 @@ where
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut ret = (0, Some(0));
+        let mut ret: (usize, Option<usize>) = (0, Some(0));
 
         for (_, stream) in &self.entries {
             let hint = stream.size_hint();
 
-            ret.0 += hint.0;
+            ret.0 = ret.0.saturating_add(hint.0);
 
             match (ret.1, hint.1) {
-                (Some(a), Some(b)) => ret.1 = Some(a + b),
+                (Some(a), Some(b)) => ret.1 = a.checked_add(b),
                 (Some(_), None) => ret.1 = None,
                 _ => {}
             }

--- a/tokio-stream/tests/stream_stream_map.rs
+++ b/tokio-stream/tests/stream_stream_map.rs
@@ -226,6 +226,30 @@ fn size_hint_without_upper() {
 }
 
 #[test]
+fn size_hint_overflow() {
+    struct Monster;
+
+    impl Stream for Monster {
+        type Item = ();
+
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut std::task::Context<'_>) -> Poll<Option<()>> {
+            panic!()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            (usize::MAX, Some(usize::MAX))
+        }
+    }
+
+    let mut map = StreamMap::new();
+
+    map.insert("a", Monster);
+    map.insert("b", Monster);
+
+    assert_eq!(map.size_hint(), (usize::MAX, None));
+}
+
+#[test]
 fn new_capacity_zero() {
     let map = StreamMap::<&str, stream::Pending<()>>::new();
     assert_eq!(0, map.capacity());


### PR DESCRIPTION
## Summary

Backport of tokio-rs/tokio#8216 (`f59aae42`) to this release branch.

`StreamMap::size_hint` summed lower/upper bounds with plain `+` / `+=`. Two streams that each report `usize::MAX` overflow the lower bound (wrapping) and the upper bound (debug panic / wrapping). That is a real correctness bug for any consumer relying on `size_hint` (e.g. `collect` pre-allocation heuristics).

### Fix
- lower bound: `saturating_add`
- upper bound: `checked_add` (overflow → `None`)

### Test
Adds `size_hint_overflow` which inserts two monster streams with `(usize::MAX, Some(usize::MAX))` and asserts `(usize::MAX, None)`.

## Why this branch
The buggy add is present on this release line and was not previously backported.

## Test plan
- [ ] CI on this PR
- [x] Cherry-pick from `f59aae42` with `-x` (applied cleanly to this branch)

Do not merge until CI is green.