### PR TITLE
io: complete zero-length in-memory stream operations immediately

### DIFF
--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -250,6 +250,10 @@ impl SimplexStream {
         cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
         if self.buffer.has_remaining() {
             let max = self.buffer.remaining().min(buf.remaining());
             buf.put_slice(&self.buffer[..max]);
@@ -278,6 +282,10 @@ impl SimplexStream {
         if self.is_closed {
             return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()));
         }
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
         let avail = self.max_buf_size - self.buffer.len();
         if avail == 0 {
             self.write_waker = Some(cx.waker().clone());
@@ -300,6 +308,10 @@ impl SimplexStream {
         if self.is_closed {
             return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()));
         }
+        if bufs.iter().all(|buf| buf.is_empty()) {
+            return Poll::Ready(Ok(0));
+        }
+
         let avail = self.max_buf_size - self.buffer.len();
         if avail == 0 {
             self.write_waker = Some(cx.waker().clone());

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -1,6 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
+use futures::FutureExt;
+use std::io::IoSlice;
 use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test]
@@ -99,6 +101,38 @@ async fn max_write_size() {
 
     // drop b only after task t1 finishes writing
     drop(b);
+}
+
+#[tokio::test]
+async fn zero_length_operations() {
+    let (mut reader, _peer) = duplex(1);
+    assert!(matches!(reader.read(&mut []).now_or_never(), Some(Ok(0))));
+
+    let (mut writer, _peer) = duplex(1);
+    writer.write_all(b"x").await.unwrap();
+    assert!(matches!(writer.write(&[]).now_or_never(), Some(Ok(0))));
+
+    let (mut writer, _peer) = duplex(1);
+    writer.write_all(b"x").await.unwrap();
+    let bufs = [IoSlice::new(&[]), IoSlice::new(&[])];
+    assert!(matches!(
+        writer.write_vectored(&bufs).now_or_never(),
+        Some(Ok(0))
+    ));
+}
+
+#[tokio::test]
+async fn zero_length_writes_to_closed_stream() {
+    let (mut writer, peer) = duplex(1);
+    drop(peer);
+    let err = writer.write(&[]).await.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
+
+    let (mut writer, peer) = duplex(1);
+    drop(peer);
+    let bufs = [IoSlice::new(&[]), IoSlice::new(&[])];
+    let err = writer.write_vectored(&bufs).await.unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::BrokenPipe);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Motivation

Zero-length operations on in-memory streams can currently return `Pending` when a read buffer has no data or a write buffer has no capacity. Their completion therefore depends on stream state even though they cannot transfer any bytes.

This applies to zero-capacity reads, empty writes, and vectored writes where every buffer is empty.

Closes #8321.

## Solution

Return immediately from the shared `SimplexStream` implementation for zero-capacity reads and writes. The write-side closed check remains first, preserving `BrokenPipe` for writes to a closed stream.

Add integration tests covering all three zero-length operations and the closed-stream precedence for scalar and vectored writes.

Verified with:

```console
cargo test -p tokio --test io_mem_stream --features full
cargo clippy -p tokio --test io_mem_stream --features full -- -D warnings
```