### PR TITLE
sync: add blocking_acquire methods to Semaphore

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -722,6 +722,91 @@ impl Semaphore {
         }
     }
 
+    /// Acquires a permit from the semaphore, blocking the current thread until
+    /// one is available.
+    ///
+    /// If the semaphore has been closed, this returns an [`AcquireError`].
+    /// Otherwise, this returns a [`SemaphorePermit`] representing the
+    /// acquired permit.
+    ///
+    /// This method is intended for use in synchronous code, such as inside
+    /// [`spawn_blocking`] or when the semaphore is shared between asynchronous
+    /// and synchronous code. It is the blocking equivalent of [`acquire`].
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution
+    /// context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::Semaphore;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let semaphore = Arc::new(Semaphore::new(2));
+    ///
+    ///     let semaphore2 = semaphore.clone();
+    ///     let blocking_task = tokio::task::spawn_blocking(move || {
+    ///         // Inside a blocking context we cannot use `.await`, so we use
+    ///         // `blocking_acquire` instead.
+    ///         let _permit = semaphore2.blocking_acquire().unwrap();
+    ///
+    ///         // ... perform blocking work while holding the permit ...
+    ///     });
+    ///
+    ///     blocking_task.await.unwrap();
+    /// }
+    /// ```
+    ///
+    /// [`AcquireError`]: crate::sync::AcquireError
+    /// [`SemaphorePermit`]: crate::sync::SemaphorePermit
+    /// [`spawn_blocking`]: crate::task::spawn_blocking
+    /// [`acquire`]: Semaphore::acquire
+    #[track_caller]
+    #[cfg(feature = "sync")]
+    pub fn blocking_acquire(&self) -> Result<SemaphorePermit<'_>, AcquireError> {
+        crate::future::block_on(self.acquire())
+    }
+
+    /// Acquires `n` permits from the semaphore, blocking the current thread
+    /// until they are available.
+    ///
+    /// If the semaphore has been closed, this returns an [`AcquireError`].
+    /// Otherwise, this returns a [`SemaphorePermit`] representing the
+    /// acquired permits.
+    ///
+    /// This method is the blocking equivalent of [`acquire_many`].
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution
+    /// context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::sync::Semaphore;
+    ///
+    /// fn main() {
+    ///     let semaphore = Semaphore::new(5);
+    ///
+    ///     let permit = semaphore.blocking_acquire_many(3).unwrap();
+    ///     assert_eq!(semaphore.available_permits(), 2);
+    /// }
+    /// ```
+    ///
+    /// [`AcquireError`]: crate::sync::AcquireError
+    /// [`SemaphorePermit`]: crate::sync::SemaphorePermit
+    /// [`acquire_many`]: Semaphore::acquire_many
+    #[track_caller]
+    #[cfg(feature = "sync")]
+    pub fn blocking_acquire_many(&self, n: u32) -> Result<SemaphorePermit<'_>, AcquireError> {
+        crate::future::block_on(self.acquire_many(n))
+    }
+
     /// Acquires a permit from the semaphore.
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method.
@@ -929,6 +1014,87 @@ impl Semaphore {
             }),
             Err(e) => Err(e),
         }
