### PR TITLE
tokio-test: fix `semicolon_in_expressions_from_macros` lint

### DIFF
--- a/tokio-test/src/macros.rs
+++ b/tokio-test/src/macros.rs
@@ -241,10 +241,7 @@ macro_rules! assert_ok {
 /// ```
 #[macro_export]
 macro_rules! assert_err {
-    ($e:expr) => {
-        assert_err!($e,);
-    };
-    ($e:expr,) => {{
+    ($e:expr $(,)?) => {{
         use std::result::Result::*;
         match $e {
             Ok(v) => panic!("assertion failed: Ok({:?})", v),

--- a/tokio-test/src/macros.rs
+++ b/tokio-test/src/macros.rs
@@ -198,10 +198,7 @@ macro_rules! assert_ready_eq {
 /// ```
 #[macro_export]
 macro_rules! assert_ok {
-    ($e:expr) => {
-        assert_ok!($e,)
-    };
-    ($e:expr,) => {{
+    ($e:expr $(,)?) => {{
         use std::result::Result::*;
         match $e {
             Ok(v) => v,


### PR DESCRIPTION
A new future incompat lint started firing on nightly: https://github.com/rust-lang/rust/issues/79813.