### PR TITLE
docs: simplify enable_io feature gate in rustdoc

### DIFF
--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -163,8 +163,8 @@ macro_rules! cfg_io_driver {
             ))]
             #[cfg_attr(docsrs, doc(cfg(any(
                 feature = "net",
-                all(unix, feature = "process"),
-                all(unix, feature = "signal"),
+                feature = "process",
+                feature = "signal",
                 all(
                     tokio_unstable,
                     feature = "io-uring",


### PR DESCRIPTION
## Motivation
The doc(cfg) attribute on cfg_io_driver! was rendering platform-specific predicates like all(unix, feature = signal) in the rustdoc output for enable_io(). This cluttered the docs with implementation details that aren't relevant to most users — they just want to know which features to enable, not which platforms each feature applies to (see #2973).

## Solution
Removed the unix qualifier from the process and signal features in the doc(cfg(...)) display attribute. The actual #[cfg(...)] gate is unchanged — signal and process still require unix at compile time. Since doc(cfg) is display-only, this is a docs-only change with no behavioral impact.
