### PR TITLE
tokio-util: optimize buffer reserve for `LengthDelimitedCodec::encode`

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -627,8 +627,8 @@ impl Encoder<Bytes> for LengthDelimitedCodec {
         })?;
 
         // Reserve capacity in the destination buffer to fit the frame and
-        // length field (plus adjustment).
-        dst.reserve(self.builder.length_field_len + n);
+        // length field.
+        dst.reserve(self.builder.length_field_len + data.len());
 
         if self.builder.length_field_is_big_endian {
             dst.put_uint(n as u64, self.builder.length_field_len);


### PR DESCRIPTION
## Motivation

`LengthDelimitedCodec::encode` reserves `length_field_len + n`, where `n` is the
length *after* `length_adjustment` has been applied. It then writes
`length_field_len` bytes of header plus `data.len()` bytes of payload, so the
reservation only matches the write when `length_adjustment` is `0`.

With a 4-byte length field and a 100-byte payload the encoder always writes 104
bytes, but reserves for:

| `length_adjustment` | reserved for | written |
| --- | --- | --- |
| -4 | 108 | 104 |
| 0 | 104 | 104 |
| 2 | 102 | 104 |
| 5 | 99 | 104 |

Both adjusted shapes in the module docs are affected (`length_adjustment(2)` in
the "length field includes the head" example, and `length_adjustment(3 + 2)` in
the "length field is at an offset" one). `BytesMut` grows on demand so nothing is
lost, but the reservation stops doing its job: encoding 64 frames of 40 bytes
with `length_adjustment(8)` into an empty `BytesMut` changes capacity 7 times.

## Solution

Reserve `length_field_len + data.len()`, which is exactly what gets written.

This is the same fix as #7188, which corrected the equivalent hard-coded
delimiter length in `AnyDelimiterCodec::encode`.

No test is included, for the same reason as #7188: the observable effect is
`BytesMut` capacity, and an assertion on that is really an assertion on
allocator behaviour, which would pass either way unless the spare capacity is
tuned to sit between the under-reserved amount and the real need.

## Testing

- `cargo test -p tokio-util --features full`
- `rustfmt --check --edition 2021 tokio-util/src/codec/length_delimited.rs`
- `cargo clippy -p tokio-util --all-features --tests` (only pre-existing `tokio`
  lib warnings)
