### PR TITLE
tokio-util: replace LocalSet with LocalRuntime in LocalPoolHandle

### DIFF
--- a/tokio-util/src/task/spawn_pinned.rs
+++ b/tokio-util/src/task/spawn_pinned.rs
@@ -4,19 +4,19 @@ use std::fmt::{Debug, Formatter};
 use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
-use tokio::runtime::Builder;
+use tokio::runtime::{Builder, LocalOptions, LocalRuntime};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 use tokio::sync::oneshot;
-use tokio::task::{spawn_local, JoinHandle, LocalSet};
+use tokio::task::JoinHandle;
 
 /// A cloneable handle to a local pool, used for spawning `!Send` tasks.
 ///
-/// Internally the local pool uses a [`tokio::task::LocalSet`] for each worker thread
+/// Internally the local pool uses a [`tokio::runtime::LocalRuntime`] for each worker thread
 /// in the pool. Consequently you can also use [`tokio::task::spawn_local`] (which will
 /// execute on the same thread) inside the Future you supply to the various spawn methods
 /// of `LocalPoolHandle`.
 ///
-/// [`tokio::task::LocalSet`]: tokio::task::LocalSet
+/// [`tokio::runtime::LocalRuntime`]: tokio::runtime::LocalRuntime
 /// [`tokio::task::spawn_local`]: tokio::task::spawn_local
 ///
 /// # Examples
@@ -238,14 +238,13 @@ impl LocalPool {
             let _abort_guard = AbortGuard(abort_handle);
 
             // Inside the future we can't run spawn_local yet because we're not
-            // in the context of a LocalSet. We need to send create_task to the
-            // LocalSet task for spawning.
+            // in the context of a LocalRuntime. We need to send create_task to the
+            // LocalRuntime worker loop for spawning.
             let spawn_task = Box::new(move || {
-                // Once we're in the LocalSet context we can call spawn_local
-                let join_handle =
-                    spawn_local(
-                        async move { Abortable::new(create_task(), abort_registration).await },
-                    );
+                // Once we're in the LocalRuntime context we can call spawn_local
+                let join_handle = tokio::task::spawn_local(async move {
+                    Abortable::new(create_task(), abort_registration).await
+                });
 
                 // Send the join handle back to the spawner. If sending fails,
                 // we assume the parent task was canceled, so cancel this task
@@ -255,7 +254,7 @@ impl LocalPool {
                 }
             });
 
-            // Send the callback to the LocalSet task
+            // Send the callback to the LocalRuntime task
             if let Err(e) = worker_spawner.send(spawn_task) {
                 // Propagate the error as a panic in the join handle.
                 panic!("Failed to send job to worker: {e}");
@@ -379,15 +378,25 @@ impl LocalWorkerHandle {
     /// Create a new worker for executing pinned tasks
     fn new_worker() -> LocalWorkerHandle {
         let (sender, receiver) = unbounded_channel();
-        let runtime = Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to start a pinned worker thread runtime");
-        let runtime_handle = runtime.handle().clone();
+        let (handle_sender, handle_receiver) = std::sync::mpsc::channel();
         let task_count = Arc::new(AtomicUsize::new(0));
         let task_count_clone = Arc::clone(&task_count);
 
-        std::thread::spawn(|| Self::run(runtime, receiver, task_count_clone));
+        std::thread::spawn(move || {
+            let runtime = Builder::new_current_thread()
+                .enable_all()
+                .build_local(LocalOptions::default())
+                .expect("Failed to start a pinned worker thread runtime");
+            let runtime_handle = runtime.handle().clone();
+            if handle_sender.send(runtime_handle).is_err() {
+                return;
+            }
+            Self::run(runtime, receiver, task_count_clone);
+        });
+
+        let runtime_handle = handle_receiver
+            .recv()
+            .expect("Worker thread panicked before sending handle");
 
         LocalWorkerHandle {
             runtime_handle,
@@ -397,28 +406,23 @@ impl LocalWorkerHandle {
     }
 
     fn run(
-        runtime: tokio::runtime::Runtime,
+        runtime: LocalRuntime,
         mut task_receiver: UnboundedReceiver<PinnedFutureSpawner>,
         task_count: Arc<AtomicUsize>,
     ) {
-        let local_set = LocalSet::new();
-        local_set.block_on(&runtime, async {
+        runtime.block_on(async {
             while let Some(spawn_task) = task_receiver.recv().await {
-                // Calls spawn_local(future)
                 (spawn_task)();
             }
         });
 
-        // If there are any tasks on the runtime associated with a LocalSet task
+        // If there are any tasks on the runtime associated with a task
         // that has already completed, but whose output has not yet been
         // reported, let that task complete.
         //
         // Since the task_count is decremented when the runtime task exits,
         // reading that counter lets us know if any such tasks completed during
         // the call to `block_on`.
-        //
-        // Tasks on the LocalSet can't complete during this loop since they're
-        // stored on the LocalSet and we aren't accessing it.
         let mut previous_task_count = task_count.load(Ordering::SeqCst);
         loop {
             // This call will also run tasks spawned on the runtime.
@@ -431,15 +435,6 @@ impl LocalWorkerHandle {
             }
         }
 
-        // It's now no longer possible for a task on the runtime to be
-        // associated with a LocalSet task that has completed. Drop both the
-        // LocalSet and runtime to let tasks on the runtime be cancelled if and
-        // only if they are still on the LocalSet.
-        //
-        // Drop the LocalSet task first so that anyone awaiting the runtime
-        // JoinHandle will see the cancelled error after the LocalSet task
-        // destructor has completed.
-        drop(local_set);
         drop(runtime);
     }
 }


### PR DESCRIPTION
Refactor LocalPoolHandle to use LocalRuntime
Description
This PR refactors the internal architecture of LocalPoolHandle in tokio-util/src/task/spawn_pinned.rs. It replaces the deprecated combination of tokio::runtime::Runtime + tokio::task::LocalSet with the stabilized tokio::runtime::LocalRuntime (addressing technical debt from issues #6741 and #6739).

The public API of LocalPoolHandle remains completely unchanged to avoid breaking downstream consumers.

 Changes
Imports: Replaced tokio::task::LocalSet with tokio::runtime::{LocalOptions, LocalRuntime}.
Worker Initialization (LocalWorkerHandle::new_worker):
Spawns the background thread and builds the LocalRuntime using Builder::new_current_thread().enable_all().build_local(LocalOptions::default()) directly inside it.
Sends the runtime's cloneable Handle back to the parent constructor using a standard synchronous channel (std::sync::mpsc::channel).
Task Dispatching:
Kept the optimized communication channel (UnboundedSender) to dispatch closure-based tasks from the main thread.
Spawns closures as pinned tasks via tokio::task::spawn_local inside the runtime.block_on loop of the worker thread. This guarantees that spawn_local executes in the correct LocalRuntime context of the background thread, avoiding run-time panics from missing local contexts.
Shutdown Loop (LocalWorkerHandle::run):
Modified the signature to accept LocalRuntime instead of Runtime.
Ensures the cleanup/yielding loop (tokio::task::yield_now()) runs within runtime.block_on(...) to properly process remaining local tasks before dropping the runtime.
Verification
Verified that all unit tests under tokio-util (including tests/spawn_pinned.rs) pass without errors.
Confirmed correct behavior of panic propagation, cancellation, task load balancing, and thread safety.