### PR TITLE
chore: prepare Tokio v1.53.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.53.0", features = ["full"] }
+tokio = { version = "1.53.1", features = ["full"] }
 ```
 Then, on your main.rs:
 

--- a/tokio/CHANGELOG.md
+++ b/tokio/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 1.53.1 (July 20th, 2026)
+
+### Fixed
+
+- signal: restore MSRV by removing `OnceLock::wait` from the Windows handler ([#8300])
+
+### Fixed (unstable)
+
+- time: fix alt timer cancellation and insertion race ([#8252])
+
+### Documented
+
+- runtime: remove dead link definition in Runtime::block_on ([#8301])
+
+[#8252]: https://github.com/tokio-rs/tokio/pull/8252
+[#8300]: https://github.com/tokio-rs/tokio/pull/8300
+[#8301]: https://github.com/tokio-rs/tokio/pull/8301
+
 # 1.53.0 (July 17th, 2026)
 
 ### Added

--- a/tokio/Cargo.toml
+++ b/tokio/Cargo.toml
@@ -6,7 +6,7 @@ name = "tokio"
 #   - README.md
 # - Update CHANGELOG.md.
 # - Create "v1.x.y" git tag.
-version = "1.53.0"
+version = "1.53.1"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -60,7 +60,7 @@ Make sure you enable the full features of the tokio crate on Cargo.toml:
 
 ```toml
 [dependencies]
-tokio = { version = "1.53.0", features = ["full"] }
+tokio = { version = "1.53.1", features = ["full"] }
 ```
 Then, on your main.rs:
 


### PR DESCRIPTION
## Blocked by [#8300], <del>#8302</del>

# 1.53.1 (July 20th, 2026)

### Fixed

- signal: restore MSRV by removing `OnceLock::wait` from the Windows handler ([#8300])

### Fixed (unstable)

- time: fix alt timer cancellation and insertion race ([#8252])

### Documented

- runtime: remove dead link definition in Runtime::block_on ([#8310])

[#8252]: https://github.com/tokio-rs/tokio/pull/8252
[#8300]: https://github.com/tokio-rs/tokio/pull/8300
[#8301]: https://github.com/tokio-rs/tokio/pull/8301
