### PR TITLE
Fix disambiguators in output

### DIFF
--- a/tokio/src/runtime/task/trace/symbol.rs
+++ b/tokio/src/runtime/task/trace/symbol.rs
@@ -65,7 +65,8 @@ impl Eq for Symbol {}
 impl fmt::Display for Symbol {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(name) = self.symbol.name() {
-            let name = name.to_string();
+            // Printing this using :# formatting omits crate disambiguators.
+            let name = format!("{name:#}");
             let name = if let Some((name, _)) = name.rsplit_once("::") {
                 name
             } else {

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -147,7 +147,7 @@ fn trace_leaf_for_test(meta: &TraceMeta, log: &mut Vec<Vec<String>>) {
     for frame in bt.frames() {
         for symbol in frame.symbols() {
             if let Some(name) = symbol.name() {
-                names.push(strip_symbol_hash(&format!("{name}")).to_owned());
+                names.push(strip_symbol_hash(&format!("{name:#}")).to_owned());
             }
         }
     }


### PR DESCRIPTION
This fixes the below CI failure caused by the new version of Rust using the new name mangling scheme. Previously, it would print `dump::a` but now it prints `dump[1f9739d5720acbda]::a`. However, the alternate printing support will omit the crate disambiguator.
```
        FAIL [   0.106s] ( 168/1502) tokio::dump current_thread
  stdout ───

    running 1 test
    test current_thread ... FAILED

    failures:

    failures:
        current_thread

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 0.10s
    
  stderr ───


    3:
    ╼ dump[1f9739d5720acbda]::a at /home/runner/work/tokio/tokio/tokio/tests/dump.rs:18:20
      └╼ dump[1f9739d5720acbda]::b at /home/runner/work/tokio/tokio/tokio/tests/dump.rs:23:20
         └╼ dump[1f9739d5720acbda]::c at /home/runner/work/tokio/tokio/tokio/tests/dump.rs:29:45
            └╼ tokio[11b48f137521fdf5]::task::yield_now::yield_now at /home/runner/work/tokio/tokio/tokio/src/task/yield_now.rs:59:6
               └╼ <core[908f964b99904f4c]::future::poll_fn::PollFn<tokio[11b48f137521fdf5]::task::yield_now::yield_now::{closure#0}::{closure#0}> as core[908f964b99904f4c]::future::future::Future> at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/future/poll_fn.rs:151:9
                  └╼ tokio[11b48f137521fdf5]::task::yield_now::yield_now::{closure#0} at /home/runner/work/tokio/tokio/tokio/src/task/yield_now.rs:41:16



    thread 'current_thread' (8155) panicked at tokio/tests/dump.rs:52:13:
    assertion failed: trace.contains("dump::a")
    stack backtrace:
       0: __rustc::rust_begin_unwind
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/std/src/panicking.rs:689:5
       1: core::panicking::panic_fmt
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/panicking.rs:80:14
       2: core::panicking::panic
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/panicking.rs:150:5
       3: dump::current_thread::dump::{closure#0}
                 at ./tests/dump.rs:52:13
       4: dump::current_thread::{closure#0}::{closure#0}
                 at ./src/macros/select.rs:710:49
       5: <core::future::poll_fn::PollFn<dump::current_thread::{closure#0}::{closure#0}> as core::future::future::Future>::poll
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/future/poll_fn.rs:151:9
       6: dump::current_thread::{closure#0}
                 at ./tests/dump.rs:60:9
       7: <tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}> as core::future::future::Future>::poll
                 at ./src/runtime/task/trace/mod.rs:359:25
       8: <core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>> as core::future::future::Future>::poll
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/future/future.rs:133:9
       9: <tokio::runtime::scheduler::current_thread::CoreGuard>::block_on::<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}::{closure#0}::{closure#0}
                 at ./src/runtime/scheduler/current_thread/mod.rs:823:70
      10: tokio::task::coop::with_budget::<core::task::poll::Poll<()>, <tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}::{closure#0}::{closure#0}>
                 at ./src/task/coop/mod.rs:167:5
      11: tokio::task::coop::budget::<core::task::poll::Poll<()>, <tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}::{closure#0}::{closure#0}>
                 at ./src/task/coop/mod.rs:133:5
      12: <tokio::runtime::scheduler::current_thread::CoreGuard>::block_on::<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}::{closure#0}
                 at ./src/runtime/scheduler/current_thread/mod.rs:823:25
      13: <tokio::runtime::scheduler::current_thread::Context>::enter::<core::task::poll::Poll<()>, <tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}::{closure#0}>
                 at ./src/runtime/scheduler/current_thread/mod.rs:481:19
      14: <tokio::runtime::scheduler::current_thread::CoreGuard>::block_on::<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}
                 at ./src/runtime/scheduler/current_thread/mod.rs:822:44
      15: <tokio::runtime::scheduler::current_thread::CoreGuard>::enter::<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}, core::option::Option<()>>::{closure#0}
                 at ./src/runtime/scheduler/current_thread/mod.rs:899:68
      16: <tokio::runtime::context::scoped::Scoped<tokio::runtime::scheduler::Context>>::set::<<tokio::runtime::scheduler::current_thread::CoreGuard>::enter<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}, core::option::Option<()>>::{closure#0}, (alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, core::option::Option<()>)>
                 at ./src/runtime/context/scoped.rs:40:9
      17: tokio::runtime::context::set_scheduler::<(alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, core::option::Option<()>), <tokio::runtime::scheduler::current_thread::CoreGuard>::enter<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}, core::option::Option<()>>::{closure#0}>::{closure#0}
                 at ./src/runtime/context.rs:187:38
      18: <std::thread::local::LocalKey<tokio::runtime::context::Context>>::try_with::<tokio::runtime::context::set_scheduler<(alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, core::option::Option<()>), <tokio::runtime::scheduler::current_thread::CoreGuard>::enter<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}, core::option::Option<()>>::{closure#0}>::{closure#0}, (alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, core::option::Option<()>)>
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/std/src/thread/local.rs:462:12
      19: <std::thread::local::LocalKey<tokio::runtime::context::Context>>::with::<tokio::runtime::context::set_scheduler<(alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, core::option::Option<()>), <tokio::runtime::scheduler::current_thread::CoreGuard>::enter<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}, core::option::Option<()>>::{closure#0}>::{closure#0}, (alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, core::option::Option<()>)>
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/std/src/thread/local.rs:426:20
      20: tokio::runtime::context::set_scheduler::<(alloc::boxed::Box<tokio::runtime::scheduler::current_thread::Core>, core::option::Option<()>), <tokio::runtime::scheduler::current_thread::CoreGuard>::enter<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}, core::option::Option<()>>::{closure#0}>
                 at ./src/runtime/context.rs:187:17
      21: <tokio::runtime::scheduler::current_thread::CoreGuard>::enter::<<tokio::runtime::scheduler::current_thread::CoreGuard>::block_on<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>::{closure#0}, core::option::Option<()>>
                 at ./src/runtime/scheduler/current_thread/mod.rs:899:27
      22: <tokio::runtime::scheduler::current_thread::CoreGuard>::block_on::<core::pin::Pin<&mut tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>>
                 at ./src/runtime/scheduler/current_thread/mod.rs:810:24
      23: <tokio::runtime::scheduler::current_thread::CurrentThread>::block_on::<tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>::{closure#0}
                 at ./src/runtime/scheduler/current_thread/mod.rs:218:33
      24: tokio::runtime::context::runtime::enter_runtime::<<tokio::runtime::scheduler::current_thread::CurrentThread>::block_on<tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>::{closure#0}, ()>
                 at ./src/runtime/context/runtime.rs:65:16
      25: <tokio::runtime::scheduler::current_thread::CurrentThread>::block_on::<tokio::runtime::task::trace::Root<dump::current_thread::{closure#0}>>
                 at ./src/runtime/scheduler/current_thread/mod.rs:206:9
      26: <tokio::runtime::runtime::Runtime>::block_on_inner::<dump::current_thread::{closure#0}>
                 at ./src/runtime/runtime.rs:376:52
      27: <tokio::runtime::runtime::Runtime>::block_on::<dump::current_thread::{closure#0}>
                 at ./src/runtime/runtime.rs:345:18
      28: dump::current_thread
                 at ./tests/dump.rs:59:8
      29: dump::current_thread::{closure#0}
                 at ./tests/dump.rs:34:20
      30: <dump::current_thread::{closure#0} as core::ops::function::FnOnce<()>>::call_once
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/ops/function.rs:250:5
      31: <fn() -> core::result::Result<(), alloc::string::String> as core::ops::function::FnOnce<()>>::call_once
                 at /rustc/2d8144b7880597b6e6d3dfd63a9a9efae3f533d3/library/core/src/ops/function.rs:250:5
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```