### PR TITLE
net: call CancelIoEx on NamedPipeServer drop

### DIFF
--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -24,7 +24,7 @@ mod doc {
     pub(super) mod windows_sys {
         pub(crate) use windows_sys::{
             Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::System::Pipes::*,
-            Win32::System::SystemServices::*,
+            Win32::System::SystemServices::*, Win32::System::IO::CancelIoEx,
         };
     }
     pub(super) use mio::windows as mio_windows;
@@ -104,6 +104,18 @@ use self::doc::*;
 #[derive(Debug)]
 pub struct NamedPipeServer {
     io: PollEvented<mio_windows::NamedPipe>,
+}
+
+impl Drop for NamedPipeServer {
+    fn drop(&mut self) {
+        unsafe {
+            // Cancel all pending overlapped I/O on this handle.
+            // We pass null for the lpOverlapped parameter to cancel all requests.
+            // We ignore the return value because failure during drop is expected
+            // if no I/O was pending.
+            windows_sys::CancelIoEx(self.as_raw_handle() as _, ptr::null_mut());
+        }
+    }
 }
 
 impl NamedPipeServer {

--- a/tokio/tests/net_named_pipe.rs
+++ b/tokio/tests/net_named_pipe.rs
@@ -397,3 +397,28 @@ async fn test_named_pipe_access() -> io::Result<()> {
     }
     Ok(())
 }
+
+#[tokio::test]
+async fn test_named_pipe_server_drop_cancels_io() -> std::io::Result<()> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+    let pipe_name = r"\\.\pipe\tokio-named-pipe-server-drop-cancel-test";
+
+    let server = ServerOptions::new().create(pipe_name)?;
+
+    {
+        // Start an asynchronous connect that will go pending because there is no client.
+        let connect_future = server.connect();
+        tokio::pin!(connect_future);
+
+        // Poll it once to ensure the overlapped I/O request is submitted to the kernel.
+        let _ = futures::poll!(&mut connect_future);
+
+        // The future is dropped at the end of this block (cancelling the Rust-side await).
+        // If CancelIoEx is not called in the Drop trait, the pending ConnectNamedPipe
+        // will leak in the Windows kernel and could cause a use-after-free.
+    }
+
+    drop(server);
+
+    Ok(())
+}


### PR DESCRIPTION
Previously, NamedPipeServer lacked an explicit Drop implementation. When dropped, the underlying Windows handle was closed via mio, but any pending asynchronous ConnectNamedPipe requests (or reads/writes) were not explicitly cancelled. This leaks IOCP kernel resources and risks use-after-free memory corruption if the kernel writes an I/O completion packet to the freed OVERLAPPED struct. This introduces a Drop implementation that calls CancelIoEx on the raw handle, safely aborting pending overlapped I/O before the struct is deallocated.