### PR TITLE
task: avoid replacing the JoinQueue waker in try_join_next

### DIFF
--- a/tokio-util/src/task/join_queue.rs
+++ b/tokio-util/src/task/join_queue.rs
@@ -188,6 +188,10 @@ impl<T> JoinQueue<T> {
     /// Note that on success the handle will panic on subsequent polls
     /// since it becomes consumed.
     fn try_poll_handle(jh: &mut AbortOnDropHandle<T>) -> Option<Result<T, JoinError>> {
+        if !jh.is_finished() {
+            return None;
+        }
+
         let waker = futures_util::task::noop_waker();
         let mut cx = Context::from_waker(&waker);
 

--- a/tokio-util/tests/task_join_queue.rs
+++ b/tokio-util/tests/task_join_queue.rs
@@ -1,5 +1,8 @@
 #![warn(rust_2018_idioms)]
 
+use std::task::Context;
+
+use futures_test::task::new_count_waker;
 use tokio::sync::oneshot;
 use tokio::task::yield_now;
 use tokio::time::Duration;
@@ -274,6 +277,60 @@ async fn test_join_queue_try_join_next() {
     assert!(queue.try_join_next().is_some());
     assert!(queue.is_empty());
     check_try_join_next_is_noop(&mut queue);
+}
+
+#[tokio::test]
+async fn test_join_queue_try_join_next_does_not_replace_waker() {
+    let (send, recv) = oneshot::channel();
+    let mut queue = JoinQueue::new();
+    queue.spawn(async move {
+        recv.await.unwrap();
+        42
+    });
+
+    let (waker, wake_count) = new_count_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    assert_pending!(queue.poll_join_next(&mut cx));
+    assert_eq!(wake_count, 0);
+    assert!(queue.try_join_next().is_none());
+
+    send.send(()).unwrap();
+    yield_now().await;
+
+    assert_eq!(wake_count, 1);
+    assert_eq!(
+        assert_ready!(queue.poll_join_next(&mut cx))
+            .unwrap()
+            .unwrap(),
+        42
+    );
+}
+
+#[tokio::test]
+async fn test_join_queue_try_join_next_with_id_does_not_replace_waker() {
+    let (send, recv) = oneshot::channel();
+    let mut queue = JoinQueue::new();
+    queue.spawn(async move {
+        recv.await.unwrap();
+        42
+    });
+
+    let (waker, wake_count) = new_count_waker();
+    let mut cx = Context::from_waker(&waker);
+
+    assert_pending!(queue.poll_join_next_with_id(&mut cx));
+    assert_eq!(wake_count, 0);
+    assert!(queue.try_join_next_with_id().is_none());
+
+    send.send(()).unwrap();
+    yield_now().await;
+
+    assert_eq!(wake_count, 1);
+    let (_, output) = assert_ready!(queue.poll_join_next_with_id(&mut cx))
+        .unwrap()
+        .unwrap();
+    assert_eq!(output, 42);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

`poll_join_next` stores the waker that should be notified when the front task completes. The non-blocking `try_join_next` methods previously polled an unfinished `JoinHandle` with `noop_waker`. That replaced the waker registered by `poll_join_next`, so task completion could wake only the no-op waker and leave the real consumer asleep.

The same helper is used by both `try_join_next` and `try_join_next_with_id`.

## Solution

Check `is_finished()` before polling with a no-op context. If the task is still running, return `None` without touching its registered waker. Poll with the no-op context only after the task has finished.

## Regression test

Use a counting waker to:

1. Poll each `poll_join_next` variant to `Pending`.
2. Call the corresponding `try_join_next` variant while the task is still running.
3. Complete the task and verify that the original counting waker is notified.
4. Poll the queue and verify the result is available.

## Testing

- `cargo test -p tokio-util --test task_join_queue --features rt`
- `cargo test -p tokio-util --features full`
- `cargo fmt --all -- --check`