### PR TITLE
time: fix the loom test of the race between cancellation/insertion

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -15,6 +15,8 @@ R-loom-time-driver:
   - any-glob-to-any-file:
     - tokio/src/runtime/time/*
     - tokio/src/runtime/time/**/*
+    - tokio/src/runtime/time_alt/*
+    - tokio/src/runtime/time_alt/**/*
 
 R-loom-current-thread:
 - changed-files:

--- a/tokio/src/runtime/time_alt/tests.rs
+++ b/tokio/src/runtime/time_alt/tests.rs
@@ -97,39 +97,41 @@ fn cancel_in_the_same_thread() {
 
 #[test]
 fn insert_of_already_cancelled_entry_does_not_enter_wheel() {
-    let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
-    let mut wheel = Wheel::new();
+    model(|| {
+        let (cancel_tx, mut cancel_rx) = cancellation_queue::new();
+        let mut wheel = Wheel::new();
 
-    // do not expire during the test
-    let far_future = 10_000_000;
-    let (hdl, awoken_count) = new_handle_with_deadline(far_future);
+        // do not expire during the test
+        let far_future = 10_000_000;
+        let (hdl, awoken_count) = new_handle_with_deadline(far_future);
 
-    // cancel the timer before inserting it into the wheel
-    hdl.cancel();
-    assert!(hdl.is_cancelled());
+        // cancel the timer before inserting it into the wheel
+        hdl.cancel();
+        assert!(hdl.is_cancelled());
 
-    // try to insert the cancelled entry into the wheel
-    unsafe {
-        wheel.insert(hdl, cancel_tx);
-    }
+        // try to insert the cancelled entry into the wheel
+        unsafe {
+            wheel.insert(hdl, cancel_tx);
+        }
 
-    // a cancelled entry should not be inserted into the wheel
-    assert!(
-        wheel.next_expiration_time().is_none(),
-        "an already-cancelled entry leaked into the wheel on insert"
-    );
+        // a cancelled entry should not be inserted into the wheel
+        assert!(
+            wheel.next_expiration_time().is_none(),
+            "an already-cancelled entry leaked into the wheel on insert"
+        );
 
-    // It also must not have been queued for cancellation removal, since
-    // it was never actually placed in the wheel for `remove` to find.
-    assert_eq!(cancel_rx.recv_all().count(), 0);
-    assert_eq!(awoken_count.get(), 0);
+        // It also must not have been queued for cancellation removal, since
+        // it was never actually placed in the wheel for `remove` to find.
+        assert_eq!(cancel_rx.recv_all().count(), 0);
+        assert_eq!(awoken_count.get(), 0);
 
-    // drain the wheel unconditionally, otherwise loom will complain
-    // about the leaked entry, which confuses developers in case
-    // this test fails for some other reason.
-    let mut wake_queue = WakeQueue::new();
-    wheel.take_expired(u64::MAX, &mut wake_queue);
-    wake_queue.wake_all();
+        // drain the wheel unconditionally, otherwise loom will complain
+        // about the leaked entry, which confuses developers in case
+        // this test fails for some other reason.
+        let mut wake_queue = WakeQueue::new();
+        wheel.take_expired(u64::MAX, &mut wake_queue);
+        wake_queue.wake_all();
+    });
 }
 
 #[test]


### PR DESCRIPTION
Fixed the failing test introduced in <https://github.com/tokio-rs/tokio/pull/8252>. Also fixed the labeler to ensure loom tests of time driver will be triggered for alt timer.

```
thread 'runtime::time_alt::tests::insert_of_already_cancelled_entry_does_not_enter_wheel' (2504) panicked at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/loom-0.7.2/src/rt/scheduler.rs:128:13:
cannot access Loom execution state from outside a Loom model. are you accessing a Loom synchronization primitive from outside a Loom test (a call to `model` or `check`)?
stack backtrace:
test runtime::time_alt::tests::insert_of_already_cancelled_entry_does_not_enter_wheel ... FAILED
   0: std::panicking::begin_panic::<&str>
   1: <loom::rt::mutex::Mutex>::new
   2: <tokio::runtime::time_alt::tests::insert_of_already_cancelled_entry_does_not_enter_wheel::{closure#0} as core::ops::function::FnOnce<()>>::call_once
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```