### PR TITLE
codec: document UdpFramed decoder errors

### DIFF
--- a/tokio-util/src/udp/frame.rs
+++ b/tokio-util/src/udp/frame.rs
@@ -22,6 +22,12 @@ use std::{
 /// handle encoding and decoding of messages frames. Note that the incoming and
 /// outgoing frame types may be distinct.
 ///
+/// A single datagram may decode into multiple frames. `UdpFramed` will keep
+/// calling [`Decoder::decode_eof`] with the current datagram until it returns
+/// `Ok(None)`. If a decoder wants to discard a malformed datagram and continue
+/// receiving later datagrams, it should consume or clear the remaining bytes
+/// from the buffer before returning `Err`.
+///
 /// This function returns a *single* object that is both [`Stream`] and [`Sink`];
 /// grouping this into a single object is often useful for layering things which
 /// require both read and write access to the underlying object.


### PR DESCRIPTION
## What changed

This PR adds a `UdpFramed` docs note explaining how decoder errors interact with per-datagram buffering.

In particular, it now documents that one UDP datagram may decode into multiple frames, and that `UdpFramed` keeps calling `Decoder::decode_eof` on the current datagram until it returns `Ok(None)`.

## Why

After the review discussion here, the useful thing to clarify is that dropping a malformed UDP datagram is the codec's responsibility.

If a codec wants to discard the current datagram and continue receiving later datagrams, it should consume or clear the remaining bytes from the buffer before returning `Err`.

## Impact

This is a docs-only change. It makes the existing `UdpFramed` behavior explicit for codec authors without changing runtime behavior.

## Validation

- `cargo fmt --all --check`