### PR TITLE
rt: remove unstable cfgs leftovers after local runtime stabilization

### DIFF
--- a/tests-integration/tests/macros_main.rs
+++ b/tests-integration/tests/macros_main.rs
@@ -16,7 +16,6 @@ async fn spawning() -> usize {
     join.await.unwrap()
 }
 
-#[cfg(tokio_unstable)]
 #[tokio::main(flavor = "local")]
 async fn local_main() -> usize {
     let join = tokio::task::spawn_local(async { 1 });
@@ -33,6 +32,5 @@ fn shell() {
     assert_eq!(1, basic_main());
     assert_eq!(bool::default(), generic_fun::<bool>());
 
-    #[cfg(tokio_unstable)]
     assert_eq!(1, local_main());
 }

--- a/tokio-util/tests/task_join_map.rs
+++ b/tokio-util/tests/task_join_map.rs
@@ -581,7 +581,6 @@ mod spawn_local {
         map.spawn_local((), async {});
     }
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 
@@ -693,7 +692,6 @@ mod spawn_local {
 mod spawn_local_on {
     use super::*;
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 

--- a/tokio-util/tests/task_tracker.rs
+++ b/tokio-util/tests/task_tracker.rs
@@ -1,7 +1,6 @@
 #![warn(rust_2018_idioms)]
 
 use futures::future::pending;
-#[cfg(tokio_unstable)]
 use std::rc::Rc;
 use tokio::sync::mpsc;
 use tokio::task::LocalSet;
@@ -182,7 +181,6 @@ fn notify_many() {
     }
 }
 
-#[cfg(tokio_unstable)]
 mod spawn {
     use super::*;
 
@@ -209,7 +207,6 @@ mod spawn {
     }
 }
 
-#[cfg(tokio_unstable)]
 mod spawn_local {
     use super::*;
 
@@ -278,7 +275,6 @@ mod spawn_local {
 mod spawn_local_on {
     use super::*;
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1100,8 +1100,7 @@ impl Builder {
     ///     println!("Hello from the Tokio runtime");
     /// });
     /// ```
-    #[allow(unused_variables, unreachable_patterns)]
-    pub fn build_local(&mut self, options: LocalOptions) -> io::Result<LocalRuntime> {
+    pub fn build_local(&mut self, _options: LocalOptions) -> io::Result<LocalRuntime> {
         match &self.kind {
             Kind::CurrentThread => self.build_current_thread_local_runtime(),
             #[cfg(feature = "rt-multi-thread")]

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -390,7 +390,6 @@ cfg_rt! {
     /// [`LocalSet`]: struct@crate::task::LocalSet
     /// [`LocalRuntime`]: struct@crate::runtime::LocalRuntime
     /// [`tokio::spawn`]: fn@crate::task::spawn
-    /// [unstable]: ../../tokio/index.html#unstable-features
     #[track_caller]
     pub fn spawn_local<F>(future: F) -> JoinHandle<F::Output>
     where

--- a/tokio/tests/async_send_sync.rs
+++ b/tokio/tests/async_send_sync.rs
@@ -769,8 +769,7 @@ mod unix_asyncfd {
     async_assert_fn!(AsyncFd<ImplsFd<NN>>::writable_mut(_): !Send & !Sync & !Unpin);
 }
 
-#[cfg(tokio_unstable)]
-mod unstable {
+mod local_runtime {
     use super::*;
 
     assert_value!(tokio::runtime::LocalRuntime: !Send & !Sync & Unpin);

--- a/tokio/tests/rt_local.rs
+++ b/tokio/tests/rt_local.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", tokio_unstable))]
+#![cfg(feature = "full")]
 
 use std::panic;
 use tokio::runtime::LocalOptions;

--- a/tokio/tests/rt_local.rs
+++ b/tokio/tests/rt_local.rs
@@ -118,25 +118,25 @@ fn test_spawn_local_from_guard_other_thread() {
 // the task would belong.
 // The test creates a `LocalRuntime` and `LocalSet`, drives the `LocalSet` on the `LocalRuntime`'s thread,
 // then spawns a **separate OS thread** and tries to call
-// `tokio::task::spawn_local` there. `std::panic::catch_unwind` is then used
-// to capture the panic and to assert that it indeed occurs.
+// `tokio::task::spawn_local` there.
 #[test]
+#[should_panic = "`spawn_local` called from outside of a `task::LocalSet` or `runtime::LocalRuntime`"]
 #[cfg_attr(target_family = "wasm", ignore)] // threads not supported
 fn test_spawn_local_panic() {
     let rt = rt();
     let local = LocalSet::new();
 
     rt.block_on(local.run_until(async {
-        let thread_result = std::thread::spawn(|| {
-            let panic_result = panic::catch_unwind(|| {
-                let _jh = tokio::task::spawn_local(async {
-                    println!("you will never see this line");
-                });
+        let panic = std::thread::spawn(|| {
+            let _jh = tokio::task::spawn_local(async {
+                println!("you will never see this line");
             });
-            assert!(panic_result.is_err(), "Expected panic, but none occurred");
         })
-        .join();
-        assert!(thread_result.is_ok(), "Thread itself panicked unexpectedly");
+        .join()
+        .unwrap_err();
+
+        // When panic=unwind
+        panic::resume_unwind(panic);
     }));
 }
 

--- a/tokio/tests/task_join_set.rs
+++ b/tokio/tests/task_join_set.rs
@@ -442,7 +442,6 @@ mod spawn_local {
         set.spawn_local(async {});
     }
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 
@@ -556,7 +555,6 @@ mod spawn_local {
 mod spawn_local_on {
     use super::*;
 
-    #[cfg(tokio_unstable)]
     mod local_runtime {
         use super::*;
 


### PR DESCRIPTION
I found out that there were some leftovers of unstable cfgs after the stabilization of the LocalRuntime