### PR TITLE
runtime: don't wait for blocking pool on panic during shutdown

### DIFF
--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -501,6 +501,12 @@ impl Runtime {
 
 impl Drop for Runtime {
     fn drop(&mut self) {
+        // On a panic, shut down the blocking pool immediately instead of waiting
+        // since a clean showdown isn't necessary once its unwinding.
+        if std::thread::panicking() {
+            self.blocking_pool.shutdown(Some(Duration::from_nanos(0)));
+        }
+
         match &mut self.scheduler {
             Scheduler::CurrentThread(current_thread) => {
                 // This ensures that tasks spawned on the current-thread

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -238,6 +238,30 @@ rt_test! {
         }));
     }
 
+    #[test]
+    fn drop_on_panic_is_immediate() {
+        use std::sync::mpsc;
+        use std::thread;
+
+        let (tx, rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            let rt = rt();
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                rt.block_on(async {
+                    tokio::task::spawn_blocking(|| {
+                        thread::sleep(Duration::from_secs(5));
+                    });
+                    panic!("trigger unwind");
+                });
+            }));
+            let _ = tx.send(());
+        });
+        // If main thread receives message from rx within 2 seconds
+        // the spawned thread had been dropped immediately, as expected
+        assert!(rx.recv_timeout(Duration::from_secs(2)).is_ok());
+    }
+
     // ==== net ======
 
     #[test]


### PR DESCRIPTION

## Motivation
When is runtime is dropped while unwinding from a panic that propagated from block_on(), drop() that impl runtime would rely on the blocking pool being dropped which waits for outstanding spawn_blocking() tasks to finish. This may have prevented the process from executing even though in the case of a panic, a clean shutdown is not really expected anymore.

This problem was shown in #5433, in which it would take multiple seconds in my testing for the main thread to finish.


## Solution
Detect unwinding and if true, shut down the blocking pool immediately instead of waiting.

Testing shows sub 30ms times for the main thread to finish.

