### PR TITLE
chore: prepare Tokio v1.51.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.3", features = ["full"] }
+tokio = { version = "1.51.4", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 1.51.4 (July 16th, 2026)
+
+### Fixed
+
+- runtime: don't skip the driver when `before_park` schedules work ([#8222])
+
+[#8222]: https://github.com/tokio-rs/tokio/pull/8222
+
 # 1.51.3 (May 8th, 2026)
 
 ### Fixed

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.51.3"
+version = "1.51.4"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.51.3", features = ["full"] }
+tokio = { version = "1.51.4", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
# 1.51.4 (July 16th, 2026)

### Fixed

- runtime: don't skip the driver when `before_park` schedules work ([#8222])

[#8222]: https://github.com/tokio-rs/tokio/pull/8222