### PR TITLE
ci: preserve QEMU exit status in uring kernel tests

### DIFF
--- a/.github/workflows/uring-kernel-version-test.yml
+++ b/.github/workflows/uring-kernel-version-test.yml
@@ -99,11 +99,8 @@ jobs:
             -initrd initramfs.cpio.gz \
             -append "console=ttyS0 rootfstype=ramfs panic=1" \
             -nographic -no-reboot -m 1024 -action panic=exit-failure 2>&1 | tee qemu-output.log
-          statuses=("${PIPESTATUS[@]}")
+          qemu_status=${PIPESTATUS[0]} tee_status=${PIPESTATUS[1]}
           set -e
-
-          qemu_status=${statuses[0]}
-          tee_status=${statuses[1]}
 
           if [ "$qemu_status" -ne 0 ]; then
             echo "QEMU exited with status $qemu_status"

--- a/.github/workflows/uring-kernel-version-test.yml
+++ b/.github/workflows/uring-kernel-version-test.yml
@@ -89,16 +89,34 @@ jobs:
             | cpio --null -ov --format=newc | gzip -9 > ../initramfs.cpio.gz)
 
       - name: Run tests in QEMU
+        shell: bash
         run: |
+          set -euo pipefail
+
+          set +e
           qemu-system-x86_64 \
             -kernel linux-${{ env.KERNEL_VERSION }}/arch/x86/boot/bzImage \
             -initrd initramfs.cpio.gz \
             -append "console=ttyS0 rootfstype=ramfs panic=1" \
             -nographic -no-reboot -m 1024 -action panic=exit-failure 2>&1 | tee qemu-output.log
+          statuses=("${PIPESTATUS[@]}")
+          set -e
 
-          # qemu always exits with 0, so we check if the tests passed by using grep.
+          qemu_status=${statuses[0]}
+          tee_status=${statuses[1]}
+
+          if [ "$qemu_status" -ne 0 ]; then
+            echo "QEMU exited with status $qemu_status"
+            exit "$qemu_status"
+          fi
+
+          if [ "$tee_status" -ne 0 ]; then
+            echo "tee exited with status $tee_status"
+            exit "$tee_status"
+          fi
+
           if grep -q "test result: FAILED" qemu-output.log; then
-            echo "tests failed (QEMU exited abnormally)"
+            echo "tests reported failures"
             exit 1
           else
             echo "all tests passed"


### PR DESCRIPTION
## Motivation

The uring kernel workflow pipes QEMU through `tee`. Without checking the individual pipeline statuses, the step can inherit `tee`'s successful exit even when QEMU fails. That can hide a kernel panic, invalid guest setup, or emulator failure. The log check only recognizes Rust's `test result: FAILED` text, so it is not a substitute for QEMU's exit status.

## Solution

- Run the step under Bash with `pipefail`.
- Capture `PIPESTATUS` immediately after the QEMU pipeline exits.
- Fail on QEMU's status, or on `tee`'s status when QEMU succeeds.
- Keep the failure-text check as a secondary test-result diagnostic.

## Testing

- `git diff --check`
- Ruby YAML parse of the workflow
- Bash simulations covering successful and failing pipelines