### PR TITLE
fs: document cancellation behavior of `tokio::fs`

### DIFF
--- a/tokio/src/fs/mod.rs
+++ b/tokio/src/fs/mod.rs
@@ -11,21 +11,22 @@
 //! behind the scenes. This is done using the [`spawn_blocking`] threadpool to
 //! run them in the background.
 //!
+//! The `tokio::fs` module should only be used for ordinary files. Trying to use
+//! it with e.g., a named pipe on Linux can result in surprising behavior,
+//! such as hangs during runtime shutdown. For special files, you should use a
+//! dedicated type such as [`tokio::net::unix::pipe`] or [`AsyncFd`] instead.
+//!
+//! Tokio currently uses [`spawn_blocking`] on all platforms, but also uses
+//! io_uring for file operations on Linux when compiled with `tokio_unstable`.
+//! Operations that cannot be cancelled with [`spawn_blocking`] may possibly
+//! be cancelled with io_uring.
+//!
 //! # Cancellation
 //!
 //! Cancelling a future from this module will stop waiting for the result, but
 //! the underlying blocking operation will continue to run on the thread pool.
 //! For example, cancelling a [`write()`] future after it has been
 //! polled will still result in the data being written to disk.
-//!
-//! The `tokio::fs` module should only be used for ordinary files. Trying to use
-//! it with e.g., a named pipe on Linux can result in surprising behavior,
-//! such as hangs during runtime shutdown. For special files, you should use a
-//! dedicated type such as [`tokio::net::unix::pipe`] or [`AsyncFd`] instead.
-//!
-//! Currently, Tokio will always use [`spawn_blocking`] on all platforms, but it
-//! may be changed to use asynchronous file system APIs such as io_uring in the
-//! future.
 //!
 //! # Usage
 //!

--- a/tokio/src/fs/mod.rs
+++ b/tokio/src/fs/mod.rs
@@ -11,6 +11,13 @@
 //! behind the scenes. This is done using the [`spawn_blocking`] threadpool to
 //! run them in the background.
 //!
+//! # Cancellation
+//!
+//! Cancelling a future from this module will stop waiting for the result, but
+//! the underlying blocking operation will continue to run on the thread pool.
+//! For example, cancelling a [`write()`] future after it has been
+//! polled will still result in the data being written to disk.
+//!
 //! The `tokio::fs` module should only be used for ordinary files. Trying to use
 //! it with e.g., a named pipe on Linux can result in surprising behavior,
 //! such as hangs during runtime shutdown. For special files, you should use a


### PR DESCRIPTION
## Motivation

Futures in `tokio::fs` use `spawn_blocking` internally, but the module docs
never mention what happens when a future is cancelled. Users may assume that
dropping a future stops the underlying I/O operation, but it doesn't — the
blocking task continues on the thread pool. This has been a source of
confusion (see #3247).

## Solution

Added a `# Cancellation` section to the `tokio::fs` module docs explaining
that cancelling a future stops waiting for the result, but the underlying
blocking operation continues to run on the thread pool.
