### PR TITLE
sync: document permit sends after mpsc receiver is dropped

### DIFF
--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -762,7 +762,12 @@ impl<T> Sender<T> {
     /// value of `Err` means that the data will never be received, but a return
     /// value of `Ok` does not mean that the data will be received. It is
     /// possible for the corresponding receiver to hang up immediately after
-    /// this function returns `Ok`.
+    /// this function returns `Ok`. Additionally, if the receiver is dropped
+    /// concurrently with a call to `send`, the call may return `Ok` even
+    /// though the value is never received, in which case the value's drop may
+    /// be deferred until every handle to the channel has been dropped. See the
+    /// [Disconnection][disconnection] section of the module documentation for
+    /// details.
     ///
     /// # Errors
     ///
@@ -772,6 +777,7 @@ impl<T> Sender<T> {
     ///
     /// [`close`]: Receiver::close
     /// [`Receiver`]: Receiver
+    /// [disconnection]: crate::sync::mpsc#disconnection
     ///
     /// # Cancel safety
     ///
@@ -870,6 +876,13 @@ impl<T> Sender<T> {
     /// with [`send`], this function has two failure cases instead of one (one for
     /// disconnection, one for a full buffer).
     ///
+    /// However, if the receiver is dropped concurrently with a call to
+    /// `try_send`, the call may return `Ok` even though the value is never
+    /// received, in which case the value's drop may be deferred until every
+    /// handle to the channel has been dropped. See the
+    /// [Disconnection][disconnection] section of the module documentation for
+    /// details.
+    ///
     /// # Errors
     ///
     /// If the channel capacity has been reached, i.e., the channel has `n`
@@ -883,6 +896,7 @@ impl<T> Sender<T> {
     /// [`send`]: Sender::send
     /// [`channel`]: channel
     /// [`close`]: Receiver::close
+    /// [disconnection]: crate::sync::mpsc#disconnection
     ///
     /// # Examples
     ///
@@ -1010,6 +1024,9 @@ impl<T> Sender<T> {
     /// synchronous code to asynchronous code, and will work even if the
     /// receiver is not using [`blocking_recv`] to receive the message.
     ///
+    /// Shares the same success and error conditions as [`send`].
+    ///
+    /// [`send`]: Sender::send
     /// [`blocking_recv`]: fn@crate::sync::mpsc::Receiver::blocking_recv
     ///
     /// # Panics
@@ -1668,7 +1685,7 @@ impl<T> Permit<'_, T> {
     /// is still sent into the channel, but it will never be received. It is
     /// dropped only when every handle to the channel (senders, weak senders,
     /// and outstanding permits) has been dropped. Do not rely on the value
-    /// being dropped promptly, e.g. when its destructor has side effects.
+    /// being dropped promptly, especially if its destructor has side effects.
     ///
     /// [`Receiver::close`]: Receiver::close
     ///
@@ -1796,7 +1813,7 @@ impl<T> OwnedPermit<T> {
     /// is still sent into the channel, but it will never be received. It is
     /// dropped only when every handle to the channel (senders, weak senders,
     /// and outstanding permits) has been dropped. Do not rely on the value
-    /// being dropped promptly, e.g. when its destructor has side effects.
+    /// being dropped promptly, especially if its destructor has side effects.
     ///
     /// Unlike [`Permit::send`], this method returns the [`Sender`] from which
     /// the `OwnedPermit` was reserved.

--- a/tokio/src/sync/mpsc/bounded.rs
+++ b/tokio/src/sync/mpsc/bounded.rs
@@ -1664,6 +1664,12 @@ impl<T> Permit<'_, T> {
     /// even if the receiver half has been closed. See [`Receiver::close`] for
     /// more details on performing a clean shutdown.
     ///
+    /// If the receiver half has been *dropped* (rather than closed), the value
+    /// is still sent into the channel, but it will never be received. It is
+    /// dropped only when every handle to the channel (senders, weak senders,
+    /// and outstanding permits) has been dropped. Do not rely on the value
+    /// being dropped promptly, e.g. when its destructor has side effects.
+    ///
     /// [`Receiver::close`]: Receiver::close
     ///
     /// # Examples
@@ -1785,6 +1791,12 @@ impl<T> OwnedPermit<T> {
     /// to the receiver and the permit is consumed. The operation will succeed
     /// even if the receiver half has been closed. See [`Receiver::close`] for
     /// more details on performing a clean shutdown.
+    ///
+    /// If the receiver half has been *dropped* (rather than closed), the value
+    /// is still sent into the channel, but it will never be received. It is
+    /// dropped only when every handle to the channel (senders, weak senders,
+    /// and outstanding permits) has been dropped. Do not rely on the value
+    /// being dropped promptly, e.g. when its destructor has side effects.
     ///
     /// Unlike [`Permit::send`], this method returns the [`Sender`] from which
     /// the `OwnedPermit` was reserved.

--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -35,8 +35,11 @@
 //!
 //! If the [`Receiver`] handle is dropped, then messages can no longer
 //! be read out of the channel. In this case, all further attempts to send will
-//! result in an error. Additionally, all unread messages will be drained from the
-//! channel and dropped.
+//! result in an error, and all unread messages are drained from the channel and
+//! dropped. However, a value sent through a previously reserved [`Permit`] or
+//! [`OwnedPermit`] does not result in an error, and is not dropped until every
+//! handle to the channel (senders, weak senders, and outstanding permits) has
+//! been dropped.
 //!
 //! # Clean Shutdown
 //!
@@ -102,6 +105,8 @@
 //!
 //! [`Sender`]: crate::sync::mpsc::Sender
 //! [`Receiver`]: crate::sync::mpsc::Receiver
+//! [`Permit`]: crate::sync::mpsc::Permit
+//! [`OwnedPermit`]: crate::sync::mpsc::OwnedPermit
 //! [bounded-send]: crate::sync::mpsc::Sender::send()
 //! [bounded-recv]: crate::sync::mpsc::Receiver::recv()
 //! [blocking-send]: crate::sync::mpsc::Sender::blocking_send()

--- a/tokio/src/sync/mpsc/mod.rs
+++ b/tokio/src/sync/mpsc/mod.rs
@@ -35,11 +35,22 @@
 //!
 //! If the [`Receiver`] handle is dropped, then messages can no longer
 //! be read out of the channel. In this case, all further attempts to send will
-//! result in an error, and all unread messages are drained from the channel and
-//! dropped. However, a value sent through a previously reserved [`Permit`] or
-//! [`OwnedPermit`] does not result in an error, and is not dropped until every
-//! handle to the channel (senders, weak senders, and outstanding permits) has
-//! been dropped.
+//! result in an error, and all unread messages will be drained from the channel
+//! and dropped. However, a send that has already reserved capacity does not
+//! fail: a value sent through a previously reserved [`Permit`] or
+//! [`OwnedPermit`] is still sent into the channel, but it is never received,
+//! and it is only dropped once every handle to the channel (senders, weak
+//! senders, and outstanding permits) has been dropped.
+//!
+//! A send that races with the receiver being dropped can behave the same way:
+//! bounded [`send`][bounded-send] (including its timeout and blocking
+//! variants) and [`try_send`][bounded-try-send], as well as unbounded
+//! [`send`][unbounded-send], may return `Ok` even though the value is never
+//! received, and its drop may likewise be deferred. Do not rely on the value
+//! being dropped promptly; for example, if the value carries a [oneshot]
+//! `Sender` for a reply, the reply receiver keeps waiting until the value is
+//! finally dropped. To shut down without stranding values, the receiver can
+//! instead use [`Receiver::close`] as described in the next section.
 //!
 //! # Clean Shutdown
 //!
@@ -105,9 +116,12 @@
 //!
 //! [`Sender`]: crate::sync::mpsc::Sender
 //! [`Receiver`]: crate::sync::mpsc::Receiver
+//! [`Receiver::close`]: crate::sync::mpsc::Receiver::close()
 //! [`Permit`]: crate::sync::mpsc::Permit
 //! [`OwnedPermit`]: crate::sync::mpsc::OwnedPermit
 //! [bounded-send]: crate::sync::mpsc::Sender::send()
+//! [bounded-try-send]: crate::sync::mpsc::Sender::try_send()
+//! [unbounded-send]: crate::sync::mpsc::UnboundedSender::send()
 //! [bounded-recv]: crate::sync::mpsc::Receiver::recv()
 //! [blocking-send]: crate::sync::mpsc::Sender::blocking_send()
 //! [blocking-recv]: crate::sync::mpsc::Receiver::blocking_recv()

--- a/tokio/src/sync/mpsc/unbounded.rs
+++ b/tokio/src/sync/mpsc/unbounded.rs
@@ -542,8 +542,15 @@ impl<T> UnboundedSender<T> {
     /// being called or the [`UnboundedReceiver`] having been dropped, this
     /// function returns an error. The error includes the value passed to `send`.
     ///
+    /// However, if the receiver is dropped concurrently with a call to `send`,
+    /// the call may return `Ok` even though the value is never received, in
+    /// which case the value's drop may be deferred until every handle to the
+    /// channel has been dropped. See the [Disconnection][disconnection]
+    /// section of the module documentation for details.
+    ///
     /// [`close`]: UnboundedReceiver::close
     /// [`UnboundedReceiver`]: UnboundedReceiver
+    /// [disconnection]: crate::sync::mpsc#disconnection
     pub fn send(&self, message: T) -> Result<(), SendError<T>> {
         if !self.inc_num_messages() {
             return Err(SendError(message));

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -536,6 +536,7 @@ async fn permit_send_after_rx_drop_defers_value_drop() {
 
     let dropped = Arc::new(AtomicBool::new(false));
     let (tx, rx) = mpsc::channel(1);
+    let weak = tx.downgrade();
 
     let permit = assert_ok!(tx.reserve().await);
     drop(rx);
@@ -545,8 +546,12 @@ async fn permit_send_after_rx_drop_defers_value_drop() {
     permit.send(SetOnDrop(dropped.clone()));
     assert!(!dropped.load(Ordering::SeqCst));
 
-    // The value is dropped together with the last channel handle.
+    // A weak sender also keeps the value alive.
     drop(tx);
+    assert!(!dropped.load(Ordering::SeqCst));
+
+    // The value is dropped together with the last channel handle.
+    drop(weak);
     assert!(dropped.load(Ordering::SeqCst));
 }
 

--- a/tokio/tests/sync_mpsc.rs
+++ b/tokio/tests/sync_mpsc.rs
@@ -519,6 +519,51 @@ async fn recv_close_gets_none_reserved() {
     assert!(rx.recv().await.is_none());
 }
 
+// Pins the behavior documented on `Permit::send`: a value sent through a
+// previously reserved permit after the receiver is *dropped* is neither
+// received nor dropped immediately; it is dropped only when every handle to
+// the channel has been dropped.
+#[maybe_tokio_test]
+async fn permit_send_after_rx_drop_defers_value_drop() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    struct SetOnDrop(Arc<AtomicBool>);
+    impl Drop for SetOnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::SeqCst);
+        }
+    }
+
+    let dropped = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = mpsc::channel(1);
+
+    let permit = assert_ok!(tx.reserve().await);
+    drop(rx);
+
+    // The send succeeds even though the receiver is gone, and the value is
+    // not dropped while the sender is still alive.
+    permit.send(SetOnDrop(dropped.clone()));
+    assert!(!dropped.load(Ordering::SeqCst));
+
+    // The value is dropped together with the last channel handle.
+    drop(tx);
+    assert!(dropped.load(Ordering::SeqCst));
+}
+
+// Contrast case: after `Receiver::close`, a value sent through a previously
+// reserved permit is still received (clean-shutdown contract).
+#[maybe_tokio_test]
+async fn permit_send_after_rx_close_is_received() {
+    let (tx, mut rx) = mpsc::channel(1);
+
+    let permit = assert_ok!(tx.reserve().await);
+    rx.close();
+
+    permit.send(123);
+    assert_eq!(rx.recv().await, Some(123));
+    assert!(rx.recv().await.is_none());
+}
+
 #[maybe_tokio_test]
 async fn tx_close_gets_none() {
     let (_, mut rx) = mpsc::channel::<i32>(10);


### PR DESCRIPTION
## Motivation

The mpsc module docs state that once the `Receiver` is dropped, "all further attempts to send will result in an error" and "all unread messages will be drained from the channel and dropped." Neither statement holds for a value sent through a previously reserved `Permit` or `OwnedPermit`: the send succeeds silently, the value is never drained, and it is only dropped when the last handle to the channel goes away. This tripped up users relying on prompt destruction of the sent value, e.g. a value whose `Drop` has side effects such as a contained `oneshot::Sender` (#7714). A behavioral fix was discussed in the issue and considered too invasive, with the discussion converging on documenting the actual semantics instead.

## Solution

- Correct the module-level "Disconnection" paragraph to describe what actually happens to permit sends after the receiver is dropped.
- Document the receiver-*dropped* case on `Permit::send` and `OwnedPermit::send`, next to the existing note about `Receiver::close` (whose clean-shutdown contract is unchanged), including a warning not to rely on prompt destruction of the value.
- Add two tests to `tests/sync_mpsc.rs` pinning the semantics: a permit send after the receiver is dropped defers the value's drop until the channel is fully dropped, and a permit send after `Receiver::close` is still received.

Locally: `cargo test -p tokio --features full --test sync_mpsc` — 103 passed.

Refs: #7714
