### PR TITLE
docs: correct spelling typos in comments and doc strings

### DIFF
--- a/tokio-util/src/codec/decoder.rs
+++ b/tokio-util/src/codec/decoder.rs
@@ -47,7 +47,7 @@ pub trait Decoder {
     /// implementation of `decode_eof` to yield an `io::Error` when the decoder
     /// fails to consume all available data.
     ///
-    /// Note that implementors of this trait can simply indicate `type Error =
+    /// Note that implementers of this trait can simply indicate `type Error =
     /// io::Error` to use I/O errors as this type.
     ///
     /// [`FramedRead`]: crate::codec::FramedRead

--- a/tokio-util/src/codec/mod.rs
+++ b/tokio-util/src/codec/mod.rs
@@ -12,7 +12,7 @@
 //! The following example demonstrates how to use a codec such as [`LinesCodec`] to
 //! write framed data. [`FramedWrite`] can be used to achieve this. Data sent to
 //! [`FramedWrite`] are first framed according to a specific codec, and then sent to
-//! an implementor of [`AsyncWrite`].
+//! an implementer of [`AsyncWrite`].
 //!
 //! ```
 //! use futures::sink::SinkExt;
@@ -43,7 +43,7 @@
 //! # Example decoding using `LinesCodec`
 //! The following example demonstrates how to use a codec such as [`LinesCodec`] to
 //! read a stream of framed data. [`FramedRead`] can be used to achieve this. [`FramedRead`]
-//! will keep reading from an [`AsyncRead`] implementor until a whole frame, according to a codec,
+//! will keep reading from an [`AsyncRead`] implementer until a whole frame, according to a codec,
 //! can be parsed.
 //!
 //!```

--- a/tokio/src/io/bsd/poll_aio.rs
+++ b/tokio/src/io/bsd/poll_aio.rs
@@ -15,8 +15,8 @@ use std::task::{ready, Context, Poll};
 
 /// Like [`mio::event::Source`], but for POSIX AIO only.
 ///
-/// Tokio's consumer must pass an implementor of this trait to create a
-/// [`Aio`] object.  Implementors must implement at least one of [`AioSource::register`] and
+/// Tokio's consumer must pass an implementer of this trait to create a
+/// [`Aio`] object.  Implementers must implement at least one of [`AioSource::register`] and
 /// [`AioSource::register_borrowed`].
 pub trait AioSource {
     /// Registers this AIO event source with Tokio's reactor.
@@ -27,7 +27,7 @@ pub trait AioSource {
     /// source may end up notifying the wrong file.
     #[deprecated(since = "1.52.0", note = "use register_borrowed instead")]
     fn register(&mut self, _kq: RawFd, _token: usize) {
-        // This default implementation exists so new AioSource implementors that implement the
+        // This default implementation exists so new AioSource implementers that implement the
         // register_borrowed method can compile without the need to implement register.
         unimplemented!("Use AioSource::register_borrowed instead")
     }
@@ -35,7 +35,7 @@ pub trait AioSource {
     /// Registers this AIO event source with Tokio's reactor.
     fn register_borrowed(&mut self, kq: BorrowedFd<'_>, token: usize) {
         // This default implementation serves to provide backwards compatibility with AioSource
-        // implementors written before 1.52.0 that only implemented the unsafe `register` method.
+        // implementers written before 1.52.0 that only implemented the unsafe `register` method.
         #[allow(deprecated)]
         self.register(kq.as_raw_fd(), token)
     }

--- a/tokio/src/io/util/vec_with_initialized.rs
+++ b/tokio/src/io/util/vec_with_initialized.rs
@@ -5,7 +5,7 @@ use std::mem::MaybeUninit;
 ///
 /// # Safety
 ///
-/// The implementor must guarantee that the vector returned by the
+/// The implementer must guarantee that the vector returned by the
 /// `as_mut` and `as_mut` methods do not change from one call to
 /// another.
 pub(crate) unsafe trait VecU8: AsRef<Vec<u8>> + AsMut<Vec<u8>> {}

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -69,7 +69,7 @@ impl TcpListener {
         /// to this listener. The port allocated can be queried via the `local_addr`
         /// method.
         ///
-        /// The address type can be any implementor of the [`ToSocketAddrs`] trait.
+        /// The address type can be any implementer of the [`ToSocketAddrs`] trait.
         /// If `addr` yields multiple addresses, bind will be attempted with each of
         /// the addresses until one succeeds and returns the listener. If none of
         /// the addresses succeed in creating a listener, the error returned from

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1149,7 +1149,7 @@ impl UdpSocket {
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes written.
     ///
-    /// Address type can be any implementor of [`ToSocketAddrs`] trait. See its
+    /// Address type can be any implementer of [`ToSocketAddrs`] trait. See its
     /// documentation for concrete examples.
     ///
     /// It is possible for `addr` to yield multiple addresses, but `send_to`

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -111,7 +111,7 @@ unsafe extern "system" fn handler(ty: u32) -> BOOL {
     // `SetConsoleCtrlHandler` and `REGISTRY` being initialized.
     let Ok(registry) = REGISTRY.wait().as_ref() else {
         // Technically unreachable since `handler` is only called if
-        // `SetConsoleCtrlHandler` succeded.
+        // `SetConsoleCtrlHandler` succeeded.
         return 0;
     };
 

--- a/tokio/tests/tcp_shutdown.rs
+++ b/tokio/tests/tcp_shutdown.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support mulithreading
+#![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi doesn't support multithreading
 
 use tokio::io::{self, AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};


### PR DESCRIPTION
Fix several spelling errors found in comments and documentation strings:

- `mulithreading` -> `multithreading` in `tokio/tests/tcp_shutdown.rs`
- `succeded` -> `succeeded` in `tokio/src/signal/windows/sys.rs`
- `implementor`/`implementors` -> `implementer`/`implementers` in multiple files (consistent with the spelling already used elsewhere in the codebase, e.g. `tokio-util/src/util/poll_buf.rs`, `tokio/src/io/async_write.rs`)

No logic changes.