### PR TITLE
Remove obsolete TokioConf notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-*[TokioConf 2026 program and tickets are now available!](https://tokioconf.com)*
-
----
-
 # Tokio
 
 A runtime for writing reliable, asynchronous, and slim applications with

--- a/tokio/README.md
+++ b/tokio/README.md
@@ -1,7 +1,3 @@
-*[TokioConf 2026 program and tickets are now available!](https://tokioconf.com)*
-
----
-
 # Tokio
 
 A runtime for writing reliable, asynchronous, and slim applications with


### PR DESCRIPTION
Remove obsolete TokioConf notices.

## Motivation

According to the website the conference ended months ago.

