### PR TITLE
rt: add error documentation for `runtime::Builder`

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1069,6 +1069,11 @@ impl Builder {
     /// });
     /// # }
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
     pub fn build(&mut self) -> io::Result<Runtime> {
         match &self.kind {
             Kind::CurrentThread => self.build_current_thread_runtime(),
@@ -1100,6 +1105,11 @@ impl Builder {
     ///     println!("Hello from the Tokio runtime");
     /// });
     /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
     #[allow(unused_variables, unreachable_patterns)]
     pub fn build_local(&mut self, options: LocalOptions) -> io::Result<LocalRuntime> {
         match &self.kind {

--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -86,6 +86,11 @@ impl LocalRuntime {
     /// // Use the runtime...
     /// ```
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
+    ///
     /// [mod]: crate::runtime
     /// [runtime builder]: crate::runtime::Builder
     pub fn new() -> std::io::Result<LocalRuntime> {

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -165,6 +165,11 @@ impl Runtime {
     /// // Use the runtime...
     /// ```
     ///
+    /// # Errors
+    ///
+    /// Returns an error if the I/O driver or other OS resources required by the
+    /// runtime cannot be initialized.
+    ///
     /// [mod]: index.html
     /// [main]: ../attr.main.html
     /// [threaded scheduler]: index.html#threaded-scheduler


### PR DESCRIPTION
Added documentation explaining when the `Builder::build` methods could return an error.