### PR TITLE
fs: add safe `impl From<OwnedFd> for File`

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -898,6 +898,13 @@ impl fmt::Debug for File {
 }
 
 #[cfg(unix)]
+impl From<std::os::fd::OwnedFd> for File {
+    fn from(fd: std::os::fd::OwnedFd) -> Self {
+        Self::from_std(StdFile::from(fd))
+    }
+}
+
+#[cfg(unix)]
 impl std::os::unix::io::AsRawFd for File {
     fn as_raw_fd(&self) -> std::os::unix::io::RawFd {
         self.std.as_raw_fd()
@@ -923,7 +930,13 @@ impl std::os::unix::io::FromRawFd for File {
 }
 
 cfg_windows! {
-    use crate::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle, AsHandle, BorrowedHandle};
+    use crate::os::windows::io::{AsRawHandle, FromRawHandle, RawHandle, AsHandle, BorrowedHandle, OwnedHandle};
+
+    impl From<OwnedHandle> for File {
+        fn from(handle: OwnedHandle) -> Self {
+            Self::from_std(StdFile::from(handle))
+        }
+    }
 
     impl AsRawHandle for File {
         fn as_raw_handle(&self) -> RawHandle {

--- a/tokio/src/fs/mocks.rs
+++ b/tokio/src/fs/mocks.rs
@@ -38,6 +38,10 @@ mock! {
         pub fn try_clone(&self) -> io::Result<Self>;
     }
     #[cfg(windows)]
+    impl From<std::os::windows::io::OwnedHandle> for File {
+        fn from(handle: std::os::windows::io::OwnedHandle) -> Self;
+    }
+    #[cfg(windows)]
     impl std::os::windows::io::AsRawHandle for File {
         fn as_raw_handle(&self) -> std::os::windows::io::RawHandle;
     }


### PR DESCRIPTION
This impl was missing to be able to create a `tokio::fs::File` directly from an `OwnedFd`, which can be done in a safe way.  Going through `RawFd` required unsafe for the same operation.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

Simplifying user code with fewer `unsafe` blocks.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Going through `std::fs::File::from(OwnedFd)` as that’s what our type contains anyway.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
