### PR TITLE
sync: add wake caveat to Semaphore memory ordering docs

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -45,6 +45,11 @@ use std::sync::Arc;
 /// [`TryAcquireError::Closed`]), along with the [`available_permits`] and
 /// [`is_closed`] methods, behave like an `Acquire` load.
 ///
+/// Note: Calling `wake` on wakers happens after changing the state of the
+/// semaphore in a non-atomic manner. This means that a task that is woken
+/// may observe the state change, but another concurrent task may not yet
+/// see it.
+///
 /// [`acquire`]: Semaphore::acquire
 /// [`acquire_many`]: Semaphore::acquire_many
 /// [`try_acquire`]: Semaphore::try_acquire

--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -47,8 +47,8 @@ use std::sync::Arc;
 ///
 /// Note: Calling `wake` on wakers happens after changing the state of the
 /// semaphore in a non-atomic manner. This means that a task that is woken
-/// may observe the state change, but another concurrent task may not yet
-/// see it.
+/// may observe the state change, even if the waker has not yet been
+/// woken.
 ///
 /// [`acquire`]: Semaphore::acquire
 /// [`acquire_many`]: Semaphore::acquire_many


### PR DESCRIPTION
## Motivation

PR #8119 added memory ordering documentation to Semaphore but was missing a caveat noted by @Darksonn in #7435: calling wake on wakers happens after changing the semaphore state in a non-atomic manner.

## Solution

Added the missing caveat to the # Memory ordering section explaining that waker wakeups are not atomic with respect to the semaphore state change.