### PR TITLE
feat: ring-per-thread runtime for `io_uring`

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 
 [features]
 test-util = ["tokio/test-util"]
+io-uring = ["tokio/io-uring"]
 
 [dependencies]
 tokio = { version = "1.5.0", path = "../tokio", features = ["full"] }
@@ -104,6 +105,11 @@ harness = false
 [[bench]]
 name = "remote_spawn"
 path = "remote_spawn.rs"
+harness = false
+
+[[bench]]
+name = "fs_read_concurrent"
+path = "fs_read_concurrent.rs"
 harness = false
 
 [lints]

--- a/benches/fs_read_concurrent.rs
+++ b/benches/fs_read_concurrent.rs
@@ -1,0 +1,92 @@
+//! Benchmark concurrent `tokio::fs::read` calls on the multi-threaded scheduler.
+//!
+//! For each concurrency level N (1, 2, 4, 8, 16, 32, 64, capped at available
+//! parallelism):
+//! - Spawns N async tasks
+//! - Each task reads its own small file NUM_READS times
+//!
+//! By default, file operations run on the `spawn_blocking` pool. To route them
+//! through io_uring instead, build with the `io-uring` feature and the
+//! `tokio_unstable` cfg:
+//!
+//! ```sh
+//! RUSTFLAGS="--cfg tokio_unstable" cargo bench --bench fs_read_concurrent --features io-uring
+//! ```
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use tokio::runtime::{self, Runtime};
+use tokio::task::JoinSet;
+
+use std::path::PathBuf;
+
+/// Number of reads each task performs per iteration
+const NUM_READS: usize = 100;
+/// Size of each file in bytes
+const FILE_SIZE: usize = 4096;
+
+fn fs_read_concurrency(c: &mut Criterion) {
+    let max_parallelism = std::thread::available_parallelism()
+        .map(|p| p.get())
+        .unwrap_or(1);
+
+    let concurrency_levels: Vec<usize> = [1, 2, 4, 8, 16, 32, 64]
+        .into_iter()
+        .filter(|&n| n <= max_parallelism)
+        .collect();
+
+    let dir = std::env::temp_dir().join(format!("tokio-fs-read-bench-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+
+    let max_tasks = concurrency_levels.iter().copied().max().unwrap_or(1);
+    let paths: Vec<PathBuf> = (0..max_tasks)
+        .map(|i| {
+            let path = dir.join(format!("file-{i}"));
+            std::fs::write(&path, vec![0u8; FILE_SIZE]).unwrap();
+            path
+        })
+        .collect();
+
+    let mut group = c.benchmark_group("fs_read");
+
+    for num_tasks in concurrency_levels {
+        group.bench_with_input(
+            BenchmarkId::new("concurrency", num_tasks),
+            &num_tasks,
+            |b, &num_tasks| {
+                let rt = rt();
+
+                b.iter(|| {
+                    rt.block_on(async {
+                        let mut tasks = JoinSet::new();
+
+                        for path in paths.iter().take(num_tasks).cloned() {
+                            tasks.spawn(async move {
+                                for _ in 0..NUM_READS {
+                                    let data = tokio::fs::read(&path).await.unwrap();
+                                    assert_eq!(data.len(), FILE_SIZE);
+                                }
+                            });
+                        }
+
+                        tasks.join_all().await;
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+
+fn rt() -> Runtime {
+    runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+criterion_group!(fs_read_benches, fs_read_concurrency);
+
+criterion_main!(fs_read_benches);

--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -295,7 +295,7 @@ pub(crate) mod test {
     #[cfg_attr(miri, ignore)] // No `sigaction` on Miri
     #[test]
     fn does_not_register_signal_if_queue_empty() {
-        let (io_driver, io_handle) = IoDriver::new(1024).unwrap();
+        let (io_driver, io_handle) = IoDriver::new(1024, 1).unwrap();
         let signal_driver = SignalDriver::new(io_driver, &io_handle).unwrap();
         let handle = signal_driver.handle();
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1120,6 +1120,11 @@ impl Builder {
             enable_time: self.enable_time,
             start_paused: self.start_paused,
             nevents: self.nevents,
+            workers: match self.kind {
+                Kind::CurrentThread => 1,
+                #[cfg(feature = "rt-multi-thread")]
+                Kind::MultiThread => self.worker_threads.unwrap_or_else(crate::loom::sys::num_cpus),
+            },
             timer_flavor: self.timer_flavor,
         }
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1123,7 +1123,9 @@ impl Builder {
             workers: match self.kind {
                 Kind::CurrentThread => 1,
                 #[cfg(feature = "rt-multi-thread")]
-                Kind::MultiThread => self.worker_threads.unwrap_or_else(crate::loom::sys::num_cpus),
+                Kind::MultiThread => self
+                    .worker_threads
+                    .unwrap_or_else(crate::loom::sys::num_cpus),
             },
             timer_flavor: self.timer_flavor,
         }

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -40,12 +40,16 @@ pub(crate) struct Cfg {
     pub(crate) enable_pause_time: bool,
     pub(crate) start_paused: bool,
     pub(crate) nevents: usize,
+    /// Number of scheduler worker threads (1 for the current-thread runtime).
+    /// The io driver shards its `io_uring` rings across this many workers.
+    pub(crate) workers: usize,
     pub(crate) timer_flavor: crate::runtime::TimerFlavor,
 }
 
 impl Driver {
     pub(crate) fn new(cfg: Cfg) -> io::Result<(Self, Handle)> {
-        let (io_stack, io_handle, signal_handle) = create_io_stack(cfg.enable_io, cfg.nevents)?;
+        let (io_stack, io_handle, signal_handle) =
+            create_io_stack(cfg.enable_io, cfg.nevents, cfg.workers)?;
 
         let clock = create_clock(cfg.enable_pause_time, cfg.start_paused);
 
@@ -146,12 +150,12 @@ cfg_io_driver! {
         Disabled(UnparkThread),
     }
 
-    fn create_io_stack(enabled: bool, nevents: usize) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
+    fn create_io_stack(enabled: bool, nevents: usize, workers: usize) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
         #[cfg(loom)]
         assert!(!enabled);
 
         let ret = if enabled {
-            let (io_driver, io_handle) = crate::runtime::io::Driver::new(nevents)?;
+            let (io_driver, io_handle) = crate::runtime::io::Driver::new(nevents, workers)?;
 
             let (signal_driver, signal_handle) = create_signal_driver(io_driver, &io_handle)?;
             let process_driver = create_process_driver(signal_driver);
@@ -212,7 +216,7 @@ cfg_not_io_driver! {
     #[derive(Debug)]
     pub(crate) struct IoStack(ParkThread);
 
-    fn create_io_stack(_enabled: bool, _nevents: usize) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
+    fn create_io_stack(_enabled: bool, _nevents: usize, _workers: usize) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
         let park_thread = ParkThread::new();
         let unpark_thread = park_thread.unpark();
         Ok((IoStack(park_thread), unpark_thread, Default::default()))

--- a/tokio/src/runtime/driver/op.rs
+++ b/tokio/src/runtime/driver/op.rs
@@ -74,7 +74,7 @@ pub(crate) enum Lifecycle {
 
 pub(crate) enum State {
     Initialize(Option<Entry>),
-    Polled(usize),
+    Polled { ring: usize, index: usize },
     Complete,
 }
 
@@ -111,10 +111,10 @@ impl<T: Cancellable> Drop for Op<T> {
             // We've already dropped this Op.
             State::Complete => (),
             // We will cancel this Op.
-            State::Polled(index) => {
+            State::Polled { ring, index } => {
                 let data = self.take_data();
                 let handle = &mut self.handle;
-                handle.inner.driver().io().cancel_op(index, data);
+                handle.inner.driver().io().cancel_op(ring, index, data);
             }
             // This Op has not been polled yet.
             // We don't need to do anything here.
@@ -174,7 +174,7 @@ impl<T: Cancellable + Completable + Send> Future for Op<T> {
 
                 // SAFETY: entry is valid for the entire duration of the operation
                 match unsafe { driver.register_op(entry, waker) } {
-                    Ok(idx) => this.state = State::Polled(idx),
+                    Ok((ring, index)) => this.state = State::Polled { ring, index },
                     Err(err) => {
                         let data = this
                             .take_data()
@@ -189,9 +189,9 @@ impl<T: Cancellable + Completable + Send> Future for Op<T> {
                 Poll::Pending
             }
 
-            State::Polled(idx) => {
-                let mut ctx = driver.get_uring().lock();
-                let lifecycle = ctx.ops.get_mut(*idx).expect("Lifecycle must be present");
+            State::Polled { ring, index } => {
+                let mut ctx = driver.uring_context(*ring).lock();
+                let lifecycle = ctx.ops.get_mut(*index).expect("Lifecycle must be present");
 
                 match mem::replace(lifecycle, Lifecycle::Submitted) {
                     // Only replace the stored waker if it wouldn't wake the new one
@@ -208,7 +208,7 @@ impl<T: Cancellable + Completable + Send> Future for Op<T> {
 
                     Lifecycle::Completed(cqe) => {
                         // Clean up and complete the future
-                        ctx.remove_op(*idx);
+                        ctx.remove_op(*index);
 
                         this.state = State::Complete;
 

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -51,6 +51,10 @@ pub(crate) struct Handle {
 
     pub(crate) metrics: IoDriverMetrics,
 
+    /// One `io_uring` ring per scheduler worker. An operation binds to the ring
+    /// of the worker that first submits it, so each ring's queues and slab are
+    /// only mutated under that ring's lock, avoiding contention on a single
+    /// global ring while the scheduler keeps stealing tasks across workers.
     #[cfg(all(
         tokio_unstable,
         feature = "io-uring",
@@ -58,8 +62,10 @@ pub(crate) struct Handle {
         feature = "fs",
         target_os = "linux",
     ))]
-    pub(crate) uring_context: Mutex<UringContext>,
+    pub(crate) uring_contexts: Box<[Mutex<UringContext>]>,
 
+    /// Kernel io_uring support probe. The set of supported opcodes is a kernel
+    /// property shared by every ring, so it is probed once for the whole runtime.
     #[cfg(all(
         tokio_unstable,
         feature = "io-uring",
@@ -103,6 +109,19 @@ pub(super) enum Tick {
 const TOKEN_WAKEUP: mio::Token = mio::Token(0);
 const TOKEN_SIGNAL: mio::Token = mio::Token(1);
 
+/// A worker registers its `io_uring` CQ fd with mio using a token that has highest bit set.
+/// Completion readiness for ring `i` arrives as `mio::Token(URING_TOKEN_FLAG | i)`.
+/// The bit distinguishes rings from `TOKEN_WAKEUP` (0), `TOKEN_SIGNAL` (1),
+/// and the `ScheduledIo` pointers (userspace addresses never have the top bit set).
+#[cfg(all(
+    tokio_unstable,
+    feature = "io-uring",
+    feature = "rt",
+    feature = "fs",
+    target_os = "linux",
+))]
+pub(crate) const URING_TOKEN_FLAG: usize = 1 << (usize::BITS - 1);
+
 fn _assert_kinds() {
     fn _assert<T: Send + Sync>() {}
 
@@ -114,7 +133,24 @@ fn _assert_kinds() {
 impl Driver {
     /// Creates a new event loop, returning any error that happened during the
     /// creation.
-    pub(crate) fn new(nevents: usize) -> io::Result<(Driver, Handle)> {
+    ///
+    /// `workers` is the number of scheduler worker threads; the io driver
+    /// allocates one `io_uring` ring per worker (the rings themselves are
+    /// created lazily on first use).
+    pub(crate) fn new(
+        nevents: usize,
+        #[cfg_attr(
+            not(all(
+                tokio_unstable,
+                feature = "io-uring",
+                feature = "rt",
+                feature = "fs",
+                target_os = "linux",
+            )),
+            allow(unused_variables)
+        )]
+        workers: usize,
+    ) -> io::Result<(Driver, Handle)> {
         let poll = mio::Poll::new()?;
         #[cfg(not(target_os = "wasi"))]
         let waker = mio::Waker::new(poll.registry(), TOKEN_WAKEUP)?;
@@ -142,7 +178,10 @@ impl Driver {
                 feature = "fs",
                 target_os = "linux",
             ))]
-            uring_context: Mutex::new(UringContext::new()),
+            uring_contexts: (0..workers)
+                .map(|_| Mutex::new(UringContext::new()))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
             #[cfg(all(
                 tokio_unstable,
                 feature = "io-uring",
@@ -206,6 +245,21 @@ impl Driver {
             } else if token == TOKEN_SIGNAL {
                 self.signal_ready = true;
             } else {
+                // Completion-queue readiness for a per-worker io_uring ring:
+                // drain just that ring rather than scanning every ring.
+                #[cfg(all(
+                    tokio_unstable,
+                    feature = "io-uring",
+                    feature = "rt",
+                    feature = "fs",
+                    target_os = "linux",
+                ))]
+                if token.0 & URING_TOKEN_FLAG != 0 {
+                    let ring = token.0 & !URING_TOKEN_FLAG;
+                    handle.uring_context(ring).lock().dispatch_completions();
+                    continue;
+                }
+
                 let ready = Ready::from_mio(event);
                 let ptr = super::EXPOSE_IO.from_exposed_addr(token.0);
 
@@ -220,19 +274,6 @@ impl Driver {
 
                 ready_count += 1;
             }
-        }
-
-        #[cfg(all(
-            tokio_unstable,
-            feature = "io-uring",
-            feature = "rt",
-            feature = "fs",
-            target_os = "linux",
-        ))]
-        {
-            let mut guard = handle.get_uring().lock();
-            let ctx = &mut *guard;
-            ctx.dispatch_completions();
         }
 
         handle.metrics.incr_ready_count_by(ready_count);

--- a/tokio/src/runtime/io/driver/uring.rs
+++ b/tokio/src/runtime/io/driver/uring.rs
@@ -7,7 +7,7 @@ use crate::runtime::driver::op::CqeResult;
 use crate::runtime::driver::op::{Cancellable, Lifecycle};
 use crate::{io::Interest, loom::sync::Mutex};
 
-use super::{Handle, TOKEN_WAKEUP};
+use super::{Handle, URING_TOKEN_FLAG};
 
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::{io, mem, task::Waker};
@@ -35,31 +35,15 @@ impl UringContext {
         self.uring.as_mut().expect("io_uring not initialized")
     }
 
-    /// Perform `io_uring_setup` system call, and Returns true if this
-    /// actually initialized the io_uring.
+    /// Create this worker's `io_uring` instance via the `io_uring_setup` system
+    /// call. Called lazily on the first operation that binds to this ring.
     ///
-    /// If the machine doesn't support io_uring, then this will return an
-    /// `ENOSYS` error.
-    pub(crate) fn try_init(&mut self, probe: &mut Probe) -> io::Result<bool> {
-        if self.uring.is_some() {
-            // Already initialized.
-            return Ok(false);
-        }
-
-        let uring = IoUring::new(DEFAULT_RING_SIZE)?;
-
-        match uring.submitter().register_probe(probe) {
-            Ok(_) => {}
-            Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
-                // The kernel does not support IORING_REGISTER_PROBE.
-                return Err(io::Error::from_raw_os_error(libc::ENOSYS));
-            }
-            Err(e) => return Err(e),
-        }
-
-        self.uring.replace(uring);
-
-        Ok(true)
+    /// Kernel support and the set of available opcodes are probed once for the
+    /// whole runtime in [`Handle::check_and_init`], so this does not probe again.
+    fn init(&mut self) -> io::Result<()> {
+        debug_assert!(self.uring.is_none());
+        self.uring = Some(IoUring::new(DEFAULT_RING_SIZE)?);
+        Ok(())
     }
 
     pub(crate) fn dispatch_completions(&mut self) {
@@ -173,14 +157,22 @@ impl Drop for UringContext {
 }
 
 impl Handle {
-    fn add_uring_source(&self, uringfd: RawFd) -> io::Result<()> {
+    fn add_uring_source(&self, index: usize, uringfd: RawFd) -> io::Result<()> {
         let mut source = SourceFd(&uringfd);
+        let token = mio::Token(URING_TOKEN_FLAG | index);
         self.registry
-            .register(&mut source, TOKEN_WAKEUP, Interest::READABLE.to_mio())
+            .register(&mut source, token, Interest::READABLE.to_mio())
     }
 
-    pub(crate) fn get_uring(&self) -> &Mutex<UringContext> {
-        &self.uring_context
+    pub(crate) fn uring_context(&self, index: usize) -> &Mutex<UringContext> {
+        &self.uring_contexts[index]
+    }
+
+    /// Index of the `io_uring` ring owned by the worker currently executing.
+    fn current_uring_index(&self) -> usize {
+        crate::runtime::context::worker_index()
+            .unwrap_or(0)
+            .min(self.uring_contexts.len() - 1)
     }
 
     /// Returns `true` if io_uring has already been initialized and the given
@@ -203,14 +195,16 @@ impl Handle {
         self.uring_probe.get().is_some()
     }
 
-    /// Check if the io_uring context is initialized. If not, it will try to initialize it.
-    /// Then, check if the provided opcode is supported.
+    /// Probe the kernel for io_uring support and check whether `opcode` is
+    /// available. The probe is performed once for the whole runtime and cached,
+    /// since the set of supported opcodes is a kernel property shared by every
+    /// ring. The per-worker rings themselves are created lazily in
+    /// [`Handle::register_op`].
     ///
-    /// If both the context initialization succeeds and the opcode is supported,
-    /// this returns `Ok(true)`.
-    /// If either io_uring is unsupported or the opcode is unsupported,
-    /// this returns `Ok(false)`.
-    /// An error is returned if an io_uring syscall returns an unexpected error value.
+    /// Returns `Ok(true)` if io_uring is supported and offers `opcode`, and
+    /// `Ok(false)` if io_uring is unavailable or `opcode` is unsupported (the
+    /// caller then falls back to `spawn_blocking`). An error is returned only if
+    /// an io_uring syscall fails unexpectedly.
     ///
     /// TODO: This would like to be a synchronous function,
     /// but we require `OnceLock::get_or_try_init`.
@@ -220,7 +214,7 @@ impl Handle {
             .uring_probe
             .get_or_try_init(|| async {
                 let mut probe = Probe::new();
-                match self.try_init(&mut probe) {
+                match Self::probe_kernel(&mut probe) {
                     Ok(()) => Ok(Some(probe)),
                     // If the system doesn't support io_uring, we set the probe to `None`.
                     Err(e) if e.raw_os_error() == Some(libc::ENOSYS) => Ok(None),
@@ -239,33 +233,58 @@ impl Handle {
             .is_some_and(|probe| probe.is_supported(opcode)))
     }
 
-    /// Initialize the io_uring context if it hasn't been initialized yet.
-    fn try_init(&self, probe: &mut Probe) -> io::Result<()> {
-        let mut guard = self.get_uring().lock();
-        if guard.try_init(probe)? {
-            self.add_uring_source(guard.ring().as_raw_fd())?;
+    /// Register a `Probe` describing the kernel's io_uring support against a
+    /// throwaway ring. The ring is dropped afterwards; only the probe is kept,
+    /// as its result applies to every per-worker ring.
+    fn probe_kernel(probe: &mut Probe) -> io::Result<()> {
+        let uring = IoUring::new(DEFAULT_RING_SIZE)?;
+        match uring.submitter().register_probe(probe) {
+            Ok(_) => Ok(()),
+            // The kernel does not support IORING_REGISTER_PROBE.
+            Err(e) if e.raw_os_error() == Some(libc::EINVAL) => {
+                Err(io::Error::from_raw_os_error(libc::ENOSYS))
+            }
+            Err(e) => Err(e),
         }
-
-        Ok(())
     }
 
-    /// Register an operation with the io_uring.
+    /// Register an operation with the current worker's io_uring, submitting it
+    /// to the kernel.
     ///
-    /// If this is the first io_uring operation, it will also initialize the io_uring context.
-    /// If io_uring isn't supported, this function returns an `ENOSYS` error, so the caller can
-    /// perform custom handling, such as falling back to an alternative mechanism.
+    /// The operation binds to the ring of the worker executing this call; that
+    /// ring is created lazily if this is its first operation. Returns the
+    /// `(ring, index)` pair identifying the operation, which the caller stores so
+    /// that later polls and cancellation reach the same ring even if the task is
+    /// stolen to another worker.
     ///
     /// # Safety
     ///
     /// Callers must ensure that parameters of the entry (such as buffer) are valid and will
     /// be valid for the entire duration of the operation, otherwise it may cause memory problems.
-    pub(crate) unsafe fn register_op(&self, entry: Entry, waker: Waker) -> io::Result<usize> {
+    pub(crate) unsafe fn register_op(&self, entry: Entry, waker: Waker) -> io::Result<(usize, usize)> {
+        // The kernel probe is always initialized before ops are registered; see
+        // `check_and_init`, which every fs entry point awaits first.
         assert!(self.uring_probe.initialized());
 
-        // Uring is initialized.
-
-        let mut guard = self.get_uring().lock();
+        let ring = self.current_uring_index();
+        let mut guard = self.uring_contexts[ring].lock();
         let ctx = &mut *guard;
+
+        // Create this worker's ring on first use, and register its fd with mio so
+        // the driver wakes up when its completions arrive.
+        if ctx.uring.is_none() {
+            ctx.init()?;
+            let fd = ctx.ring().as_raw_fd();
+            if let Err(e) = self.add_uring_source(ring, fd) {
+                // Registration failed after the ring was created, leaving it with
+                // an fd mio isn't watching. Drop the ring so a later operation
+                // retries a clean init rather than submitting to a ring whose
+                // completions would never be dispatched.
+                ctx.uring = None;
+                return Err(e);
+            }
+        }
+
         let index = ctx.ops.insert(Lifecycle::Waiting(waker));
         let entry = entry.user_data(index as u64);
 
@@ -292,11 +311,11 @@ impl Handle {
         // Note: For now, we submit the entry immediately without utilizing batching.
         submit_or_remove(ctx)?;
 
-        Ok(index)
+        Ok((ring, index))
     }
 
-    pub(crate) fn cancel_op<T: Cancellable>(&self, index: usize, data: Option<T>) {
-        let mut guard = self.get_uring().lock();
+    pub(crate) fn cancel_op<T: Cancellable>(&self, ring: usize, index: usize, data: Option<T>) {
+        let mut guard = self.uring_contexts[ring].lock();
         let ctx = &mut *guard;
         let ops = &mut ctx.ops;
         let Some(lifecycle) = ops.get_mut(index) else {

--- a/tokio/src/runtime/io/driver/uring.rs
+++ b/tokio/src/runtime/io/driver/uring.rs
@@ -261,7 +261,11 @@ impl Handle {
     ///
     /// Callers must ensure that parameters of the entry (such as buffer) are valid and will
     /// be valid for the entire duration of the operation, otherwise it may cause memory problems.
-    pub(crate) unsafe fn register_op(&self, entry: Entry, waker: Waker) -> io::Result<(usize, usize)> {
+    pub(crate) unsafe fn register_op(
+        &self,
+        entry: Entry,
+        waker: Waker,
+    ) -> io::Result<(usize, usize)> {
         // The kernel probe is always initialized before ops are registered; see
         // `check_and_init`, which every fs entry point awaits first.
         assert!(self.uring_probe.initialized());


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

As discussed in #7995, this PR includes a new ring-per-thread runtime for the unstable io_uring feature. The main motivation behind this change is to reduce Mutex contention of the previous one global ring.

Previously: 
- `Handle` in `runtime/io/driver.rs:61` holds a single `uring_context: Mutex<UringContext>`. 
- `register_op`, `cancel_op`, and `dispatch_completions` all take that one lock.
- `register_op` performs `io_uring_enter` while holding the Mutex! Essentially all other workers have to wait for the kernel to finish submission. 



<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution


How does other runtime handle this?

The issue context mentioned [kimojio-rs](https://github.com/Azure/kimojio-rs), and I also looked into compio, glommio and tokio-uring. They heavily favor a lock-less thread-per-core model. 

However, in tokio, due to work-stealing and remote `JoinHandle::abort()`, some per-ring synchronization is unavoidable. Other io_uring runtime pin a task to a thread, while our tasks are `Send`. So in my implementation, individual rings are wrapped by their own Mutex. (Still much less contention compared to a global Mutex).

In this PR:

- One `Mutex<UringContext>` per worker. Lazy per-ring init creates rings on first use. 
- Ops bind to a ring at first registration. A stolen task polled on worker j still locks it's original ring-i mutex. 
- Completion dispatch and work stealing stay unchanged.  
- New `benches/fs_read_concurrent.rs` targets concurrent io_uring Ops.



<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## Benchmarks

fs_read_concurrent (100× 4 KiB fs::read per task). 24-core machine, criterion medians.

| Concurrency | Global ring (before) | Ring-per-thread (after) | Speedup |
|------------:|---------------------:|------------------------:|--------:|
| 1           | 1.52 ms              | 1.53 ms                 | 1.00×   |
| 2           | 2.15 ms              | 2.14 ms                 | 1.00×   |
| 4           | 2.92 ms              | 2.52 ms                 | 1.16×   |
| 8           | 6.97 ms              | 3.51 ms                 | 1.99×   |
| 16          | 18.43 ms             | 5.43 ms                 | 3.39×   |