### PR TITLE
runtime: fix misleading atomic ordering comments in park.rs

### DIFF
--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -95,10 +95,9 @@ impl Inner {
             Err(NOTIFIED) => {
                 // We must read here, even though we know it will be `NOTIFIED`.
                 // This is because `unpark` may have been called again since we read
-                // `NOTIFIED` in the `compare_exchange` above. We must perform an
-                // acquire operation that synchronizes with that `unpark` to observe
-                // any writes it made before the call to unpark. To do that we must
-                // read from the write it made to `state`.
+                // `NOTIFIED` in the `compare_exchange` above. We use `SeqCst` to
+                // synchronize with that `unpark` to observe any writes it made before
+                // the call to unpark.
                 let old = self.state.swap(EMPTY, SeqCst);
                 debug_assert_eq!(old, NOTIFIED, "park state changed unexpectedly");
 
@@ -176,10 +175,8 @@ impl Inner {
 
     fn unpark(&self) {
         // To ensure the unparked thread will observe any writes we made before
-        // this call, we must perform a release operation that `park` can
-        // synchronize with. To do that we must write `NOTIFIED` even if `state`
-        // is already `NOTIFIED`. That is why this must be a swap rather than a
-        // compare-and-swap that returns if it reads `NOTIFIED` on failure.
+        // this call, we use `SeqCst` which `park` can synchronize with. To do
+        // that we must write `NOTIFIED` even if `state` is already `NOTIFIED`.
         match self.state.swap(NOTIFIED, SeqCst) {
             EMPTY => return,    // no one was waiting
             NOTIFIED => return, // already unparked

--- a/tokio/src/runtime/park.rs
+++ b/tokio/src/runtime/park.rs
@@ -95,9 +95,11 @@ impl Inner {
             Err(NOTIFIED) => {
                 // We must read here, even though we know it will be `NOTIFIED`.
                 // This is because `unpark` may have been called again since we read
-                // `NOTIFIED` in the `compare_exchange` above. We use `SeqCst` to
-                // synchronize with that `unpark` to observe any writes it made before
-                // the call to unpark.
+                // `NOTIFIED` in the `compare_exchange` above. We must perform an
+                // acquire operation that synchronizes with that `unpark` to observe
+                // any writes it made before the call to unpark. To do that we must
+                // read from the write it made to `state`. The `swap` uses `SeqCst`,
+                // which has acquire semantics.
                 let old = self.state.swap(EMPTY, SeqCst);
                 debug_assert_eq!(old, NOTIFIED, "park state changed unexpectedly");
 
@@ -175,8 +177,11 @@ impl Inner {
 
     fn unpark(&self) {
         // To ensure the unparked thread will observe any writes we made before
-        // this call, we use `SeqCst` which `park` can synchronize with. To do
-        // that we must write `NOTIFIED` even if `state` is already `NOTIFIED`.
+        // this call, we must perform a release operation that `park` can
+        // synchronize with. The `swap` uses `SeqCst`, which has release
+        // semantics. To do that we must write `NOTIFIED` even if `state`
+        // is already `NOTIFIED`. That is why this must be a swap rather than
+        // a compare-and-swap that returns if it reads `NOTIFIED` on failure.
         match self.state.swap(NOTIFIED, SeqCst) {
             EMPTY => return,    // no one was waiting
             NOTIFIED => return, // already unparked


### PR DESCRIPTION
## Motivation

Comments in park.rs mention 'acquire operation' and 'release operation' but the code uses SeqCst ordering, which is confusing. See #4298.

## Solution

Updated comments to accurately reflect that SeqCst ordering is used for synchronization.
