### PR TITLE
signal: restore MSRV by removing OnceLock::wait from the Windows handler

### DIFF
--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -60,9 +60,7 @@ fn new(signal: SignalKind) -> io::Result<RxFuture> {
     // Initialize the registry BEFORE registering the OS handler: the
     // handler thread can then always observe an initialized `REGISTRY`
     // (`SetConsoleCtrlHandler` happens-after the initialization below),
-    // so it needs no blocking wait. Registration itself still happens
-    // exactly once, and a failure is cached so every subsequent call
-    // reports the same error, matching the previous behavior.
+    // so it needs no blocking wait.
     let registry = REGISTRY.get_or_init(Registry::default);
 
     HANDLER_RESULT

--- a/tokio/src/signal/windows/sys.rs
+++ b/tokio/src/signal/windows/sys.rs
@@ -57,15 +57,22 @@ pub(super) fn ctrl_shutdown() -> io::Result<RxFuture> {
 }
 
 fn new(signal: SignalKind) -> io::Result<RxFuture> {
-    let registry = REGISTRY
+    // Initialize the registry BEFORE registering the OS handler: the
+    // handler thread can then always observe an initialized `REGISTRY`
+    // (`SetConsoleCtrlHandler` happens-after the initialization below),
+    // so it needs no blocking wait. Registration itself still happens
+    // exactly once, and a failure is cached so every subsequent call
+    // reports the same error, matching the previous behavior.
+    let registry = REGISTRY.get_or_init(Registry::default);
+
+    HANDLER_RESULT
         .get_or_init(
             || match unsafe { console::SetConsoleCtrlHandler(Some(handler), 1) } {
                 0 => Err(Error::last_os_error().raw_os_error().expect("unreachable")),
-                _ => Ok(Registry::default()),
+                _ => Ok(()),
             },
         )
-        .as_ref()
-        .map_err(|&code| Error::from_raw_os_error(code))?;
+        .map_err(Error::from_raw_os_error)?;
 
     let rx = registry[signal].subscribe();
     Ok(RxFuture::new(rx))
@@ -94,7 +101,11 @@ impl Index<SignalKind> for Registry {
     }
 }
 
-static REGISTRY: OnceLock<Result<Registry, i32>> = OnceLock::new();
+static REGISTRY: OnceLock<Registry> = OnceLock::new();
+
+/// Whether `SetConsoleCtrlHandler` succeeded, initialized (once) only
+/// after `REGISTRY` — see `new` for the ordering argument.
+static HANDLER_RESULT: OnceLock<Result<(), i32>> = OnceLock::new();
 
 unsafe extern "system" fn handler(ty: u32) -> BOOL {
     let signal = match ty {
@@ -107,11 +118,13 @@ unsafe extern "system" fn handler(ty: u32) -> BOOL {
         _ => return 0,
     };
 
-    // Note that `OnceLock::get` does not handle the small window between calling
-    // `SetConsoleCtrlHandler` and `REGISTRY` being initialized.
-    let Ok(registry) = REGISTRY.wait().as_ref() else {
-        // Technically unreachable since `handler` is only called if
-        // `SetConsoleCtrlHandler` succeeded.
+    // `new` initializes `REGISTRY` before it registers this handler with
+    // the OS, so an invoked handler always finds it initialized —
+    // `get()` suffices and no blocking wait is needed (using `get`
+    // also keeps the crate's MSRV: `OnceLock::wait` needs Rust 1.86).
+    let Some(registry) = REGISTRY.get() else {
+        // Unreachable by the ordering above; kept as a defensive
+        // fallback that lets the OS run the next handler.
         return 0;
     };
 


### PR DESCRIPTION
## Motivation

Fixes #8299: tokio 1.53.0 declares `rust-version = "1.71"` but uses `OnceLock::wait` — stabilized in Rust **1.86** — in the Windows console ctrl handler (`src/signal/windows/sys.rs`), so any `cargo check` of a Windows target with a toolchain in the declared-supported `1.71..1.86` range fails:

```
error[E0599]: no method named `wait` found for struct `OnceLock` in the current scope
```

This began breaking downstream MSRV CI on Windows the day 1.53.0 published (e.g. opentelemetry-rust's `msrv (windows-latest)` job — diagnosis in open-telemetry/opentelemetry-rust#3600).

## Solution

The `wait()` existed only because `SetConsoleCtrlHandler` was called **inside** `REGISTRY`'s `get_or_init` closure — i.e. before the `OnceLock` was actually initialized — leaving a window where an invoked handler could observe an uninitialized `REGISTRY` (the comment in `handler` documented exactly that window).

This PR removes the window instead of blocking on it: initialize the registry first, then register the OS handler (exactly once, through a second `OnceLock` that also caches a registration failure so every subsequent `new()` reports the same error — identical semantics to before). The handler can then rely on plain `get()`: registration happens-after initialization, so an invoked handler always finds the registry. The defensive `else` arm is kept (returns 0, letting the OS run the next handler) with an updated comment.

No behavior change intended beyond restoring the MSRV: same one-time registration, same cached-failure semantics, same handler behavior; the existing tests in the module (which drive `handler` directly after creating signals through the public API) are unchanged and still compile for the Windows target.

Verification (done from a non-Windows host — `cargo check` needs no linker):

- `cargo +1.71 check -p tokio --features full --target x86_64-pc-windows-msvc` — **fails with the reported E0599 before this change, clean after** (1.71 = the declared MSRV).
- `cargo check -p tokio --features full --target x86_64-pc-windows-msvc --all-targets` on stable — clean (includes the module's test targets).

Disclosure: this fix was developed with AI assistance under my direction; I reviewed the change and the verification above was run as described.
