### PR TITLE
tokio-test: fix lost waker when `tokio_test::io::Mock` is split

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -66,11 +66,22 @@ enum Action {
     WriteError(Option<Arc<io::Error>>),
 }
 
+/// Identifies which half is polling the shared `Sleep`.
+///
+/// A `Mock` may be used through [`tokio::io::split`], in which case the read
+/// and write halves are polled by two independent tasks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Half {
+    Read,
+    Write,
+}
+
 struct Inner {
     actions: VecDeque<Action>,
     waiting: Option<Instant>,
     sleep: Option<Pin<Box<Sleep>>>,
     read_wait: Option<Waker>,
+    write_wait: Option<Waker>,
     rx: UnboundedReceiverStream<Action>,
     name: String,
 }
@@ -201,6 +212,7 @@ impl Inner {
             actions,
             sleep: None,
             read_wait: None,
+            write_wait: None,
             rx,
             waiting: None,
             name,
@@ -209,6 +221,49 @@ impl Inner {
         let handle = Handle { tx };
 
         (inner, handle)
+    }
+
+    /// Polls the pending `Wait` timer, if one is set.
+    ///
+    /// Both `poll_read` and `poll_write` drive this same `Sleep`, but a timer
+    /// only stores the waker of its most recent poll. When a `Mock` is used
+    /// through [`tokio::io::split`], the two halves are polled by independent
+    /// tasks, so whichever half polls last evicts the other half's waker and
+    /// that half would never be woken again.
+    ///
+    /// To keep the shared wait usable from both halves, each half records its
+    /// own waker here, and the half that observes the timer firing wakes the
+    /// other one. The `Sleep` itself is still shared, so a `wait()` continues
+    /// to describe a single timeline for the whole `Mock`.
+    ///
+    /// See <https://github.com/tokio-rs/tokio/issues/7445>.
+    fn poll_sleep(&mut self, cx: &mut task::Context<'_>, half: Half) -> Poll<()> {
+        if let Some(ref mut sleep) = self.sleep {
+            if Pin::new(sleep).poll(cx).is_pending() {
+                match half {
+                    Half::Read => self.read_wait = Some(cx.waker().clone()),
+                    Half::Write => self.write_wait = Some(cx.waker().clone()),
+                }
+
+                return Poll::Pending;
+            }
+
+            // The shared timer fired. Polling it above replaced whatever waker
+            // the other half had registered, so wake that half explicitly.
+            let other = match half {
+                Half::Read => self.write_wait.take(),
+                Half::Write => self.read_wait.take(),
+            };
+
+            if let Some(waker) = other {
+                waker.wake();
+            }
+        }
+
+        // If a sleep was set, it has already fired
+        self.sleep = None;
+
+        Poll::Ready(())
     }
 
     fn poll_action(&mut self, cx: &mut task::Context<'_>) -> Poll<Option<Action>> {
@@ -363,12 +418,7 @@ impl AsyncRead for Mock {
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
         loop {
-            if let Some(ref mut sleep) = self.inner.sleep {
-                ready!(Pin::new(sleep).poll(cx));
-            }
-
-            // If a sleep is set, it has already fired
-            self.inner.sleep = None;
+            ready!(self.inner.poll_sleep(cx, Half::Read));
 
             // Capture 'filled' to monitor if it changed
             let filled = buf.filled().len();
@@ -411,12 +461,7 @@ impl AsyncWrite for Mock {
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
         loop {
-            if let Some(ref mut sleep) = self.inner.sleep {
-                ready!(Pin::new(sleep).poll(cx));
-            }
-
-            // If a sleep is set, it has already fired
-            self.inner.sleep = None;
+            ready!(self.inner.poll_sleep(cx, Half::Write));
 
             if self.inner.actions.is_empty() {
                 match self.inner.poll_action(cx) {

--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -236,6 +236,15 @@ impl Inner {
     /// other one. The `Sleep` itself is still shared, so a `wait()` continues
     /// to describe a single timeline for the whole `Mock`.
     ///
+    /// Note that `read_wait` is also the slot `maybe_wakeup_reader` uses to
+    /// park a reader that currently has nothing to read. Both uses only ever
+    /// take the waker and wake it, so a wake arriving from either path is at
+    /// worst an extra poll.
+    ///
+    /// This does not help a half whose peer stops polling entirely: if the task
+    /// holding the timer's waker is dropped, nobody observes the timer firing
+    /// and the remaining half stays parked.
+    ///
     /// See <https://github.com/tokio-rs/tokio/issues/7445>.
     fn poll_sleep(&mut self, cx: &mut task::Context<'_>, half: Half) -> Poll<()> {
         if let Some(ref mut sleep) = self.sleep {

--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -234,7 +234,7 @@ impl Inner {
     /// To keep the shared wait usable from both halves, each half records its
     /// own waker here, and the half that observes the timer firing wakes the
     /// other one. The `Sleep` itself is still shared, so a `wait()` continues
-    /// to describe a single timeline for the whole `Mock`.
+    /// to describe a single shared deadline for the whole `Mock`.
     ///
     /// Note that `read_wait` is also the slot `maybe_wakeup_reader` uses to
     /// park a reader that currently has nothing to read. Both uses only ever

--- a/tokio-test/tests/io_split_waker.rs
+++ b/tokio-test/tests/io_split_waker.rs
@@ -4,16 +4,20 @@ use std::time::{Duration, Instant};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio_test::io::Builder;
 
-/// Regression test for #7445.
-///
-/// `poll_read` and `poll_write` drive the same `Sleep`, and a timer only stores
-/// the waker of its most recent poll. Whichever half polled it last used to
-/// evict the other half's waker, leaving that half permanently unwoken.
-///
-/// Note this asserts on elapsed time rather than simply on completion: wrapping
-/// the write in a `timeout` masks the bug, because the timeout's own timer wakes
-/// the task and lets the write re-poll. The `timeout` here is only a guard so a
-/// regression fails the suite instead of hanging it forever.
+// Regression tests for #7445.
+//
+// `poll_read` and `poll_write` drive the same `Sleep`, and a timer only stores
+// the waker of its most recent poll. Whichever half polled it last used to
+// evict the other half's waker, leaving that half permanently unwoken.
+//
+// Both tests assert on elapsed time rather than merely on completion: wrapping
+// the stranded operation in a `timeout` masks the bug, because the timeout's
+// own timer wakes the task and lets the operation re-poll. The `timeout` calls
+// here are only guards, so that a regression fails the suite instead of
+// hanging it forever.
+
+/// The write half must still be woken when the read half polled the shared
+/// `Sleep` last.
 #[tokio::test]
 async fn split_wait_does_not_lose_writer_waker() {
     let socket = Builder::new()
@@ -23,6 +27,7 @@ async fn split_wait_does_not_lose_writer_waker() {
 
     let (mut recv, mut send) = tokio::io::split(socket);
 
+    // The read half polls the shared `Sleep` after the write half parks on it.
     let reader = tokio::spawn(async move {
         let _ = recv.read_u8().await;
     });
@@ -42,8 +47,8 @@ async fn split_wait_does_not_lose_writer_waker() {
     );
 }
 
-/// The same scenario with the roles reversed: the read half must still be woken
-/// when the write half is the one that polled the shared `Sleep` last.
+/// The mirror case: the read half must still be woken when the write half
+/// polled the shared `Sleep` last.
 #[tokio::test]
 async fn split_wait_does_not_lose_reader_waker() {
     let socket = Builder::new()
@@ -51,16 +56,25 @@ async fn split_wait_does_not_lose_reader_waker() {
         .read(b"z")
         .build();
 
-    let (mut recv, send) = tokio::io::split(socket);
+    let (mut recv, mut send) = tokio::io::split(socket);
 
     let start = Instant::now();
-    let byte = tokio::time::timeout(Duration::from_secs(5), recv.read_u8())
+
+    // Park the read half on the shared `Sleep` first.
+    let reader = tokio::spawn(async move { recv.read_u8().await });
+    tokio::task::yield_now().await;
+
+    // Then poll the write half, which drives the same `Sleep` and takes over
+    // the timer's single waker slot. This write never completes (the script
+    // has no `write` action), it only needs to poll the shared timer.
+    let _ = tokio::time::timeout(Duration::from_millis(50), send.write_u8(0)).await;
+
+    let byte = tokio::time::timeout(Duration::from_secs(5), reader)
         .await
         .expect("the read half was never woken")
+        .expect("the reader task panicked")
         .expect("read failed");
     let elapsed = start.elapsed();
-
-    drop(send);
 
     assert_eq!(byte, b'z');
     assert!(

--- a/tokio-test/tests/io_split_waker.rs
+++ b/tokio-test/tests/io_split_waker.rs
@@ -20,10 +20,13 @@ use tokio_test::io::Builder;
 // Note the assertions are on elapsed time rather than merely on completion:
 // the `timeout` guards would otherwise mask the bug, because a timeout's own
 // timer wakes the task and lets the stranded operation re-poll.
+//
+// The flavor is pinned explicitly: which half ends up evicting the other's
+// waker registration depends on the single-threaded poll ordering below.
 
 /// The write half must still be woken when the read half polled the shared
 /// `Sleep` last.
-#[tokio::test(start_paused = true)]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn split_wait_does_not_lose_writer_waker() {
     let socket = Builder::new()
         .wait(Duration::from_millis(10))
@@ -55,7 +58,7 @@ async fn split_wait_does_not_lose_writer_waker() {
 
 /// The mirror case: the read half must still be woken when the write half
 /// polled the shared `Sleep` last.
-#[tokio::test(start_paused = true)]
+#[tokio::test(flavor = "current_thread", start_paused = true)]
 async fn split_wait_does_not_lose_reader_waker() {
     let socket = Builder::new()
         .wait(Duration::from_millis(10))
@@ -70,12 +73,20 @@ async fn split_wait_does_not_lose_reader_waker() {
     let reader = tokio::spawn(async move { recv.read_u8().await });
     tokio::task::yield_now().await;
 
-    // Then park the write half on that same `Sleep`, which takes over the
-    // timer's single waker slot. This write never completes -- the script has
-    // no `write` action -- it only needs to poll the shared timer. It is left
-    // parked rather than polled to completion, because re-polling it after the
-    // read half drains the script would trip the mock's `unexpected write`
-    // panic.
+    // Then park the write half on that same `Sleep`, so it takes over the
+    // timer's single waker slot.
+    //
+    // This write is never driven to completion, and that is deliberate: a
+    // *successful* write calls `maybe_wakeup_reader`, which would wake the read
+    // half on its own and mask the bug this test is for. The script therefore
+    // has no `write` action, so once the wait elapses the write half settles in
+    // `poll_write`'s `Ok(0)` branch and stays parked.
+    //
+    // That branch returns `Poll::Pending` without registering a waker -- a
+    // separate, still-unfixed gap -- which is what keeps the write half from
+    // being polled again after the read half drains the script (which would
+    // trip the mock's `unexpected write` panic). If that gap is ever fixed,
+    // this test will need to hold the write half parked some other way.
     let writer = tokio::spawn(async move {
         let _ = send.write_u8(0).await;
     });

--- a/tokio-test/tests/io_split_waker.rs
+++ b/tokio-test/tests/io_split_waker.rs
@@ -1,0 +1,70 @@
+#![warn(rust_2018_idioms)]
+
+use std::time::{Duration, Instant};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_test::io::Builder;
+
+/// Regression test for #7445.
+///
+/// `poll_read` and `poll_write` drive the same `Sleep`, and a timer only stores
+/// the waker of its most recent poll. Whichever half polled it last used to
+/// evict the other half's waker, leaving that half permanently unwoken.
+///
+/// Note this asserts on elapsed time rather than simply on completion: wrapping
+/// the write in a `timeout` masks the bug, because the timeout's own timer wakes
+/// the task and lets the write re-poll. The `timeout` here is only a guard so a
+/// regression fails the suite instead of hanging it forever.
+#[tokio::test]
+async fn split_wait_does_not_lose_writer_waker() {
+    let socket = Builder::new()
+        .wait(Duration::from_millis(10))
+        .write([0].as_slice())
+        .build();
+
+    let (mut recv, mut send) = tokio::io::split(socket);
+
+    let reader = tokio::spawn(async move {
+        let _ = recv.read_u8().await;
+    });
+
+    let start = Instant::now();
+    tokio::time::timeout(Duration::from_secs(5), send.write_u8(0))
+        .await
+        .expect("the write half was never woken")
+        .expect("write failed");
+    let elapsed = start.elapsed();
+
+    reader.abort();
+
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "the write half lost its waker: a 10ms wait took {elapsed:?}"
+    );
+}
+
+/// The same scenario with the roles reversed: the read half must still be woken
+/// when the write half is the one that polled the shared `Sleep` last.
+#[tokio::test]
+async fn split_wait_does_not_lose_reader_waker() {
+    let socket = Builder::new()
+        .wait(Duration::from_millis(10))
+        .read(b"z")
+        .build();
+
+    let (mut recv, send) = tokio::io::split(socket);
+
+    let start = Instant::now();
+    let byte = tokio::time::timeout(Duration::from_secs(5), recv.read_u8())
+        .await
+        .expect("the read half was never woken")
+        .expect("read failed");
+    let elapsed = start.elapsed();
+
+    drop(send);
+
+    assert_eq!(byte, b'z');
+    assert!(
+        elapsed < Duration::from_millis(500),
+        "the read half lost its waker: a 10ms wait took {elapsed:?}"
+    );
+}

--- a/tokio-test/tests/io_split_waker.rs
+++ b/tokio-test/tests/io_split_waker.rs
@@ -1,7 +1,8 @@
 #![warn(rust_2018_idioms)]
 
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::time::Instant;
 use tokio_test::io::Builder;
 
 // Regression tests for #7445.
@@ -10,15 +11,19 @@ use tokio_test::io::Builder;
 // the waker of its most recent poll. Whichever half polled it last used to
 // evict the other half's waker, leaving that half permanently unwoken.
 //
-// Both tests assert on elapsed time rather than merely on completion: wrapping
-// the stranded operation in a `timeout` masks the bug, because the timeout's
-// own timer wakes the task and lets the operation re-poll. The `timeout` calls
-// here are only guards, so that a regression fails the suite instead of
-// hanging it forever.
+// These run on a paused clock, so they assert on virtual time and never depend
+// on how fast the machine is. A healthy run observes exactly the 10ms wait; a
+// stranded half instead runs out the multi-second guard, and the clock
+// auto-advances straight to it, so either outcome is reached in ~0s of real
+// time.
+//
+// Note the assertions are on elapsed time rather than merely on completion:
+// the `timeout` guards would otherwise mask the bug, because a timeout's own
+// timer wakes the task and lets the stranded operation re-poll.
 
 /// The write half must still be woken when the read half polled the shared
 /// `Sleep` last.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn split_wait_does_not_lose_writer_waker() {
     let socket = Builder::new()
         .wait(Duration::from_millis(10))
@@ -43,14 +48,14 @@ async fn split_wait_does_not_lose_writer_waker() {
     reader.abort();
 
     assert!(
-        elapsed < Duration::from_millis(500),
+        elapsed < Duration::from_secs(1),
         "the write half lost its waker: a 10ms wait took {elapsed:?}"
     );
 }
 
 /// The mirror case: the read half must still be woken when the write half
 /// polled the shared `Sleep` last.
-#[tokio::test]
+#[tokio::test(start_paused = true)]
 async fn split_wait_does_not_lose_reader_waker() {
     let socket = Builder::new()
         .wait(Duration::from_millis(10))
@@ -87,7 +92,7 @@ async fn split_wait_does_not_lose_reader_waker() {
 
     assert_eq!(byte, b'z');
     assert!(
-        elapsed < Duration::from_millis(500),
+        elapsed < Duration::from_secs(1),
         "the read half lost its waker: a 10ms wait took {elapsed:?}"
     );
 }

--- a/tokio-test/tests/io_split_waker.rs
+++ b/tokio-test/tests/io_split_waker.rs
@@ -27,7 +27,8 @@ async fn split_wait_does_not_lose_writer_waker() {
 
     let (mut recv, mut send) = tokio::io::split(socket);
 
-    // The read half polls the shared `Sleep` after the write half parks on it.
+    // The read half polls the shared `Sleep` after the write half parks on it,
+    // taking over the timer's single waker slot.
     let reader = tokio::spawn(async move {
         let _ = recv.read_u8().await;
     });
@@ -64,10 +65,16 @@ async fn split_wait_does_not_lose_reader_waker() {
     let reader = tokio::spawn(async move { recv.read_u8().await });
     tokio::task::yield_now().await;
 
-    // Then poll the write half, which drives the same `Sleep` and takes over
-    // the timer's single waker slot. This write never completes (the script
-    // has no `write` action), it only needs to poll the shared timer.
-    let _ = tokio::time::timeout(Duration::from_millis(50), send.write_u8(0)).await;
+    // Then park the write half on that same `Sleep`, which takes over the
+    // timer's single waker slot. This write never completes -- the script has
+    // no `write` action -- it only needs to poll the shared timer. It is left
+    // parked rather than polled to completion, because re-polling it after the
+    // read half drains the script would trip the mock's `unexpected write`
+    // panic.
+    let writer = tokio::spawn(async move {
+        let _ = send.write_u8(0).await;
+    });
+    tokio::task::yield_now().await;
 
     let byte = tokio::time::timeout(Duration::from_secs(5), reader)
         .await
@@ -75,6 +82,8 @@ async fn split_wait_does_not_lose_reader_waker() {
         .expect("the reader task panicked")
         .expect("read failed");
     let elapsed = start.elapsed();
+
+    writer.abort();
 
     assert_eq!(byte, b'z');
     assert!(


### PR DESCRIPTION
## Motivation

Splitting a `tokio_test::io::Mock` with `tokio::io::split` deadlocks as soon as the script contains a `wait()`. The repro from #7445 hangs forever:

```rust
#[tokio::test]
async fn check_io() {
    let socket = tokio_test::io::Builder::new()
        .wait(Duration::from_millis(10))
        .write([0].as_slice())
        .build();

    let (mut recv, mut send) = tokio::io::split(socket);
    tokio::spawn(async move { recv.read_u8().await.unwrap() });
    send.write_u8(0).await.unwrap();
}
```

`Inner` holds a single `sleep: Option<Pin<Box<Sleep>>>`, and both `poll_read` and `poll_write` begin by driving it:

```rust
if let Some(ref mut sleep) = self.inner.sleep {
    ready!(Pin::new(sleep).poll(cx));
}
```

A timer only stores the waker of its most recent poll. Under `split` the two halves are polled by independent tasks, so whichever half polls last evicts the other half's waker, and that half is never woken again. @ADD-SP diagnosed exactly this timeline in the issue.

## Solution

Keep the single shared `Sleep`, but have `Mock` retain both halves' wakers. `Inner` gains a `write_wait` slot alongside the existing `read_wait`, and the two duplicated sleep-polling blocks are replaced by one helper:

```rust
fn poll_sleep(&mut self, cx: &mut task::Context<'_>, half: Half) -> Poll<()>
```

On `Pending` it records the polling half's own waker; on `Ready` it wakes the other half, which may have had its registration replaced. This is the same "don't replace a waker someone else still needs" shape as #8279 and the `Sleep` waker retention added in #2217 / #2290.

Deliberately **not** giving each half its own timer: the `Sleep` stays shared, so `wait()` still describes one timeline for the whole `Mock` and `elapsed` is unchanged. That avoids the semantics question raised on #7468 about what `elapsed` should mean for a split mock — this change does not answer it, it avoids depending on the answer.

## Tests

Two regression tests covering both directions (write half stranded, read half stranded). They fail on `master` and pass with this change.

They run on a paused clock and assert on virtual elapsed time rather than merely on completion. Both details matter:

- a `timeout` around the stranded operation would otherwise *mask* the bug, because the timeout's own timer wakes the task and lets the operation re-poll;
- with the clock paused, a healthy run observes exactly the 10ms wait and a stranded one runs out the guard, both in ~0s of real time — no dependence on machine speed, and a regression fails immediately instead of costing seconds of CI.

## Notes for review

- The reader-side test leaves the write half parked in `poll_write`'s existing `Ok(0)` branch, which returns `Poll::Pending` without registering a waker. That is a separate, pre-existing gap that this PR does not touch; the test comment records the dependency. Driving that write to completion instead would call `maybe_wakeup_reader` and mask the bug being tested.
- `read_wait` now serves two purposes — the cross-half wake above, and the existing `maybe_wakeup_reader` park. Both only take and wake, so a wake arriving from either path is at worst an extra poll. Documented on `poll_sleep`.
- This does not help a half whose peer stops polling entirely: if the task holding the timer's waker is dropped, nobody observes the timer firing. Also documented.

Fixes #7445
