### PR TITLE
rt: flush CQE in case of  CQE overflow

### DIFF
--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -234,7 +234,7 @@ impl Driver {
             let ctx = &mut *guard;
             ctx.dispatch_completions();
 
-            // There might be some cases when the CQ overflows, so we need to flush
+            // There might be some cases where the CQ overflows, so we need to flush
             // the remaining buffered CQEs.
             while ctx
                 .uring

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -233,6 +233,18 @@ impl Driver {
             let mut guard = handle.get_uring().lock();
             let ctx = &mut *guard;
             ctx.dispatch_completions();
+
+            // There might be some cases when the CQ overflows, so we need to flush
+            // the remaining buffered CQEs.
+            while ctx
+                .uring
+                .as_mut()
+                .is_some_and(|uring| uring.submission().cq_overflow())
+            {
+                ctx.submit()
+                    .expect("failed to flush io_uring completion queue overflow");
+                ctx.dispatch_completions();
+            }
         }
 
         handle.metrics.incr_ready_count_by(ready_count);


### PR DESCRIPTION
It can happen that the stat_many_files test in tokio::fs_uring_statx hangs forever in some cases. The problem was observed for example in this [run](https://github.com/tokio-rs/tokio/actions/runs/29169914217/job/86589377340?pr=8275#logs):

```
SLOW [> 60.000s] (─────────) tokio::fs_uring_statx stat_many_files
        SLOW [>120.000s] (─────────) tokio::fs_uring_statx stat_many_files
        SLOW [>180.000s] (─────────) tokio::fs_uring_statx stat_many_files
        SLOW [>240.000s] (─────────) tokio::fs_uring_statx stat_many_files
        SLOW [>300.000s] (─────────) tokio::fs_uring_statx stat_many_files
        SLOW [>360.000s] (─────────) tokio::fs_uring_statx stat_many_files
        SLOW [>420.000s] (─────────) tokio::fs_uring_statx stat_many_files
```

I did some tests and analyzed the flow, and it seems that the CQ overflows so we need to flush it to be able to dispatch the completions. I debug the issue locally and cq_overflow returns true in some cases:

```
[tokio/src/runtime/io/driver.rs:241:38] uring.submission().cq_overflow() = true
```