### PR TITLE
runtime: remove dead link definition in `Runtime::block_on`

### DIFF
--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -334,8 +334,6 @@ impl Runtime {
     /// });
     /// # }
     /// ```
-    ///
-    /// [handle]: fn@Handle::block_on
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

The link reference definition '[handle]: fn@Handle::block_on' in the doc comment for `Runtime::block_on` is never referenced by any link text, making it a dead definition.

This was introduced in #2437 alongside the text:

> [runtime::Handle::block_on][handle] provides a version that takes &self.

That sentence was removed in #2782 when block_on was refactored to take &self, but the link definition was left behind. It was then carried over as-is when Runtime was moved to its own file in #5159.

## Solution

Remove the unused link reference definition.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
