### PR TITLE
tokio-test: return Pending for delayed handle writes

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -420,9 +420,7 @@ impl AsyncWrite for Mock {
 
             if self.inner.actions.is_empty() {
                 match self.inner.poll_action(cx) {
-                    Poll::Pending => {
-                        // do not propagate pending
-                    }
+                    Poll::Pending => return Poll::Pending,
                     Poll::Ready(Some(action)) => {
                         self.inner.actions.push_back(action);
                     }

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -3,7 +3,7 @@
 use std::io;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::time::{Duration, Instant};
-use tokio_test::io::Builder;
+use tokio_test::{io::Builder, task};
 
 #[tokio::test]
 async fn read() {
@@ -59,6 +59,24 @@ async fn write_with_handle() {
 
     mock.write_all(b"hello ").await.expect("write 1");
     mock.write_all(b"world!").await.expect("write 2");
+}
+
+#[test]
+fn write_with_handle_after_pending() {
+    let (mock, mut handle) = Builder::new().build_with_handle();
+    let mut write = task::spawn(async move {
+        let mut mock = mock;
+        mock.write_all(b"hello ").await
+    });
+
+    assert!(
+        write.poll().is_pending(),
+        "write should wait for a handle action"
+    );
+
+    handle.write(b"hello ");
+
+    assert!(matches!(write.poll(), std::task::Poll::Ready(Ok(()))));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

`tokio_test::io::Mock::poll_write` now returns `Poll::Pending` when the scripted action queue is empty and the handle-backed action stream has not produced a write action yet.

The PR also adds a regression test that polls a `write_all` future before any handle action is queued, then injects the expected write through the handle and verifies the future completes.

## Why

The earlier fix in #5814 already addressed the original `BrokenPipe` report from #5813 for handle-backed writes when the action is already queued before the first write poll.

What still breaks is the delayed-action case: `poll_write` checks the dynamic action stream when `actions` is empty, but it currently swallows `Poll::Pending` and falls through to `Inner::write()`. At that point `Inner::write()` still sees an empty action queue and returns `BrokenPipe`.

That means a handle-backed write can still behave like a hard write failure if the expected action arrives after the first poll, even though the handle stream has registered a waker and the correct async behavior is to wait.

## Impact

Tests that script writes through `build_with_handle()` can now wait for the next dynamic write action instead of failing spuriously with `BrokenPipe` when the action arrives after the first poll.

## Validation

- `cargo test -p tokio-test --test io`
- `cargo fmt --all --check`