### PR TITLE
Support ucred.rs on Fuchsia

### DIFF
--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -69,9 +69,10 @@ pub(crate) use self::impl_aix::get_peer_cred;
 
 #[cfg(any(
     target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "hurd",
     target_os = "nuttx",
-    target_os = "vita",
-    target_os = "hurd"
+    target_os = "vita"
 ))]
 pub(crate) use self::impl_noproc::get_peer_cred;
 
@@ -400,9 +401,10 @@ pub(crate) mod impl_aix {
 
 #[cfg(any(
     target_os = "espidf",
+    target_os = "fuchsia",
+    target_os = "hurd",
     target_os = "nuttx",
-    target_os = "vita",
-    target_os = "hurd"
+    target_os = "vita"
 ))]
 pub(crate) mod impl_noproc {
     use crate::net::unix::UnixStream;


### PR DESCRIPTION
## Motivation

Compiling tokio on Fuchsia with the net feature enabled results in a compile time error due to a missing target_os cfg in ucred.rs.

## Solution

The commit in this pull request adds the missing target_os cfg flags and makes compilation pass on Fuchsia.