### PR TITLE
tokio-util: wake `DelayQueue` when cleared

### DIFF
--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -1036,10 +1036,18 @@ impl<T> DelayQueue<T> {
     /// # }
     /// ```
     pub fn clear(&mut self) {
+        let had_entries = !self.slab.is_empty();
+
         self.slab.clear();
         self.expired = Stack::default();
         self.wheel = Wheel::new();
         self.delay = None;
+
+        if had_entries {
+            if let Some(waker) = self.waker.take() {
+                waker.wake();
+            }
+        }
     }
 
     /// Returns the number of elements the queue can hold without reallocating.

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -915,6 +915,20 @@ async fn wake_after_remove_last() {
     assert!(assert_ready!(poll!(queue)).is_none());
 }
 
+#[tokio::test(start_paused = true)]
+async fn wake_after_clear() {
+    let mut queue = task::spawn(DelayQueue::new());
+    queue.insert("foo", ms(1000));
+
+    assert_pending!(poll!(queue));
+    assert!(!queue.is_woken());
+
+    queue.clear();
+
+    assert!(queue.is_woken());
+    assert!(assert_ready!(poll!(queue)).is_none());
+}
+
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
 }


### PR DESCRIPTION
## Motivation

`DelayQueue::poll_expired` stores the caller's waker when a future item causes it to return `Pending`. Calling `clear` then makes the queue ready to return `None`, but previously discarded the active delay without waking that task. The consumer could remain pending indefinitely.

This differs from removing the final entry, which already wakes the registered task.

## Solution

Remember whether the queue had entries before clearing it. After resetting the queue state, wake the stored task only for a nonempty-to-empty transition, matching the existing behavior of `remove`.

Add a regression test that verifies the task is asleep before `clear`, is woken by it, and observes `Ready(None)` on the next poll.