### PR TITLE
time: adjust tests::time_rt::tickspace

### DIFF
--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -188,7 +188,9 @@ fn tickspace() {
 
     let _guard = rt_past.enter();
     let mut sleep = std::pin::pin!(sleep(Duration::from_millis(1)));
-    assert_pending!(sleep.as_mut().poll(&mut Context::from_waker(noop_waker_ref())));
+    assert_pending!(sleep
+        .as_mut()
+        .poll(&mut Context::from_waker(noop_waker_ref())));
 
     let deadline = sleep.deadline();
     rt.block_on(async { sleep.as_mut().reset(deadline + Duration::from_millis(1)) });

--- a/tokio/tests/time_rt.rs
+++ b/tokio/tests/time_rt.rs
@@ -1,10 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-use futures_test::task::noop_context;
 use tokio::runtime::Runtime;
 use tokio::time::*;
-use tokio_test::assert_pending;
 
 use std::sync::mpsc;
 
@@ -168,9 +166,14 @@ fn timeout_value() {
 }
 
 #[test]
+#[cfg(feature = "test-util")]
 fn tickspace() {
+    use futures::task::noop_waker_ref;
     use std::future::Future as _;
+    use std::task::Context;
     use std::thread;
+    use tokio_test::assert_pending;
+
     let rt = || {
         tokio::runtime::Builder::new_current_thread()
             .enable_time()
@@ -185,7 +188,7 @@ fn tickspace() {
 
     let _guard = rt_past.enter();
     let mut sleep = std::pin::pin!(sleep(Duration::from_millis(1)));
-    assert_pending!(sleep.as_mut().poll(&mut noop_context()));
+    assert_pending!(sleep.as_mut().poll(&mut Context::from_waker(noop_waker_ref())));
 
     let deadline = sleep.deadline();
     rt.block_on(async { sleep.as_mut().reset(deadline + Duration::from_millis(1)) });


### PR DESCRIPTION
When Android vendors Tokio, its tests are run without the test-util feature enabled, which caused a build failure in this file. Thus, fix that.