### PR TITLE
test: re-enable `tcp_stream::try_read_buf` test for WASI

### DIFF
--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -307,10 +307,6 @@ fn write_until_pending(stream: &mut TcpStream) -> usize {
     total
 }
 
-// This test is temporarily disabled on WASI due to
-// https://github.com/bytecodealliance/wasmtime/issues/13040.  We can re-enable
-// it once that issue is fixed and the fix is included in a Wasmtime release.
-#[cfg_attr(target_os = "wasi", ignore)]
 #[tokio::test]
 async fn try_read_buf() {
     const DATA: &[u8] = &[2u8; 4000];


### PR DESCRIPTION
Now that https://github.com/bytecodealliance/wasmtime/issues/13040 has been addressed, https://github.com/tokio-rs/tokio/issues/8034 is fixed, and we no longer need to disable the test for WASI.

Closes #8034
