### PR TITLE
time: fix alt timer leaking cancelled entries into the wheel

### DIFF
--- a/tokio/src/runtime/time_alt/entry.rs
+++ b/tokio/src/runtime/time_alt/entry.rs
@@ -210,12 +210,26 @@ impl Handle {
         }
     }
 
-    pub(crate) fn register_cancel_tx(&self, cancel_tx: Sender) {
+    /// Registers `cancel_tx` so that a subsequent [`Handle::cancel`] call can
+    /// find its way back into the wheel it is about to be (or already is)
+    /// inserted into.
+    ///
+    /// Returns `false` — without registering anything — if the entry was
+    /// already cancelled or already woken up by the time this is called.
+    /// Callers must not insert an entry into the wheel when this returns
+    /// `false`: without a registered `cancel_tx`, nothing could ever
+    /// remove it again, and it would sit in the wheel until it naturally
+    /// expires or the runtime shuts down.
+    #[must_use]
+    pub(crate) fn register_cancel_tx(&self, cancel_tx: Sender) -> bool {
         let mut lock = self.entry.state.lock();
         if !lock.cancelled && !lock.woken_up {
             let old_tx = lock.cancel_tx.replace(cancel_tx);
             // don't unlock — poisoning the `Mutex` stops others from using the bad state.
             assert!(old_tx.is_none(), "cancel_tx is already registered");
+            true
+        } else {
+            false
         }
     }
 

--- a/tokio/src/runtime/time_alt/entry.rs
+++ b/tokio/src/runtime/time_alt/entry.rs
@@ -210,17 +210,7 @@ impl Handle {
         }
     }
 