+    }
+
+    /// Acquires a permit from the semaphore, blocking the current thread until
+    /// one is available.
+    ///
+    /// The semaphore must be wrapped in an [`Arc`] to call this method.
+    /// If the semaphore has been closed, this returns an [`AcquireError`].
+    /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
+    /// acquired permit.
+    ///
+    /// This method is the blocking equivalent of [`acquire_owned`].
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution
+    /// context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::Semaphore;
+    ///
+    /// fn main() {
+    ///     let semaphore = Arc::new(Semaphore::new(2));
+    ///
+    ///     let permit = semaphore.clone().blocking_acquire_owned().unwrap();
+    ///     assert_eq!(semaphore.available_permits(), 1);
+    /// }
+    /// ```
+    ///
+    /// [`Arc`]: std::sync::Arc
+    /// [`AcquireError`]: crate::sync::AcquireError
+    /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
+    /// [`acquire_owned`]: Semaphore::acquire_owned
+    #[track_caller]
+    #[cfg(feature = "sync")]
+    pub fn blocking_acquire_owned(self: Arc<Self>) -> Result<OwnedSemaphorePermit, AcquireError> {
+        crate::future::block_on(self.acquire_owned())
+    }
+
+    /// Acquires `n` permits from the semaphore, blocking the current thread
+    /// until they are available.
+    ///
+    /// The semaphore must be wrapped in an [`Arc`] to call this method.
+    /// If the semaphore has been closed, this returns an [`AcquireError`].
+    /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
+    /// acquired permits.
+    ///
+    /// This method is the blocking equivalent of [`acquire_many_owned`].
+    ///
+    /// # Panics
+    ///
+    /// This function panics if called within an asynchronous execution
+    /// context.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::sync::Arc;
+    /// use tokio::sync::Semaphore;
+    ///
+    /// fn main() {
+    ///     let semaphore = Arc::new(Semaphore::new(5));
+    ///
+    ///     let permit = semaphore.clone().blocking_acquire_many_owned(3).unwrap();
+    ///     assert_eq!(semaphore.available_permits(), 2);
+    /// }
+    /// ```
+    ///
+    /// [`Arc`]: std::sync::Arc
+    /// [`AcquireError`]: crate::sync::AcquireError
+    /// [`OwnedSemaphorePermit`]: crate::sync::OwnedSemaphorePermit
+    /// [`acquire_many_owned`]: Semaphore::acquire_many_owned
+    #[track_caller]
+    #[cfg(feature = "sync")]
+    pub fn blocking_acquire_many_owned(
+        self: Arc<Self>,
+        n: u32,
+    ) -> Result<OwnedSemaphorePermit, AcquireError> {
+        crate::future::block_on(self.acquire_many_owned(n))
     }
 
     /// Closes the semaphore.

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -744,7 +744,7 @@ impl Semaphore {
     /// use std::sync::Arc;
     /// use tokio::sync::Semaphore;
     ///
-    /// #[tokio::main]
+    /// #[tokio::main(flavor = "current_thread")]
     /// async fn main() {
     ///     let semaphore = Arc::new(Semaphore::new(2));
     ///

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -1092,7 +1092,7 @@ impl Semaphore {
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method.
     /// If the semaphore has been closed, this returns an [`AcquireError`].
-    /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
+    /// Otherwise, this returns an [`OwnedSemaphorePermit`] representing the
     /// acquired permits.
     ///
     /// This method is the blocking equivalent of [`acquire_many_owned`].

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -770,6 +770,8 @@ impl Semaphore {
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(not(target_family = "wasm"))]
+    /// # {
     /// use std::sync::Arc;
     /// use tokio::sync::Semaphore;
     ///
@@ -788,6 +790,7 @@ impl Semaphore {
     ///
     ///     blocking_task.await.unwrap();
     /// }
+    /// # }
     /// ```
     ///
     /// [`AcquireError`]: crate::sync::AcquireError

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -1053,7 +1053,7 @@ impl Semaphore {
     ///
     /// The semaphore must be wrapped in an [`Arc`] to call this method.
     /// If the semaphore has been closed, this returns an [`AcquireError`].
-    /// Otherwise, this returns a [`OwnedSemaphorePermit`] representing the
+    /// Otherwise, this returns an [`OwnedSemaphorePermit`] representing the
     /// acquired permit.
     ///
     /// This method is the blocking equivalent of [`acquire_owned`].

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -289,17 +289,46 @@ fn blocking_acquire_many_owned() {
 #[test]
 #[cfg(not(target_family = "wasm"))]
 fn blocking_acquire_closed() {
-    let sem = Semaphore::new(1);
+    let sem = Arc::new(Semaphore::new(1));
     sem.close();
     assert!(sem.blocking_acquire().is_err());
     assert!(sem.blocking_acquire_many(2).is_err());
+    assert!(sem.clone().blocking_acquire_owned().is_err());
+    assert!(sem.clone().blocking_acquire_many_owned(2).is_err());
 }
 
 #[tokio::test]
-#[cfg(feature = "full")]
+#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
 #[should_panic]
 async fn blocking_acquire_in_async_context() {
     let sem = Semaphore::new(1);
     // Calling a blocking method from an async context must panic.
     let _permit = sem.blocking_acquire();
+}
+
+#[tokio::test]
+#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
+#[should_panic]
+async fn blocking_acquire_many_in_async_context() {
+    let sem = Semaphore::new(1);
+    // Calling a blocking method from an async context must panic.
+    let _permit = sem.blocking_acquire_many(1);
+}
+
+#[tokio::test]
+#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
+#[should_panic]
+async fn blocking_acquire_owned_in_async_context() {
+    let sem = Arc::new(Semaphore::new(1));
+    // Calling a blocking method from an async context must panic.
+    let _permit = sem.blocking_acquire_owned();
+}
+
+#[tokio::test]
+#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
+#[should_panic]
+async fn blocking_acquire_many_owned_in_async_context() {
+    let sem = Arc::new(Semaphore::new(1));
+    // Calling a blocking method from an async context must panic.
+    let _permit = sem.blocking_acquire_many_owned(1);
 }

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -228,3 +228,78 @@ fn no_panic_at_maxpermits() {
     let s = Semaphore::new(Semaphore::MAX_PERMITS - 1);
     s.add_permits(1);
 }
+
+#[test]
+#[cfg(not(target_family = "wasm"))] // wasm doesn't support threads
+fn blocking_acquire() {
+    let sem = Semaphore::new(1);
+    let permit = sem.blocking_acquire().unwrap();
+    assert_eq!(sem.available_permits(), 0);
+    drop(permit);
+    assert_eq!(sem.available_permits(), 1);
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn blocking_acquire_waits_for_permit() {
+    let sem = Arc::new(Semaphore::new(0));
+
+    let sem2 = sem.clone();
+    let handle = std::thread::spawn(move || {
+        // Blocks until a permit becomes available.
+        let _permit = sem2.blocking_acquire().unwrap();
+    });
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    sem.add_permits(1);
+
+    handle.join().unwrap();
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn blocking_acquire_many() {
+    let sem = Semaphore::new(5);
+    let permit = sem.blocking_acquire_many(3).unwrap();
+    assert_eq!(sem.available_permits(), 2);
+    drop(permit);
+    assert_eq!(sem.available_permits(), 5);
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn blocking_acquire_owned() {
+    let sem = Arc::new(Semaphore::new(1));
+    let permit = sem.clone().blocking_acquire_owned().unwrap();
+    assert_eq!(sem.available_permits(), 0);
+    drop(permit);
+    assert_eq!(sem.available_permits(), 1);
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn blocking_acquire_many_owned() {
+    let sem = Arc::new(Semaphore::new(5));
+    let permit = sem.clone().blocking_acquire_many_owned(3).unwrap();
+    assert_eq!(sem.available_permits(), 2);
+    drop(permit);
+    assert_eq!(sem.available_permits(), 5);
+}
+
+#[test]
+#[cfg(not(target_family = "wasm"))]
+fn blocking_acquire_closed() {
+    let sem = Semaphore::new(1);
+    sem.close();
+    assert!(sem.blocking_acquire().is_err());
+    assert!(sem.blocking_acquire_many(2).is_err());
+}
+
+#[tokio::test]
+#[cfg(feature = "full")]
+#[should_panic]
+async fn blocking_acquire_in_async_context() {
+    let sem = Semaphore::new(1);
+    // Calling a blocking method from an async context must panic.
+    let _permit = sem.blocking_acquire();
+}

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -230,7 +230,6 @@ fn no_panic_at_maxpermits() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))] // wasm doesn't support threads
 fn blocking_acquire() {
     let sem = Semaphore::new(1);
     let permit = sem.blocking_acquire().unwrap();
@@ -240,7 +239,7 @@ fn blocking_acquire() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))]
+#[cfg(not(target_family = "wasm"))] // spawns a thread, which wasm doesn't support
 fn blocking_acquire_waits_for_permit() {
     let sem = Arc::new(Semaphore::new(0));
 
@@ -250,14 +249,12 @@ fn blocking_acquire_waits_for_permit() {
         let _permit = sem2.blocking_acquire().unwrap();
     });
 
-    std::thread::sleep(std::time::Duration::from_millis(100));
     sem.add_permits(1);
 
     handle.join().unwrap();
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))]
 fn blocking_acquire_many() {
     let sem = Semaphore::new(5);
     let permit = sem.blocking_acquire_many(3).unwrap();
@@ -267,7 +264,6 @@ fn blocking_acquire_many() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))]
 fn blocking_acquire_owned() {
     let sem = Arc::new(Semaphore::new(1));
     let permit = sem.clone().blocking_acquire_owned().unwrap();
@@ -277,7 +273,6 @@ fn blocking_acquire_owned() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))]
 fn blocking_acquire_many_owned() {
     let sem = Arc::new(Semaphore::new(5));
     let permit = sem.clone().blocking_acquire_many_owned(3).unwrap();
@@ -287,7 +282,6 @@ fn blocking_acquire_many_owned() {
 }
 
 #[test]
-#[cfg(not(target_family = "wasm"))]
 fn blocking_acquire_closed() {
     let sem = Arc::new(Semaphore::new(1));
     sem.close();

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -292,8 +292,8 @@ fn blocking_acquire_closed() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
-#[should_panic]
+#[cfg(feature = "full")]
+#[should_panic = "Cannot block the current thread from within a runtime"]
 async fn blocking_acquire_in_async_context() {
     let sem = Semaphore::new(1);
     // Calling a blocking method from an async context must panic.
@@ -301,8 +301,8 @@ async fn blocking_acquire_in_async_context() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
-#[should_panic]
+#[cfg(feature = "full")]
+#[should_panic = "Cannot block the current thread from within a runtime"]
 async fn blocking_acquire_many_in_async_context() {
     let sem = Semaphore::new(1);
     // Calling a blocking method from an async context must panic.
@@ -310,8 +310,8 @@ async fn blocking_acquire_many_in_async_context() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
-#[should_panic]
+#[cfg(feature = "full")]
+#[should_panic = "Cannot block the current thread from within a runtime"]
 async fn blocking_acquire_owned_in_async_context() {
     let sem = Arc::new(Semaphore::new(1));
     // Calling a blocking method from an async context must panic.
@@ -319,8 +319,8 @@ async fn blocking_acquire_owned_in_async_context() {
 }
 
 #[tokio::test]
-#[cfg(all(feature = "full", not(target_family = "wasm")))] // wasm doesn't support unwinding
-#[should_panic]
+#[cfg(feature = "full")]
+#[should_panic = "Cannot block the current thread from within a runtime"]
 async fn blocking_acquire_many_owned_in_async_context() {
     let sem = Arc::new(Semaphore::new(1));
     // Calling a blocking method from an async context must panic.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

`Mutex` has `blocking_lock()` and `RwLock` has `blocking_read()`, but `Semaphore` has no blocking version. There is no way to acquire a permit from non-async code.

## Solution

Added 4 blocking methods, same pattern as `Mutex::blocking_lock`:

- `blocking_acquire()`
- `blocking_acquire_many(n)`
- `blocking_acquire_owned()`
- `blocking_acquire_many_owned(n)`
