### PR TITLE
chore: prepare tokio-macros v2.7.2

### DIFF
--- a/tokio-macros/CHANGELOG.md
+++ b/tokio-macros/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 2.7.2 (July 29th, 2026)
+
+- macros: upgrade syn to v3 ([#8304])
+
+[#8304]: https://github.com/tokio-rs/tokio/pull/8304
+
 # 2.7.1 (July 17th, 2026)
 
 - macros: clarify `tokio::main` expansion ([#8193])

--- a/tokio-macros/Cargo.toml
+++ b/tokio-macros/Cargo.toml
@@ -4,7 +4,7 @@ name = "tokio-macros"
 # - Remove path dependencies (if any)
 # - Update CHANGELOG.md.
 # - Create "tokio-macros-x.y.z" git tag.
-version = "2.7.1"
+version = "2.7.2"
 edition = "2021"
 rust-version = "1.71"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
# 2.7.2 (July 29th, 2026)

- macros: upgrade syn to v3 (#8304)

(Feels like this doesn't need to be 2.8.0? Happy to change if that seems more appropriate.)