-    /// Registers `cancel_tx` so that a subsequent [`Handle::cancel`] call can
-    /// find its way back into the wheel it is about to be (or already is)
-    /// inserted into.
-    ///
-    /// Returns `false` — without registering anything — if the entry was
-    /// already cancelled or already woken up by the time this is called.
-    /// Callers must not insert an entry into the wheel when this returns
-    /// `false`: without a registered `cancel_tx`, nothing could ever
-    /// remove it again, and it would sit in the wheel until it naturally
-    /// expires or the runtime shuts down.
-    #[must_use]
+    /// Returns `false` if the `self` has already been cancelled or woken up.
     pub(crate) fn register_cancel_tx(&self, cancel_tx: Sender) -> bool {
         let mut lock = self.entry.state.lock();
         if !lock.cancelled && !lock.woken_up {

--- a/tokio/src/runtime/time_alt/tests.rs
+++ b/tokio/src/runtime/time_alt/tests.rs
@@ -12,8 +12,12 @@ const NUM_ITEMS: usize = 16;
 const NUM_ITEMS: usize = 64;
 
 fn new_handle() -> (EntryHandle, AwokenCount) {
+    new_handle_with_deadline(0)
+}
+
+fn new_handle_with_deadline(deadline: u64) -> (EntryHandle, AwokenCount) {
     let (waker, count) = new_count_waker();
-    let entry = EntryHandle::new(0);
+    let entry = EntryHandle::new(deadline);
     _ = entry.poll(&mut Context::from_waker(&waker));
     (entry, count)
 }
@@ -66,7 +70,7 @@ fn cancel_in_the_same_thread() {
 
         for _ in 0..NUM_ITEMS {
             let (hdl, count) = new_handle();
-            hdl.register_cancel_tx(cancel_tx.clone());
+            assert!(hdl.register_cancel_tx(cancel_tx.clone()));
             counts.push(count);
             unsafe {
                 reg_queue.push_front(hdl.clone());
@@ -88,6 +92,136 @@ fn cancel_in_the_same_thread() {
         wake_queue.wake_all();
 
         assert!(counts.into_iter().all(|c| c.get() == 0));
+    });
+}
+
+#[test]
+/// Reproduces the scenario where a timer is cancelled (e.g. its `Sleep` is
+/// dropped) *before* `Wheel::insert` is called for it, which is the normal
+/// case for a timer that is dropped while it's still sitting in the
+/// per-worker `RegistrationQueue` and has not yet been handed a `cancel_tx`
+/// (e.g. `tokio::select!` where the sleep branch loses and its future is
+/// dropped, or a `timeout()` whose inner future resolves first, all without
+/// the worker parking in between).
+///
+/// Before this fix, `Wheel::insert` called `register_cancel_tx` but ignored
+/// whether it actually succeeded, and unconditionally added the entry to a
+/// wheel slot regardless. A `register_cancel_tx` failure means the entry is
+/// cancelled/woken with no `cancel_tx` stored, so nothing could ever find it
+/// in the wheel to remove it again -- it would sit there, occupying a slot,
+/// until it naturally expired (up to ~2 years later, see
+/// `wheel::MAX_DURATION`) or the runtime shut down.
+fn insert_of_already_cancelled_entry_does_not_enter_wheel() {
+    model(|| {
+        let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
+        let mut wheel = Wheel::new();
+
+        // Use a deadline far in the future so it can't accidentally be
+        // treated as already-expired.
+        let far_future = 10_000_000;
+        let (hdl, count) = new_handle_with_deadline(far_future);
+
+        // The timer is cancelled *before* it is ever inserted into a wheel,
+        // i.e. before it has a `cancel_tx` to remove itself through.
+        hdl.cancel();
+        assert!(hdl.is_cancelled());
+
+        // The driver now processes it, exactly as
+        // `scheduler::util::time_alt::process_registration_queue` /
+        // `insert_inject_timers` do for entries that haven't hit their
+        // deadline yet.
+        unsafe {
+            wheel.insert(hdl, cancel_tx);
+        }
+
+        // The cancelled entry must NOT be occupying a slot in the wheel:
+        // there is no live `Sleep`/`Timer` left that could ever remove it,
+        // so if it went into the wheel it is stuck there until it naturally
+        // expires or the runtime shuts down.
+        assert!(
+            wheel.next_expiration_time().is_none(),
+            "an already-cancelled entry leaked into the wheel on insert"
+        );
+
+        // It also must not have been queued for cancellation removal, since
+        // it was never actually placed in the wheel for `remove` to find.
+        assert_eq!(cancel_rx.recv_all().count(), 0);
+        assert_eq!(count.get(), 0);
+
+        // `Wheel` has no `Drop` impl of its own (unlike the other queues) --
+        // it relies on the driver always fully draining it via
+        // `take_expired`/`shutdown_alt` before it goes away. Do the same
+        // here so a leaked entry (i.e. this test failing) is reported via
+        // the assertion above and not obscured by an unrelated
+        // "Arc leaked" panic from loom's own leak checker.
+        let mut wake_queue = WakeQueue::new();
+        wheel.take_expired(u64::MAX, &mut wake_queue);
+        wake_queue.wake_all();
+    });
+}
+
+#[test]
+/// The concurrent counterpart of the test above: this races a real
+/// `Handle::cancel()` call against `Wheel::insert()` for the *same* entry
+/// on two different (loom-modelled) threads, which is exactly what happens
+/// when a `Sleep` created on one worker is dropped from a different thread
+/// (e.g. the task got migrated) at the same moment the original worker is
+/// draining its registration queue into the wheel.
+///
+/// This is the interleaving that a naive fix -- checking
+/// `hdl.is_cancelled()` once up front before calling `Wheel::insert` --
+/// would still miss: the check-then-insert would not be atomic, so a
+/// `cancel()` landing in the gap could still slip an entry into the wheel
+/// with no `cancel_tx` registered. The real fix makes `Wheel::insert` act
+/// on the same lock-guarded answer that `register_cancel_tx` computes,
+/// so there is no gap to race into.
+fn cancel_races_with_insert() {
+    model(|| {
+        let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
+        let mut wheel = Wheel::new();
+
+        let far_future = 10_000_000;
+        let (hdl, count) = new_handle_with_deadline(far_future);
+
+        let hdl2 = hdl.clone();
+        let jh = thread::spawn(move || {
+            hdl2.cancel();
+        });
+
+        unsafe {
+            wheel.insert(hdl, cancel_tx);
+        }
+
+        jh.join().unwrap();
+
+        // Whichever way the race went, the entry must end up in exactly one
+        // of two consistent end states -- never "in the wheel with no way
+        // to ever remove it again":
+        //
+        // (a) `cancel()` won the race and ran first: `insert` sees it's
+        //     already cancelled and refuses to add it to the wheel.
+        // (b) `insert` won the race and registered `cancel_tx` first:
+        //     `cancel()` then finds `cancel_tx` and pushes the entry into
+        //     the cancellation queue for later removal from the wheel.
+        //
+        // Either way, the entry is not left stuck in the wheel with no
+        // corresponding entry in the cancellation queue.
+        let cancelled_via_queue = cancel_rx.recv_all().count();
+        let leaked_in_wheel = wheel.next_expiration_time().is_some();
+
+        assert!(
+            !leaked_in_wheel || cancelled_via_queue == 1,
+            "entry is stuck in the wheel with no way to ever be removed"
+        );
+        assert_eq!(count.get(), 0, "a cancelled entry must never be woken");
+
+        // Drain the wheel unconditionally so this test doesn't trip loom's
+        // leak checker on the (bug-exhibiting) path where the entry ended
+        // up stuck in the wheel -- see the comment in
+        // `insert_of_already_cancelled_entry_does_not_enter_wheel`.
+        let mut wake_queue = WakeQueue::new();
+        wheel.take_expired(u64::MAX, &mut wake_queue);
+        wake_queue.wake_all();
     });
 }
 
@@ -137,7 +271,7 @@ fn cancel_in_the_different_thread() {
 
         for _ in 0..NUM_ITEMS {
             let (hdl, count) = new_handle();
-            hdl.register_cancel_tx(cancel_tx.clone());
+            assert!(hdl.register_cancel_tx(cancel_tx.clone()));
             counts.push(count);
             hdls.push(hdl.clone());
             unsafe {

--- a/tokio/src/runtime/time_alt/tests.rs
+++ b/tokio/src/runtime/time_alt/tests.rs
@@ -97,86 +97,63 @@ fn cancel_in_the_same_thread() {
 
 #[test]
 fn insert_of_already_cancelled_entry_does_not_enter_wheel() {
-    model(|| {
-        let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
-        let mut wheel = Wheel::new();
+    let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
+    let mut wheel = Wheel::new();
 
-        // Use a deadline far in the future so it can't accidentally be
-        // treated as already-expired.
-        let far_future = 10_000_000;
-        let (hdl, count) = new_handle_with_deadline(far_future);
+    // do not expire during the test
+    let far_future = 10_000_000;
+    let (hdl, awoken_count) = new_handle_with_deadline(far_future);
 
-        // The timer is cancelled *before* it is ever inserted into a wheel,
-        // i.e. before it has a `cancel_tx` to remove itself through.
-        hdl.cancel();
-        assert!(hdl.is_cancelled());
+    // cancel the timer before inserting it into the wheel
+    hdl.cancel();
+    assert!(hdl.is_cancelled());
 
-        // The driver now processes it, exactly as
-        // `scheduler::util::time_alt::process_registration_queue` /
-        // `insert_inject_timers` do for entries that haven't hit their
-        // deadline yet.
-        unsafe {
-            wheel.insert(hdl, cancel_tx);
-        }
+    // try to insert the cancelled entry into the wheel
+    unsafe {
+        wheel.insert(hdl, cancel_tx);
+    }
 
-        // The cancelled entry must NOT be occupying a slot in the wheel:
-        // there is no live `Sleep`/`Timer` left that could ever remove it,
-        // so if it went into the wheel it is stuck there until it naturally
-        // expires or the runtime shuts down.
-        assert!(
-            wheel.next_expiration_time().is_none(),
-            "an already-cancelled entry leaked into the wheel on insert"
-        );
+    // a cancelled entry should not be inserted into the wheel
+    assert!(
+        wheel.next_expiration_time().is_none(),
+        "an already-cancelled entry leaked into the wheel on insert"
+    );
 
-        // It also must not have been queued for cancellation removal, since
-        // it was never actually placed in the wheel for `remove` to find.
-        assert_eq!(cancel_rx.recv_all().count(), 0);
-        assert_eq!(count.get(), 0);
+    // It also must not have been queued for cancellation removal, since
+    // it was never actually placed in the wheel for `remove` to find.
+    assert_eq!(cancel_rx.recv_all().count(), 0);
+    assert_eq!(awoken_count.get(), 0);
 
-        // `Wheel` has no `Drop` impl of its own (unlike the other queues) --
-        // it relies on the driver always fully draining it via
-        // `take_expired`/`shutdown_alt` before it goes away. Do the same
-        // here so a leaked entry (i.e. this test failing) is reported via
-        // the assertion above and not obscured by an unrelated
-        // "Arc leaked" panic from loom's own leak checker.
-        let mut wake_queue = WakeQueue::new();
-        wheel.take_expired(u64::MAX, &mut wake_queue);
-        wake_queue.wake_all();
-    });
+    // drain the wheel unconditionally, otherwise loom will complain
+    // about the leaked entry, which confuses developers in case
+    // this test fails for some other reason.
+    let mut wake_queue = WakeQueue::new();
+    wheel.take_expired(u64::MAX, &mut wake_queue);
+    wake_queue.wake_all();
 }
 
 #[test]
-/// The concurrent counterpart of the test above: this races a real
-/// `Handle::cancel()` call against `Wheel::insert()` for the *same* entry
-/// on two different (loom-modelled) threads, which is exactly what happens
-/// when a `Sleep` created on one worker is dropped from a different thread
-/// (e.g. the task got migrated) at the same moment the original worker is
-/// draining its registration queue into the wheel.
-///
-/// This is the interleaving that a naive fix -- checking
-/// `hdl.is_cancelled()` once up front before calling `Wheel::insert` --
-/// would still miss: the check-then-insert would not be atomic, so a
-/// `cancel()` landing in the gap could still slip an entry into the wheel
-/// with no `cancel_tx` registered. The real fix makes `Wheel::insert` act
-/// on the same lock-guarded answer that `register_cancel_tx` computes,
-/// so there is no gap to race into.
 fn cancel_races_with_insert() {
     model(|| {
         let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
         let mut wheel = Wheel::new();
 
+        // do not expire during the test
         let far_future = 10_000_000;
         let (hdl, count) = new_handle_with_deadline(far_future);
 
         let hdl2 = hdl.clone();
         let jh = thread::spawn(move || {
+            // cancel the timer concurrently with insertion into the wheel
             hdl2.cancel();
         });
 
+        // try to insert the entry into the wheel concurrently with cancellation
         unsafe {
             wheel.insert(hdl, cancel_tx);
         }
 
+        // ensure the cancellation thread has exited
         jh.join().unwrap();
 
         // Whichever way the race went, the entry must end up in exactly one
@@ -200,10 +177,9 @@ fn cancel_races_with_insert() {
         );
         assert_eq!(count.get(), 0, "a cancelled entry must never be woken");
 
-        // Drain the wheel unconditionally so this test doesn't trip loom's
-        // leak checker on the (bug-exhibiting) path where the entry ended
-        // up stuck in the wheel -- see the comment in
-        // `insert_of_already_cancelled_entry_does_not_enter_wheel`.
+        // drain the wheel unconditionally, otherwise loom will complain
+        // about the leaked entry, which confuses developers in case
+        // this test fails for some other reason.
         let mut wake_queue = WakeQueue::new();
         wheel.take_expired(u64::MAX, &mut wake_queue);
         wake_queue.wake_all();

--- a/tokio/src/runtime/time_alt/tests.rs
+++ b/tokio/src/runtime/time_alt/tests.rs
@@ -96,21 +96,6 @@ fn cancel_in_the_same_thread() {
 }
 
 #[test]
-/// Reproduces the scenario where a timer is cancelled (e.g. its `Sleep` is
-/// dropped) *before* `Wheel::insert` is called for it, which is the normal
-/// case for a timer that is dropped while it's still sitting in the
-/// per-worker `RegistrationQueue` and has not yet been handed a `cancel_tx`
-/// (e.g. `tokio::select!` where the sleep branch loses and its future is
-/// dropped, or a `timeout()` whose inner future resolves first, all without
-/// the worker parking in between).
-///
-/// Before this fix, `Wheel::insert` called `register_cancel_tx` but ignored
-/// whether it actually succeeded, and unconditionally added the entry to a
-/// wheel slot regardless. A `register_cancel_tx` failure means the entry is
-/// cancelled/woken with no `cancel_tx` stored, so nothing could ever find it
-/// in the wheel to remove it again -- it would sit there, occupying a slot,
-/// until it naturally expired (up to ~2 years later, see
-/// `wheel::MAX_DURATION`) or the runtime shut down.
 fn insert_of_already_cancelled_entry_does_not_enter_wheel() {
     model(|| {
         let (cancel_tx, mut cancel_rx) = cancellation_queue::new();

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -54,12 +54,7 @@ impl Wheel {
         self.elapsed
     }
 
-    /// Inserts an entry into the timing wheel, unless it has already been
-    /// cancelled or woken up (e.g. a racing `Handle::cancel` from another
-    /// thread beat us here). In that case, the entry is dropped instead:
-    /// there is nothing to insert into the wheel for, and — crucially — no
-    /// `cancel_tx` was registered on it, so it must not be added, or it
-    /// would sit in the wheel forever with no way to be removed again.
+    /// Inserts an entry into the timing wheel
     ///
     /// # Arguments
     ///
@@ -75,14 +70,8 @@ impl Wheel {
 
         assert!(deadline > self.elapsed);
 
-        // This is the single point of truth for whether the entry is safe to
-        // insert: `register_cancel_tx` re-checks the cancelled/woken state
-        // under the entry's own lock and atomically stores `cancel_tx` only
-        // if it is still live. If it returns `false`, some racing
-        // `Handle::cancel`/wake already ran (or ran with no `cancel_tx` to
-        // find), so there is no way to ever remove `hdl` from the wheel
-        // again and it must not be added.
         if !hdl.register_cancel_tx(cancel_tx) {
+            // `hdl` has been cancelled or woken up concurrently
             return;
         }
 

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -54,7 +54,12 @@ impl Wheel {
         self.elapsed
     }
 
-    /// Inserts an entry into the timing wheel.
+    /// Inserts an entry into the timing wheel, unless it has already been
+    /// cancelled or woken up (e.g. a racing `Handle::cancel` from another
+    /// thread beat us here). In that case, the entry is dropped instead:
+    /// there is nothing to insert into the wheel for, and — crucially — no
+    /// `cancel_tx` was registered on it, so it must not be added, or it
+    /// would sit in the wheel forever with no way to be removed again.
     ///
     /// # Arguments
     ///
@@ -70,7 +75,16 @@ impl Wheel {
 
         assert!(deadline > self.elapsed);
 
-        hdl.register_cancel_tx(cancel_tx);
+        // This is the single point of truth for whether the entry is safe to
+        // insert: `register_cancel_tx` re-checks the cancelled/woken state
+        // under the entry's own lock and atomically stores `cancel_tx` only
+        // if it is still live. If it returns `false`, some racing
+        // `Handle::cancel`/wake already ran (or ran with no `cancel_tx` to
+        // find), so there is no way to ever remove `hdl` from the wheel
+        // again and it must not be added.
+        if !hdl.register_cancel_tx(cancel_tx) {
+            return;
+        }
 
         // Get the level at which the entry should be stored
         let level = self.level_for(deadline);


### PR DESCRIPTION
`Wheel::insert` calls `hdl.register_cancel_tx(cancel_tx)` to hand the entry a way back into the cancellation queue, but it never checked whether that actually succeeded before adding the entry to a wheel slot. `register_cancel_tx` already refuses to store the sender if the entry is already cancelled or woken (it re-checks under the entry's own lock), so that part was fine — but the caller just ignored the outcome and inserted anyway.

The reachable case: a `Sleep` gets created and dropped again (e.g. the losing branch of a `select!`, or `timeout()` where the other future wins) before the worker parks and moves it out of local state into the wheel. `cancel()` runs while there's still no `cancel_tx` registered, so it can only flip the `cancelled` bit — there's no queue for it to push into. When the wheel insertion happens shortly after, `register_cancel_tx` correctly declines, but the entry still gets added to a slot. Since nothing has a `cancel_tx` for it anymore, there's no way to ever pull it back out again except by natural expiration (which can be a long time out, the wheel supports deadlines up to ~2 years) or full runtime shutdown.

Fix makes `register_cancel_tx` return whether it stored the sender, and `insert` bails before touching the wheel if it didn't. This also closes a narrower race: a naive `if hdl.is_cancelled() { skip }` pre-check in the caller wouldn't be atomic with the insert, so a `cancel()` landing in the gap could still slip through. Making `insert` act on the same lock-guarded answer `register_cancel_tx` already computes removes that gap entirely.

Added a loom test (`cancel_races_with_insert`) that races `cancel()` against `insert()` on separate threads and asserts the entry never ends up in the wheel without either being removable via the cancellation queue or a proper wakeup — it panics reliably against the old code (loom finds the bad interleaving on essentially the first schedule) and passes at preemption bound 3 with the fix. Also added a plain sequential test for the simpler single-thread case.