### PR TITLE
sync: Holding an OwnedPermit for mpsc deadlocks other senders, even when there are more free slots than

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -1080,6 +1080,8 @@ impl<T> Sender<T> {
     ///
     /// Dropping [`Permit`] without sending a message releases the capacity back
     /// to the channel.
+    /// While held, a [`Permit`] occupies one slot of channel capacity; see the
+    /// [module-level documentation](crate::sync::mpsc#permits-and-reserve-ordering).
     ///
     /// [`Permit`]: Permit
     /// [`send`]: Permit::send
@@ -1134,6 +1136,9 @@ impl<T> Sender<T> {
     ///
     /// Dropping [`PermitIterator`] without consuming it entirely releases the remaining
     /// permits back to the channel.
+    /// While held, a [`PermitIterator`] occupies one slot of channel capacity
+    /// per remaining permit; see the
+    /// [module-level documentation](crate::sync::mpsc#permits-and-reserve-ordering).
     ///
     /// [`PermitIterator`]: PermitIterator
     /// [`Permit`]: Permit
@@ -1202,6 +1207,8 @@ impl<T> Sender<T> {
     ///
     /// Dropping the [`OwnedPermit`] without sending a message releases the
     /// capacity back to the channel.
+    /// While held, an [`OwnedPermit`] occupies one slot of channel capacity; see
+    /// the [module-level documentation](crate::sync::mpsc#permits-and-reserve-ordering).
     ///
     /// # Cancel safety
     ///

--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -84,6 +84,25 @@
 //! because they require access to the Tokio timer. See the documentation of
 //! each `*_timeout` method for more information on its use.
 //!
+//! # Permits and reserve ordering
+//!
+//! Bounded channel methods that wait for capacity, such as [`Sender::send`],
+//! [`Sender::reserve`], [`Sender::reserve_many`], and
+//! [`Sender::reserve_owned`], all draw from the same shared channel capacity.
+//! Calls are served in the order they were requested. A call that cannot be
+//! fully satisfied waits at the back of the queue, and released capacity is
+//! assigned to the waiter at the front of the queue first. See the method-level
+//! cancel safety documentation for details.
+//!
+//! An outstanding [`Permit`] or [`OwnedPermit`] holds one slot of capacity for
+//! its entire lifetime, until it is used to send a message or dropped. Holding
+//! a permit therefore reduces the capacity available to all other senders.
+//!
+//! For example, if a call to [`Sender::reserve_many`] is at the front of the
+//! queue, it blocks later [`Sender::send`] and reserve calls until enough
+//! capacity is available to satisfy its full request. Permits are not
+//! reassigned to arbitrary free slots.
+//!
 //! # Allocation behavior
 //!
 //! <div class="warning">The implementation details described in this section may change in future
@@ -102,6 +121,8 @@
 //!
 //! [`Sender`]: crate::sync::mpsc::Sender
 //! [`Receiver`]: crate::sync::mpsc::Receiver
+//! [`Permit`]: crate::sync::mpsc::Permit
+//! [`OwnedPermit`]: crate::sync::mpsc::OwnedPermit
 //! [bounded-send]: crate::sync::mpsc::Sender::send()
 //! [bounded-recv]: crate::sync::mpsc::Receiver::recv()
 //! [blocking-send]: crate::sync::mpsc::Sender::blocking_send()


### PR DESCRIPTION
Resolves #7709.

**Version** ``` │   │   │   │   ├── tokio v1.48.0 │   │   │   │   │   └── tokio-macros v2.6.0 (proc-macro) │   │   │   │   ├── tokio-util v0.7.16 │   │   │   │   │   └── tokio v1.48.0 (*) │   │   │   ├── tokio v1.48.0 (*) │   │   │   ├── tokio v1.48.0 (*) │   │   ├── tokio v1.48.0 (*) │   │   │   ├── tokio v1.48.0 (*) │   ├── tokio v1.48.0 (*) │   │   ├── tokio v1.48.0 (*) │   │   ├── tokio-native-tls v0.3.1 │   │   │   └── tokio v1.48.0 (*) │   ├── tokio v1.48.0 (*) │   ├── tokio-native-tls

## Motivation

## Solution