### PR TITLE
io: do not treat zero-length reads as EOF in `Chain`

### DIFF
--- a/tokio/src/io/util/chain.rs
+++ b/tokio/src/io/util/chain.rs
@@ -94,7 +94,9 @@ where
         if !*me.done_first {
             let rem = buf.remaining();
             ready!(me.first.poll_read(cx, buf))?;
-            if buf.remaining() == rem {
+            // A read that fills nothing only indicates EOF if the buffer
+            // had capacity to begin with.
+            if buf.remaining() == rem && rem != 0 {
                 *me.done_first = true;
             } else {
                 return Poll::Ready(Ok(()));

--- a/tokio/tests/io_chain.rs
+++ b/tokio/tests/io_chain.rs
@@ -14,3 +14,15 @@ async fn chain() {
     assert_ok!(rd.read_to_end(&mut buf).await);
     assert_eq!(buf, b"hello world");
 }
+
+#[tokio::test]
+async fn empty_read_does_not_skip_first() {
+    let mut buf = Vec::new();
+    let rd1: &[u8] = b"hello ";
+    let rd2: &[u8] = b"world";
+
+    let mut rd = rd1.chain(rd2);
+    assert_eq!(assert_ok!(rd.read(&mut []).await), 0);
+    assert_ok!(rd.read_to_end(&mut buf).await);
+    assert_eq!(buf, b"hello world");
+}


### PR DESCRIPTION
## Motivation

`AsyncReadExt::chain` detects EOF of the first reader by checking whether `poll_read` added any bytes to the caller's buffer. A zero-capacity buffer can never receive bytes, so a single zero-length read issued while the first reader still has data sets `done_first` and permanently skips the rest of the first reader:

```rust
let rd1: &[u8] = b"hello ";
let rd2: &[u8] = b"world";
let mut rd = rd1.chain(rd2);

rd.read(&mut []).await?; // Ok(0)

let mut buf = Vec::new();
rd.read_to_end(&mut buf).await?;
assert_eq!(buf, b"world"); // "hello " is lost
```

`std::io::Chain` guards this case explicitly (`0 if !buf.is_empty() => self.done_first = true`), and the `AsyncReadExt::read` docs describe a zero-length buffer as one of the two normal ways to observe `Ok(0)`, distinct from EOF.

## Solution

Treat a read that filled nothing as EOF of the first reader only when the buffer had remaining capacity, matching `std::io::Chain`.

## Tests

- `cargo test -p tokio --test io_chain --features full` (`empty_read_does_not_skip_first` fails before the fix with `read_to_end` returning `b"world"`, passes after)
- `cargo test -p tokio --features full` (debug and `--release`)
- `cargo test --doc -p tokio --features full,test-util`
- `cargo fmt --check`
- `cargo +1.88 clippy -p tokio --tests --no-deps --features full,test-util` with `RUSTFLAGS=-Dwarnings`
- `cargo +1.71 check -p tokio --features full,test-util`
