### PR TITLE
tokio-stream: Simplify TakeWhile with Option::filter()

### DIFF
--- a/tokio-stream/src/stream_ext/take_while.rs
+++ b/tokio-stream/src/stream_ext/take_while.rs
@@ -49,13 +49,7 @@ where
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         if !*self.as_mut().project().done {
             self.as_mut().project().stream.poll_next(cx).map(|ready| {
-                let ready = ready.and_then(|item| {
-                    if !(self.as_mut().project().predicate)(&item) {
-                        None
-                    } else {
-                        Some(item)
-                    }
-                });
+                let ready = ready.filter(self.as_mut().project().predicate);
 
                 if ready.is_none() {
                     *self.as_mut().project().done = true;


### PR DESCRIPTION
`Option::filter()` exists since Rust 1.27.0, and is much more readable than the open coded variant that was there before, using `Option::and_then()`.

This has been found by clippy.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

This makes the code much more readable than open-coding it.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Use `Option::filter()`.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
