### PR TITLE
rt: move block_in_place setup into a non-generic function

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -402,10 +402,32 @@ where
         }
     }
 
+    // Move the runtime to another thread, if there is one to move.
+    // Do this in a non-generic function that doesn't depend on `F` or `R`.
+    let (had_entered, take_core) = match maybe_move_runtime() {
+        Ok(r) => r,
+        Err(panic_message) => panic!("{}", panic_message),
+    };
+
+    if had_entered {
+        // Unset the current task's budget. Blocking sections are not
+        // constrained by task budgets.
+        let _reset = Reset {
+            take_core,
+            budget: coop::stop(),
+        };
+
+        crate::runtime::context::exit_runtime(f)
+    } else {
+        f()
+    }
+}
+
+fn maybe_move_runtime() -> Result<(bool, bool), &'static str> {
     let mut had_entered = false;
     let mut take_core = false;
 
-    let setup_result = with_current(|maybe_cx| {
+    with_current(|maybe_cx| {
         match (
             crate::runtime::context::current_enter_context(),
             maybe_cx.is_some(),
@@ -488,24 +510,8 @@ where
         let worker = cx.worker.clone();
         runtime::spawn_blocking(move || run(worker));
         Ok(())
-    });
-
-    if let Err(panic_message) = setup_result {
-        panic!("{}", panic_message);
-    }
-
-    if had_entered {
-        // Unset the current task's budget. Blocking sections are not
-        // constrained by task budgets.
-        let _reset = Reset {
-            take_core,
-            budget: coop::stop(),
-        };
-
-        crate::runtime::context::exit_runtime(f)
-    } else {
-        f()
-    }
+    })?;
+    Ok((had_entered, take_core))
 }
 
 impl Launch {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
Right now each callsite of `block_in_place` creates a fresh copy of the runtime-moving code.
In particular this includes the call `runtime::spawn_blocking(move || run(worker))`.
That closure gets a different name for each callsite, which means that stack traces of code running on the Tokio runtime have random different functions at the top of the stack. This is not really a huge problem but it is annoying.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
Bring the setup code out-of-line so that there is just one copy of it. This may also reduce code size a little bit.