### PR TITLE
rt: correct `tick` to `tick_op` in set_readiness doc

### DIFF
--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -200,7 +200,7 @@ impl ScheduledIo {
     /// the current value, returning the previous readiness value.
     ///
     /// # Arguments
-    /// - `tick`: whether setting the tick or trying to clear readiness for a
+    /// - `tick_op`: whether setting the tick or trying to clear readiness for a
     ///   specific tick.
     /// - `f`: a closure returning a new readiness value given the previous
     ///   readiness.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

The arg name is incorrect.
This addresses a doc update that was missed in #6966.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Correct the arg name.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
