### PR TITLE
net: enable various tests for WASI

### DIFF
--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -42,10 +42,6 @@ async fn set_linger() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn try_read_write() {
     const DATA: &[u8] = &[2u8; 4000];
 
@@ -395,10 +391,6 @@ async fn try_read_buf() {
 
 // read_closed is a best effort event, so test only for no false positives.
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/732"
-)]
 async fn read_closed() {
     let (client, mut server) = create_pair().await;
 

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -58,7 +58,7 @@ async fn send_recv_poll() -> std::io::Result<()> {
 #[tokio::test]
 #[cfg_attr(
     target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
+    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/13933"
 )]
 async fn send_to_recv_closed_returns_err() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
@@ -87,10 +87,6 @@ async fn send_to_recv_closed_returns_err() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn send_to_recv_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -107,10 +103,6 @@ async fn send_to_recv_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn send_to_recv_from_poll() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -497,10 +489,6 @@ async fn try_send_recv() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn try_send_to_recv_from() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -605,10 +593,6 @@ async fn recv_buf() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn try_recv_buf_from() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();
@@ -652,10 +636,6 @@ async fn try_recv_buf_from() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn recv_buf_from() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;
@@ -673,10 +653,6 @@ async fn recv_buf_from() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/WebAssembly/wasi-libc/pull/734"
-)]
 async fn poll_ready() {
     // Create listener
     let server = UdpSocket::bind("127.0.0.1:0").await.unwrap();


### PR DESCRIPTION
These tests were temporarily disabled until required `wasi-libc` fixes made their way into a Rust release.  Now that that has happened, we can enable them.

Note that `send_to_recv_closed_returns_err` remains disabled for a bit longer. The applicable `wasi-libc` bug was masking a separate bug in Wasmtime, fixed [here](https://github.com/bytecodealliance/wasmtime/pull/13933).  Once that fix makes its way into a release (presumably v48.0.0), we'll finally be able enable that test, and that should be the last of the temporarily-disabled-on-WASI-due-to-bugs tests.
