### PR TITLE
chore: prepare tokio-stream v0.1.19

### DIFF
--- a/tokio-stream/CHANGELOG.md
+++ b/tokio-stream/CHANGELOG.md
@@ -1,3 +1,38 @@
+# 0.1.19 (July 22nd, 2026)
+
+### Added
+
+- stream: implement `FromStream` for standard collections ([#7954], [#7966])
+- stream: implement `FusedStream` for various stream adaptors ([#7854], [#8090], [#8096])
+- stream: implement `Peekable::size_hint` ([#8109])
+- task: add `JoinSetStream` wrapper for `JoinSet` ([#8189])
+
+### Changed
+
+- stream: bump minimum required `tokio` version to `1.38.0` ([#7887])
+- stream: use cooperative budgeting in `tokio_stream::iter` ([#8218])
+- stream: update coop handling for `empty` and `once` ([#8227])
+
+### Fixed
+
+- stream: fix overflow in `StreamMap::size_hint` ([#8216])
+- stream: honor `StreamMap::next_many` limit ([#8215])
+- stream: stop polling underlying stream once `map_while` yields `None` ([#8233])
+
+[#7854]: https://github.com/tokio-rs/tokio/pull/7854
+[#7887]: https://github.com/tokio-rs/tokio/pull/7887
+[#7954]: https://github.com/tokio-rs/tokio/pull/7954
+[#7966]: https://github.com/tokio-rs/tokio/pull/7966
+[#8090]: https://github.com/tokio-rs/tokio/pull/8090
+[#8096]: https://github.com/tokio-rs/tokio/pull/8096
+[#8109]: https://github.com/tokio-rs/tokio/pull/8109
+[#8189]: https://github.com/tokio-rs/tokio/pull/8189
+[#8215]: https://github.com/tokio-rs/tokio/pull/8215
+[#8216]: https://github.com/tokio-rs/tokio/pull/8216
+[#8218]: https://github.com/tokio-rs/tokio/pull/8218
+[#8227]: https://github.com/tokio-rs/tokio/pull/8227
+[#8233]: https://github.com/tokio-rs/tokio/pull/8233
+
 # 0.1.18 (January 4th, 2026)
 
 ### Added

--- a/tokio-stream/Cargo.toml
+++ b/tokio-stream/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-stream"
 # - Remove path dependencies (if any)
 # - Update CHANGELOG.md.
 # - Create "tokio-stream-0.1.x" git tag.
-version = "0.1.18"
+version = "0.1.19"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 0.1.19 (July 22nd, 2026)

### Added

- stream: implement `FromStream` for standard collections ([#7954], [#7966])
- stream: implement `FusedStream` for various stream adaptors ([#7854], [#8090], [#8096])
- stream: implement `Peekable::size_hint` ([#8109])
- task: add `JoinSetStream` wrapper for `JoinSet` ([#8189])

### Changed

- stream: bump minimum required `tokio` version to `1.38.0` ([#7887])
- stream: use cooperative budgeting in `tokio_stream::iter` ([#8218])
- stream: update coop handling for `empty` and `once` ([#8227])

### Fixed

- stream: fix overflow in `StreamMap::size_hint` ([#8216])
- stream: honor `StreamMap::next_many` limit ([#8215])
- stream: stop polling underlying stream once `map_while` yields `None` ([#8233])

[#7854]: https://github.com/tokio-rs/tokio/pull/7854
[#7887]: https://github.com/tokio-rs/tokio/pull/7887
[#7954]: https://github.com/tokio-rs/tokio/pull/7954
[#7966]: https://github.com/tokio-rs/tokio/pull/7966
[#8090]: https://github.com/tokio-rs/tokio/pull/8090
[#8096]: https://github.com/tokio-rs/tokio/pull/8096
[#8109]: https://github.com/tokio-rs/tokio/pull/8109
[#8189]: https://github.com/tokio-rs/tokio/pull/8189
[#8215]: https://github.com/tokio-rs/tokio/pull/8215
[#8216]: https://github.com/tokio-rs/tokio/pull/8216
[#8218]: https://github.com/tokio-rs/tokio/pull/8218
[#8227]: https://github.com/tokio-rs/tokio/pull/8227
[#8233]: https://github.com/tokio-rs/tokio/pull/8233