### PR TITLE
Upgrade syn to v3

### DIFF
--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -24,7 +24,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1.0.60"
 quote = "1"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "3.0", features = ["full"] }
 
 [dev-dependencies]
 tokio = { version = "1.0.0", features = ["full", "test-util"] }

--- a/tokio-macros/src/entry.rs
+++ b/tokio-macros/src/entry.rs
@@ -326,7 +326,7 @@ fn contains_impl_trait(ty: &syn::Type) -> bool {
                     _ => false,
                 }),
                 syn::PathArguments::Parenthesized(args) => {
-                    args.inputs.iter().any(contains_impl_trait)
+                    args.inputs.iter().any(|arg| contains_impl_trait(&arg.ty))
                         || matches!(&args.output, syn::ReturnType::Type(_, t) if contains_impl_trait(t))
                 }
                 syn::PathArguments::None => false,


### PR DESCRIPTION
## Motivation

The proc macros ecosystem is upgrading to [syn v3](https://github.com/dtolnay/syn/releases/tag/3.0.0).

## Solution

Upgrade tokio-macros to syn v3 too.