### PR TITLE
codec: clamp runtime frame length to field width

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -630,13 +630,6 @@ impl Encoder<Bytes> for LengthDelimitedCodec {
             )
         })?;
 
-        if n as u64 > self.builder.max_length_field_value() {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                LengthDelimitedCodecError { _priv: () },
-            ));
-        }
-
         // Reserve capacity in the destination buffer to fit the frame and
         // length field (plus adjustment).
         dst.reserve(self.builder.length_field_len + n);

--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -493,8 +493,12 @@ impl LengthDelimitedCodec {
     /// words, if a frame is currently in process of being decoded with a frame
     /// size greater than `val` but less than the max frame length in effect
     /// before calling this function, then the frame will be allowed.
+    ///
+    /// If `val` is larger than what the length field can represent, it is
+    /// clipped to the maximum representable value.
     pub fn set_max_frame_length(&mut self, val: usize) {
         self.builder.max_frame_length(val);
+        self.builder.adjust_max_frame_len();
     }
 
     fn decode_head(&mut self, src: &mut BytesMut) -> io::Result<Option<usize>> {
@@ -625,6 +629,13 @@ impl Encoder<Bytes> for LengthDelimitedCodec {
                 "provided length would overflow after adjustment",
             )
         })?;
+
+        if n as u64 > self.builder.max_length_field_value() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                LengthDelimitedCodecError { _priv: () },
+            ));
+        }
 
         // Reserve capacity in the destination buffer to fit the frame and
         // length field (plus adjustment).
@@ -1049,16 +1060,25 @@ impl Builder {
     }
 
     fn adjust_max_frame_len(&mut self) {
-        // Calculate the maximum number that can be represented using `length_field_len` bytes.
-        let max_number = match 1u64.checked_shl((8 * self.length_field_len) as u32) {
+        let max_allowed_len = self.max_allowed_frame_len();
+
+        if self.max_frame_len > max_allowed_len {
+            self.max_frame_len = max_allowed_len;
+        }
+    }
+
+    fn max_allowed_frame_len(&self) -> usize {
+        let max_allowed_len = self
+            .max_length_field_value()
+            .saturating_add_signed(self.length_adjustment as i64);
+
+        usize::try_from(max_allowed_len).unwrap_or(usize::MAX)
+    }
+
+    fn max_length_field_value(&self) -> u64 {
+        match 1u64.checked_shl((8 * self.length_field_len) as u32) {
             Some(shl) => shl - 1,
             None => u64::MAX,
-        };
-
-        let max_allowed_len = max_number.saturating_add_signed(self.length_adjustment as i64);
-
-        if self.max_frame_len as u64 > max_allowed_len {
-            self.max_frame_len = usize::try_from(max_allowed_len).unwrap_or(usize::MAX);
         }
     }
 }

--- a/tokio-util/tests/length_delimited.rs
+++ b/tokio-util/tests/length_delimited.rs
@@ -700,6 +700,29 @@ fn frame_does_not_fit() {
 }
 
 #[test]
+fn runtime_max_frame_len_respects_length_field() {
+    let mut codec = LengthDelimitedCodec::builder()
+        .length_field_length(1)
+        .new_codec();
+
+    codec.set_max_frame_length(1_000);
+
+    let mut dst = BytesMut::from(&b"prefix"[..]);
+    let original = dst.clone();
+    let result = codec.encode(Bytes::from(vec![0; 256]), &mut dst);
+
+    assert!(
+        result.is_err(),
+        "encoded {} bytes despite the one-byte length field",
+        dst.len() - original.len()
+    );
+    let err = result.unwrap_err();
+    assert_eq!(codec.max_frame_length(), 255);
+    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    assert_eq!(dst, original);
+}
+
+#[test]
 fn neg_adjusted_frame_does_not_fit() {
     let codec = LengthDelimitedCodec::builder()
         .length_field_length(1)

--- a/tokio-util/tests/length_delimited.rs
+++ b/tokio-util/tests/length_delimited.rs
@@ -701,25 +701,29 @@ fn frame_does_not_fit() {
 
 #[test]
 fn runtime_max_frame_len_respects_length_field() {
-    let mut codec = LengthDelimitedCodec::builder()
-        .length_field_length(1)
-        .new_codec();
+    for (adjustment, max_frame_len) in [(-1, 254), (0, 255), (1, 256)] {
+        let mut codec = LengthDelimitedCodec::builder()
+            .length_field_length(1)
+            .length_adjustment(adjustment)
+            .new_codec();
 
-    codec.set_max_frame_length(1_000);
+        codec.set_max_frame_length(1_000);
+        assert_eq!(codec.max_frame_length(), max_frame_len);
 
-    let mut dst = BytesMut::from(&b"prefix"[..]);
-    let original = dst.clone();
-    let result = codec.encode(Bytes::from(vec![0; 256]), &mut dst);
+        let mut dst = BytesMut::new();
+        codec
+            .encode(Bytes::from(vec![0; max_frame_len]), &mut dst)
+            .unwrap();
+        assert_eq!(dst[0], u8::MAX);
 
-    assert!(
-        result.is_err(),
-        "encoded {} bytes despite the one-byte length field",
-        dst.len() - original.len()
-    );
-    let err = result.unwrap_err();
-    assert_eq!(codec.max_frame_length(), 255);
-    assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
-    assert_eq!(dst, original);
+        let mut dst = BytesMut::from(&b"prefix"[..]);
+        let original = dst.clone();
+        let result = codec.encode(Bytes::from(vec![0; max_frame_len + 1]), &mut dst);
+
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::InvalidInput);
+        assert_eq!(dst, original);
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Motivation

`LengthDelimitedCodec` clamps its maximum frame length during construction, but `set_max_frame_length` previously bypassed that limit. With a one-byte length field, setting the runtime limit to 1,000 allowed a 256-byte payload to pass the size check even though its length could not be represented in the wire header. The truncated header could desynchronize the peer's frame parsing.

## Solution

- Reuse the length-field representability calculation when updating the runtime maximum.
- Keep the existing encoder size check as the single validation point; the runtime clamp now guarantees that an accepted adjusted length fits the field.
- Add a regression test for the one-byte field case and buffer preservation.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tokio-util --test length_delimited --features full`
- `cargo test -p tokio-util --features full`