### PR TITLE
Support Nuttx target os

### DIFF
--- a/tokio/src/net/tcp/socket.rs
+++ b/tokio/src/net/tcp/socket.rs
@@ -286,6 +286,7 @@ impl TcpSocket {
         not(target_os = "solaris"),
         not(target_os = "illumos"),
         not(target_os = "cygwin"),
+        not(target_os = "nuttx"),
     ))]
     #[cfg_attr(
         docsrs,
@@ -294,6 +295,7 @@ impl TcpSocket {
             not(target_os = "solaris"),
             not(target_os = "illumos"),
             not(target_os = "cygwin"),
+            not(target_os = "nuttx"),
         )))
     )]
     pub fn set_reuseport(&self, reuseport: bool) -> io::Result<()> {
@@ -331,6 +333,7 @@ impl TcpSocket {
         not(target_os = "solaris"),
         not(target_os = "illumos"),
         not(target_os = "cygwin"),
+        not(target_os = "nuttx"),
     ))]
     #[cfg_attr(
         docsrs,
@@ -339,6 +342,7 @@ impl TcpSocket {
             not(target_os = "solaris"),
             not(target_os = "illumos"),
             not(target_os = "cygwin"),
+            not(target_os = "nuttx"),
         )))
     )]
     pub fn reuseport(&self) -> io::Result<bool> {

--- a/tokio/src/net/unix/ucred.rs
+++ b/tokio/src/net/unix/ucred.rs
@@ -67,7 +67,12 @@ pub(crate) use self::impl_solaris::get_peer_cred;
 #[cfg(target_os = "aix")]
 pub(crate) use self::impl_aix::get_peer_cred;
 
-#[cfg(any(target_os = "espidf", target_os = "vita", target_os = "hurd"))]
+#[cfg(any(
+    target_os = "espidf",
+    target_os = "nuttx",
+    target_os = "vita",
+    target_os = "hurd"
+))]
 pub(crate) use self::impl_noproc::get_peer_cred;
 
 #[cfg(any(
@@ -390,7 +395,12 @@ pub(crate) mod impl_aix {
     }
 }
 
-#[cfg(any(target_os = "espidf", target_os = "vita", target_os = "hurd"))]
+#[cfg(any(
+    target_os = "espidf",
+    target_os = "nuttx",
+    target_os = "vita",
+    target_os = "hurd"
+))]
 pub(crate) mod impl_noproc {
     use crate::net::unix::UnixStream;
     use std::io;


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Nuttx is a Tier3 target. When we add tokio dependency to nuttx rust app and enable net feature, it will compile failed.
See https://doc.rust-lang.org/rustc/platform-support/nuttx.html for more information about Nuttx target.

## Solution

Nuttx is not support reuseport.
Use impl_noproc to handle get_peer_cred, for now, let's get tokio working.
