### PR TITLE
time: handle wrapped top-level timer-wheel slots

### DIFF
--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -190,4 +190,113 @@ mod test {
             }
         }
     }
+
+    fn level_with(level: usize, occupied: u64) -> Level {
+        let mut level = Level::new(level);
+        level.occupied = occupied;
+        level
+    }
+
+    #[test]
+    fn next_occupied_slot_on_an_empty_level() {
+        assert_eq!(Level::new(0).next_occupied_slot(0), None);
+        assert_eq!(Level::new(5).next_occupied_slot(1 << 36), None);
+    }
+
+    #[test]
+    fn next_occupied_slot_of_a_single_slot() {
+        // slot 10 of level 0, i.e. tick 10 of every 64-tick window
+        let level = level_with(0, 1 << 10);
+
+        assert_eq!(level.next_occupied_slot(0), Some(10));
+        assert_eq!(level.next_occupied_slot(9), Some(10));
+        // `now` inside the slot itself, and past it
+        assert_eq!(level.next_occupied_slot(10), Some(10));
+        assert_eq!(level.next_occupied_slot(11), Some(10));
+        // `now` past the window: the slot is taken modulo 64
+        assert_eq!(level.next_occupied_slot(64 + 3), Some(10));
+    }
+
+    #[test]
+    fn next_occupied_slot_picks_the_nearest_slot_forward() {
+        let level = level_with(0, (1 << 10) | (1 << 40));
+
+        assert_eq!(level.next_occupied_slot(0), Some(10));
+        assert_eq!(level.next_occupied_slot(20), Some(40));
+        // nothing left ahead in this window, so the scan wraps to slot 10
+        assert_eq!(level.next_occupied_slot(41), Some(10));
+    }
+
+    #[test]
+    fn next_occupied_slot_skips_the_slot_holding_now() {
+        // The occurrence of slot 0 in this rotation has already started, so it
+        // can only be processed a full `level_range` later. Slot 1 is still
+        // ahead of `now` in this rotation and therefore expires first.
+        let level = level_with(5, 0b11);
+
+        assert_eq!(level.next_occupied_slot(0), Some(1));
+        assert_eq!(level.next_occupied_slot((1 << 30) - 1), Some(1));
+
+        // The same holds for any later slot, not just the adjacent one.
+        let level = level_with(5, 1 | (1 << 40));
+
+        assert_eq!(level.next_occupied_slot(0), Some(40));
+    }
+
+    #[test]
+    fn next_occupied_slot_of_the_slot_holding_now_when_it_is_the_only_one() {
+        // Nothing is ahead of `now`, so slot 0 is the earliest expiration even
+        // though it is reached only in the next rotation.
+        let level = level_with(5, 1);
+
+        assert_eq!(level.next_occupied_slot(0), Some(0));
+        assert_eq!(level.next_occupied_slot((1 << 30) - 1), Some(0));
+    }
+
+    #[test]
+    fn next_occupied_slot_of_the_last_slot() {
+        let level = level_with(5, 1 << 63);
+
+        assert_eq!(level.next_occupied_slot(62 << 30), Some(63));
+        assert_eq!(level.next_occupied_slot(63 << 30), Some(63));
+    }
+
+    #[test]
+    fn next_expiration_reports_the_start_of_the_slot() {
+        // slot 3 of level 1: slots are 64 ticks wide, so it starts at tick 192
+        let expiration = level_with(1, 1 << 3).next_expiration(100).unwrap();
+
+        assert_eq!(expiration.level, 1);
+        assert_eq!(expiration.slot, 3);
+        assert_eq!(expiration.deadline, 192);
+    }
+
+    #[test]
+    fn next_expiration_below_the_top_level() {
+        let level = level_with(4, 1 << 1);
+
+        assert_eq!(level.next_expiration(0).unwrap().deadline, 1 << 24);
+        assert_eq!(level.next_expiration(1000).unwrap().deadline, 1 << 24);
+    }
+
+    #[test]
+    fn next_expiration_at_the_top_level() {
+        let level = level_with(5, 1 << 1);
+
+        assert_eq!(level.next_expiration(0).unwrap().deadline, 1 << 30);
+        assert_eq!(level.next_expiration(1000).unwrap().deadline, 1 << 30);
+    }
+
+    #[test]
+    fn next_expiration_wraps_a_slot_at_or_behind_now() {
+        // Slot 0 of the top level starts at tick 0, so its next occurrence is a
+        // full rotation of the level away.
+        let level = level_with(5, 1 << 0);
+
+        assert_eq!(level.next_expiration(0).unwrap().deadline, 1 << 36);
+        assert_eq!(
+            level.next_expiration((1 << 30) + 10).unwrap().deadline,
+            1 << 36
+        );
+    }
 }

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -111,8 +111,15 @@ impl Level {
             return None;
         }
 
-        // Get the slot for now using Maths
-        let now_slot = (now / slot_range(self.level)) as usize;
+        // Add the +1 offset for the `now_slot` to ignore the slot that `now` fits in,
+        // since it's the farthest timer that could appear from `now`.
+        // This is mostly relevant for the top level because it acts as a
+        // pseudo-ring buffer: timers that would logically go past the top level are
+        // fudged into it by `level_for` and the `MAX_DURATION` cap, so the slot holding
+        // `now` can be occupied by an entry that is a whole rotation away.
+        // For the lower levels `level_for` always places an entry in a slot other
+        // than the one holding `now`, so `now_slot` is always empty there.
+        let now_slot = ((now / slot_range(self.level)) % LEVEL_MULT as u64) as usize + 1;
         let occupied = self.occupied.rotate_right(now_slot as u32);
         let zeros = occupied.trailing_zeros() as usize;
         let slot = (zeros + now_slot) % LEVEL_MULT;

--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -131,7 +131,12 @@ impl Level {
     pub(crate) unsafe fn remove_entry(&mut self, item: NonNull<TimerShared>) {
         let slot = slot_for(unsafe { item.as_ref().registered_when() }, self.level);
 
-        unsafe { self.slot[slot].remove(item) };
+        unsafe {
+            assert!(
+                self.slot[slot].remove(item).is_some(),
+                "Attempt to remove item not present in the timing wheel"
+            )
+        };
         if self.slot[slot].is_empty() {
             // The bit is currently set
             debug_assert!(self.occupied & occupied_bit(slot) != 0);

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -292,6 +292,8 @@ fn level_for(elapsed: u64, when: u64) -> usize {
 
 #[cfg(all(test, not(loom)))]
 mod test {
+    use std::pin::Pin;
+
     use super::*;
 
     #[test]
@@ -328,5 +330,179 @@ mod test {
                 }
             }
         }
+    }
+
+    #[must_use]
+    fn insert_entry(wheel: &mut Wheel, when: u64) -> Pin<Box<TimerShared>> {
+        let entry = Box::pin(TimerShared::new());
+
+        unsafe { entry.set_expiration(when) };
+
+        unsafe { wheel.insert(entry.as_ref().handle()).unwrap() };
+
+        entry
+    }
+
+    #[test]
+    fn test_next_expiration_to_level_4() {
+        let wheel = &mut Wheel::new();
+
+        // that should occupy slot 1 of the level 4 of the wheel
+        let when = (1 << 24) + 10;
+
+        let _entry = insert_entry(wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+        // next expiration should be calculated as the start of the level 4 range
+        assert_eq!(expiration, Some(1 << 24));
+
+        // set the elapsed to the start of the previous expiration
+        wheel.poll(1 << 24);
+
+        let expiration = wheel.next_expiration_time();
+        // that should be equal of the LEVEL_WHEN which is 10 ms after previous expiration
+        assert_eq!(expiration, Some(when));
+
+        wheel.poll(when);
+
+        assert!(wheel.next_expiration().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_to_level_5() {
+        let wheel = &mut Wheel::new();
+
+        // that will occupy slot 1 of the level 5 of the wheel
+        let when = (1 << 30) + 10;
+        let _entry = insert_entry(wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(1 << 30));
+
+        // set the elapsed to the start of the previous expiration
+        wheel.poll(1 << 30);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some((1 << 30) + 10));
+
+        wheel.poll(when);
+
+        assert!(wheel.next_expiration().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_after_level_5() {
+        let wheel = &mut Wheel::new();
+
+        // that will occupy slot 0 of the level 5 of the wheel
+        let when = (1 << 36) + 5;
+        let _entry = insert_entry(wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // that should come after the wheel
+        assert_eq!(expiration, Some(1 << 36));
+
+        // set the elapsed to the start of the previous expiration
+        wheel.poll(1 << 36);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(when));
+
+        wheel.poll(when);
+
+        assert!(wheel.next_expiration_time().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_after_level_5_twice() {
+        let wheel = &mut Wheel::new();
+
+        // that will occupy slot 0 of the level 5 of the wheel
+        let when = (1 << 37) + 5;
+        let _entry = insert_entry(wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // that should come after the wheel
+        assert_eq!(expiration, Some(1 << 36));
+
+        // set the elapsed to the start of the previous expiration
+        wheel.poll(1 << 36);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(1 << 37));
+
+        wheel.poll(1 << 37);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(when));
+
+        wheel.poll(when);
+
+        assert!(wheel.next_expiration_time().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_to_level_5_and_after_level_5() {
+        let wheel = &mut Wheel::new();
+
+        // that will occupy slot 0 of the level 5 of the wheel
+        let when = (1 << 36) + 1;
+        let _entry = insert_entry(wheel, when);
+
+        // that will occupy slot 1 of the level 5 of the wheel
+        let when = (1 << 30) + 10;
+        let _entry = insert_entry(wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // this should point to the expiration of the slot 1 entry
+        // and not the slot 0 that is higher than 2^36
+        assert_eq!(expiration, Some(1 << 30));
+
+        // set the elapsed to the start of the previous expiration
+        wheel.poll(1 << 30);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some((1 << 30) + 10));
+
+        wheel.poll(when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // The next expiration show refer the next loop of top level
+        assert_eq!(expiration, Some(1 << 36));
+    }
+
+    #[test]
+    fn test_next_expiration_at_slot_5_of_the_top_level() {
+        let wheel = &mut Wheel::new();
+
+        // move the wheel into slot 5 of the top level
+        wheel.poll(5 << 30);
+
+        // that will occupy slot 5 of the level 5 of the wheel, the same slot the
+        // elapsed time sits in, so it is reachable only one rotation of the
+        // level later
+        let when = (1 << 36) + (5 << 30) + 1;
+        let _entry = insert_entry(wheel, when);
+
+        // that will occupy slot 20 of the level 5 of the wheel, still ahead in
+        // the current rotation
+        let when = (20 << 30) + 10;
+        let _entry = insert_entry(wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // this should point to the start of the slot 20 and not to the slot 5
+        // that comes around only after the whole level rotates
+        assert_eq!(expiration, Some(20 << 30));
     }
 }

--- a/tokio/src/runtime/time_alt/wheel/level.rs
+++ b/tokio/src/runtime/time_alt/wheel/level.rs
@@ -112,8 +112,15 @@ impl Level {
             return None;
         }
 
-        // Get the slot for now using Maths
-        let now_slot = (now / slot_range(self.level)) as usize;
+        // Add the +1 offset for the `now_slot` to ignore the slot that `now` fits in,
+        // since it's the farthest timer that could appear from `now`.
+        // This is mostly relevant for the top level because it acts as a
+        // pseudo-ring buffer: timers that would logically go past the top level are
+        // fudged into it by `level_for` and the `MAX_DURATION` cap, so the slot holding
+        // `now` can be occupied by an entry that is a whole rotation away.
+        // For the lower levels `level_for` always places an entry in a slot other
+        // than the one holding `now`, so `now_slot` is always empty there.
+        let now_slot = ((now / slot_range(self.level)) % LEVEL_MULT as u64) as usize + 1;
         let occupied = self.occupied.rotate_right(now_slot as u32);
         let zeros = occupied.trailing_zeros() as usize;
         let slot = (zeros + now_slot) % LEVEL_MULT;
@@ -197,5 +204,114 @@ mod test {
                 assert_eq!(pos, slot_for(a as u64, level));
             }
         }
+    }
+
+    fn level_with(level: usize, occupied: u64) -> Level {
+        let mut level = Level::new(level);
+        level.occupied = occupied;
+        level
+    }
+
+    #[test]
+    fn next_occupied_slot_on_an_empty_level() {
+        assert_eq!(Level::new(0).next_occupied_slot(0), None);
+        assert_eq!(Level::new(5).next_occupied_slot(1 << 36), None);
+    }
+
+    #[test]
+    fn next_occupied_slot_of_a_single_slot() {
+        // slot 10 of level 0, i.e. tick 10 of every 64-tick window
+        let level = level_with(0, 1 << 10);
+
+        assert_eq!(level.next_occupied_slot(0), Some(10));
+        assert_eq!(level.next_occupied_slot(9), Some(10));
+        // `now` inside the slot itself, and past it
+        assert_eq!(level.next_occupied_slot(10), Some(10));
+        assert_eq!(level.next_occupied_slot(11), Some(10));
+        // `now` past the window: the slot is taken modulo 64
+        assert_eq!(level.next_occupied_slot(64 + 3), Some(10));
+    }
+
+    #[test]
+    fn next_occupied_slot_picks_the_nearest_slot_forward() {
+        let level = level_with(0, (1 << 10) | (1 << 40));
+
+        assert_eq!(level.next_occupied_slot(0), Some(10));
+        assert_eq!(level.next_occupied_slot(20), Some(40));
+        // nothing left ahead in this window, so the scan wraps to slot 10
+        assert_eq!(level.next_occupied_slot(41), Some(10));
+    }
+
+    #[test]
+    fn next_occupied_slot_skips_the_slot_holding_now() {
+        // The occurrence of slot 0 in this rotation has already started, so it
+        // can only be processed a full `level_range` later. Slot 1 is still
+        // ahead of `now` in this rotation and therefore expires first.
+        let level = level_with(5, 0b11);
+
+        assert_eq!(level.next_occupied_slot(0), Some(1));
+        assert_eq!(level.next_occupied_slot((1 << 30) - 1), Some(1));
+
+        // The same holds for any later slot, not just the adjacent one.
+        let level = level_with(5, 1 | (1 << 40));
+
+        assert_eq!(level.next_occupied_slot(0), Some(40));
+    }
+
+    #[test]
+    fn next_occupied_slot_of_the_slot_holding_now_when_it_is_the_only_one() {
+        // Nothing is ahead of `now`, so slot 0 is the earliest expiration even
+        // though it is reached only in the next rotation.
+        let level = level_with(5, 1);
+
+        assert_eq!(level.next_occupied_slot(0), Some(0));
+        assert_eq!(level.next_occupied_slot((1 << 30) - 1), Some(0));
+    }
+
+    #[test]
+    fn next_occupied_slot_of_the_last_slot() {
+        let level = level_with(5, 1 << 63);
+
+        assert_eq!(level.next_occupied_slot(62 << 30), Some(63));
+        assert_eq!(level.next_occupied_slot(63 << 30), Some(63));
+    }
+
+    #[test]
+    fn next_expiration_reports_the_start_of_the_slot() {
+        // slot 3 of level 1: slots are 64 ticks wide, so it starts at tick 192
+        let expiration = level_with(1, 1 << 3).next_expiration(100).unwrap();
+
+        assert_eq!(expiration.level, 1);
+        assert_eq!(expiration.slot, 3);
+        assert_eq!(expiration.deadline, 192);
+    }
+
+    #[test]
+    fn next_expiration_below_the_top_level() {
+        let level = level_with(4, 1 << 1);
+
+        assert_eq!(level.next_expiration(0).unwrap().deadline, 1 << 24);
+        assert_eq!(level.next_expiration(1000).unwrap().deadline, 1 << 24);
+    }
+
+    #[test]
+    fn next_expiration_at_the_top_level() {
+        let level = level_with(5, 1 << 1);
+
+        assert_eq!(level.next_expiration(0).unwrap().deadline, 1 << 30);
+        assert_eq!(level.next_expiration(1000).unwrap().deadline, 1 << 30);
+    }
+
+    #[test]
+    fn next_expiration_wraps_a_slot_at_or_behind_now() {
+        // Slot 0 of the top level starts at tick 0, so its next occurrence is a
+        // full rotation of the level away.
+        let level = level_with(5, 1 << 0);
+
+        assert_eq!(level.next_expiration(0).unwrap().deadline, 1 << 36);
+        assert_eq!(
+            level.next_expiration((1 << 30) + 10).unwrap().deadline,
+            1 << 36
+        );
     }
 }

--- a/tokio/src/runtime/time_alt/wheel/level.rs
+++ b/tokio/src/runtime/time_alt/wheel/level.rs
@@ -134,7 +134,12 @@ impl Level {
     pub(crate) unsafe fn remove_entry(&mut self, hdl: EntryHandle) {
         let slot = slot_for(hdl.deadline(), self.level);
 
-        unsafe { self.slot[slot].remove(NonNull::from(&hdl)) };
+        unsafe {
+            assert!(
+                self.slot[slot].remove(NonNull::from(&hdl)).is_some(),
+                "Attempt to remove item not present in the timing wheel"
+            )
+        };
         if self.slot[slot].is_empty() {
             // The bit is currently set
             debug_assert!(self.occupied & occupied_bit(slot) != 0);

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -236,6 +236,7 @@ fn level_for(elapsed: u64, when: u64) -> usize {
 
 #[cfg(all(test, not(loom)))]
 mod test {
+    use super::super::cancellation_queue;
     use super::*;
 
     #[test]
@@ -272,5 +273,181 @@ mod test {
                 }
             }
         }
+    }
+
+    #[must_use]
+    fn insert_entry(wheel: &mut Wheel, when: u64) -> EntryHandle {
+        let (cancel_tx, _cancel_rx) = cancellation_queue::new();
+        let hdl = EntryHandle::new(when);
+        unsafe { wheel.insert(hdl.clone(), cancel_tx) };
+        hdl
+    }
+
+    fn poll(wheel: &mut Wheel, now: u64) {
+        let mut wq = WakeQueue::new();
+        wheel.take_expired(now, &mut wq);
+    }
+
+    #[test]
+    fn test_next_expiration_to_level_4() {
+        let mut wheel = Wheel::new();
+
+        // that should occupy slot 1 of the level 4 of the wheel
+        let when = (1 << 24) + 10;
+
+        let _entry = insert_entry(&mut wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+        // next expiration should be calculated as the start of the level 4 range
+        assert_eq!(expiration, Some(1 << 24));
+
+        // set the elapsed to the start of the previous expiration
+        poll(&mut wheel, 1 << 24);
+
+        let expiration = wheel.next_expiration_time();
+        // that should be equal of the LEVEL_WHEN which is 10 ms after previous expiration
+        assert_eq!(expiration, Some(when));
+
+        poll(&mut wheel, when);
+
+        assert!(wheel.next_expiration_time().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_to_level_5() {
+        let mut wheel = Wheel::new();
+
+        // that will occupy slot 1 of the level 5 of the wheel
+        let when = (1 << 30) + 10;
+        let _entry = insert_entry(&mut wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(1 << 30));
+
+        // set the elapsed to the start of the previous expiration
+        poll(&mut wheel, 1 << 30);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some((1 << 30) + 10));
+
+        poll(&mut wheel, when);
+
+        assert!(wheel.next_expiration_time().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_after_level_5() {
+        let mut wheel = Wheel::new();
+
+        // that will occupy slot 0 of the level 5 of the wheel
+        let when = (1 << 36) + 5;
+        let _entry = insert_entry(&mut wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // that should come after the wheel
+        assert_eq!(expiration, Some(1 << 36));
+
+        // set the elapsed to the start of the previous expiration
+        poll(&mut wheel, 1 << 36);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(when));
+
+        poll(&mut wheel, when);
+
+        assert!(wheel.next_expiration_time().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_after_level_5_twice() {
+        let mut wheel = Wheel::new();
+
+        // that will occupy slot 0 of the level 5 of the wheel
+        let when = (1 << 37) + 5;
+        let _entry = insert_entry(&mut wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // that should come after the wheel
+        assert_eq!(expiration, Some(1 << 36));
+
+        // set the elapsed to the start of the previous expiration
+        poll(&mut wheel, 1 << 36);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(1 << 37));
+
+        poll(&mut wheel, 1 << 37);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some(when));
+
+        poll(&mut wheel, when);
+
+        assert!(wheel.next_expiration_time().is_none());
+    }
+
+    #[test]
+    fn test_next_expiration_to_level_5_and_after_level_5() {
+        let mut wheel = Wheel::new();
+
+        // that will occupy slot 0 of the level 5 of the wheel
+        let when = (1 << 36) + 1;
+        let _entry = insert_entry(&mut wheel, when);
+
+        // that will occupy slot 1 of the level 5 of the wheel
+        let when = (1 << 30) + 10;
+        let _entry = insert_entry(&mut wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // this should point to the expiration of the slot 1 entry
+        // and not the slot 0 that is higher than 2^36
+        assert_eq!(expiration, Some(1 << 30));
+
+        // set the elapsed to the start of the previous expiration
+        poll(&mut wheel, 1 << 30);
+
+        let expiration = wheel.next_expiration_time();
+
+        assert_eq!(expiration, Some((1 << 30) + 10));
+
+        poll(&mut wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // The next expiration show refer the next loop of top level
+        assert_eq!(expiration, Some(1 << 36));
+    }
+
+    #[test]
+    fn test_next_expiration_at_slot_5_of_the_top_level() {
+        let mut wheel = Wheel::new();
+
+        // move the wheel into slot 5 of the top level
+        poll(&mut wheel, 5 << 30);
+
+        // that will occupy slot 5 of the level 5 of the wheel, the same slot the
+        // elapsed time sits in, so it is reachable only one rotation of the
+        // level later
+        let when = (1 << 36) + (5 << 30) + 1;
+        let _entry = insert_entry(&mut wheel, when);
+
+        // that will occupy slot 20 of the level 5 of the wheel, still ahead in
+        // the current rotation
+        let when = (20 << 30) + 10;
+        let _entry = insert_entry(&mut wheel, when);
+
+        let expiration = wheel.next_expiration_time();
+
+        // this should point to the start of the slot 20 and not to the slot 5
+        // that comes around only after the whole level rotates
+        assert_eq!(expiration, Some(20 << 30));
     }
 }

--- a/tokio/tests/time_sleep.rs
+++ b/tokio/tests/time_sleep.rs
@@ -289,6 +289,39 @@ async fn no_out_of_bounds_close_to_max() {
     time::sleep(Duration::MAX - Duration::from_millis(1)).await;
 }
 
+#[tokio::test(start_paused = true)]
+async fn long_wait_sleep_does_not_break_other_timers() {
+    tokio::spawn(time::sleep(ms(10 << 36)));
+
+    time::advance(ms((1 << 30) - 1)).await;
+
+    let start = Instant::now();
+    time::sleep(ms(10)).await;
+    assert_elapsed!(start, ms(10));
+}
+
+#[tokio::test(start_paused = true)]
+async fn long_wait_sleep_does_not_corrupt_wheel() {
+    use futures::poll;
+
+    tokio::spawn(time::sleep(ms(10 << 36)));
+
+    time::advance(ms((1 << 30) - 1)).await;
+
+    let mut first = Box::pin(time::sleep(ms(10)));
+    assert_pending!(poll!(first.as_mut()));
+    let mut second = Box::pin(time::sleep(ms(20)));
+    assert_pending!(poll!(second.as_mut()));
+
+    time::advance(ms(30)).await;
+
+    drop(first);
+
+    time::advance(ms(1 << 31)).await;
+
+    drop(second);
+}
+
 fn ms(n: u64) -> Duration {
     Duration::from_millis(n)
 }


### PR DESCRIPTION
## Motivation

During investigation of the report https://github.com/pgdogdev/pgdog/issues/1017 that mentioned that the sleep/interval tasks were silently hanging after 12 days of uptime I was able to reproduce the issue with hanging timers after reaching top level of the timer wheel in tokio.

Here are some test code that helped me to reproduce it by imitating the proper conditions:
- https://github.com/meskill/tokio/pull/1
- https://github.com/meskill/tokio/pull/2

The prerequisites for reproduction are one long sleep delay like [this](https://github.com/pgdogdev/pgdog/blob/main/pgdog-config/src/lib.rs#L49) and the uptime reaching the 12 days.

## Observed behavior

First of all it's the mentioned hanging of the background tasks - after 12 days the tasks we're running periodically with the interval (1-15 seconds) stop running.

### Debug build

On the local build with debug_asserts the following logs could appear.

On the shutdown when the broken timers are dropped, multiple errors like this:
```
thread 'tokio-rt-worker' (2223576) panicked at /proc/self/cwd/src/runtime/time/wheel/mod.rs:135:17:
elapsed=9358; when=4336
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/panicking.rs:80:14
   2: <tokio::runtime::time::wheel::Wheel>::remove
             at /proc/self/cwd/src/runtime/time/wheel/mod.rs:135:17
   3: <tokio::runtime::time::handle::Handle>::clear_entry
             at /proc/self/cwd/src/runtime/time/mod.rs:385:28
   4: <tokio::runtime::time::entry::TimerEntry>::cancel
             at /proc/self/cwd/src/runtime/time/entry.rs:519:32
   5: <tokio::runtime::time::entry::TimerEntry as core::ops::drop::Drop>::drop::__drop_inner
             at /proc/self/cwd/src/runtime/time/entry.rs:302:18
   6: <tokio::runtime::time::entry::TimerEntry as core::ops::drop::Drop>::drop
             at /kache/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/pin-project-lite-0.2.17/src/lib.rs:1374:17
   7: core::ptr::drop_in_place::<tokio::runtime::time::entry::TimerEntry>
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/ptr/mod.rs:810:1
```

or occasional panics like this during the load (when many timers are created and dropped):
```
thread 'tokio-rt-worker' (2282006) panicked at /proc/self/cwd/src/util/linked_list.rs:204:13:
assertion `left == right` failed
  left: None
 right: Some(0x704f3c1eb108)
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/panicking.rs:80:14
   2: core::panicking::assert_failed_inner
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/panicking.rs:439:17
   3: core::panicking::assert_failed::<core::option::Option<core::ptr::non_null::NonNull<tokio::runtime::time::entry::TimerShared>>, core::option::Option<core::ptr::non_null::NonNull<tokio::runtime::time::entry::TimerShared>>>
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/panicking.rs:394:5
   4: <tokio::util::linked_list::LinkedList<tokio::runtime::time::entry::TimerShared>>::remove
             at /proc/self/cwd/src/util/linked_list.rs:204:13
   5: <tokio::runtime::time::wheel::level::Level>::remove_entry
             at /proc/self/cwd/src/runtime/time/wheel/level.rs:134:34
   6: <tokio::runtime::time::wheel::Wheel>::remove
             at /proc/self/cwd/src/runtime/time/wheel/mod.rs:143:36
   7: <tokio::runtime::time::handle::Handle>::clear_entry
             at /proc/self/cwd/src/runtime/time/mod.rs:385:28
   8: <tokio::runtime::time::entry::TimerEntry>::cancel
             at /proc/self/cwd/src/runtime/time/entry.rs:519:32
   9: <tokio::runtime::time::entry::TimerEntry as core::ops::drop::Drop>::drop::__drop_inner
             at /proc/self/cwd/src/runtime/time/entry.rs:302:18
             
 thread 'tokio-rt-worker' (2282006) panicked at /proc/self/cwd/src/runtime/time/wheel/level.rs:137:13:
assertion failed: self.occupied & occupied_bit(slot) != 0
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/std/src/panicking.rs:689:5
   1: core::panicking::panic_fmt
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/panicking.rs:80:14
   2: core::panicking::panic
             at /rustc/ac68faa20c58cbccd01ee7208bf3b6e93a7d7f96/library/core/src/panicking.rs:150:5
   3: <tokio::runtime::time::wheel::level::Level>::remove_entry
             at /proc/self/cwd/src/runtime/time/wheel/level.rs:137:13
   4: <tokio::runtime::time::wheel::Wheel>::remove
             at /proc/self/cwd/src/runtime/time/wheel/mod.rs:143:36
   5: <tokio::runtime::time::handle::Handle>::clear_entry
             at /proc/self/cwd/src/runtime/time/mod.rs:385:28
   6: <tokio::runtime::time::entry::TimerEntry>::cancel
             at /proc/self/cwd/src/runtime/time/entry.rs:519:32
   7: <tokio::runtime::time::entry::TimerEntry as core::ops::drop::Drop>::drop::__drop_inner
             at /proc/self/cwd/src/runtime/time/entry.rs:302:18
```

### Prod build

Since some debug_asserts are compiled out the tokio code goes deeper and breaks in some other places:

```
thread 'tokio-rt-worker' (2471830) panicked at /proc/self/cwd/src/util/linked_list.rs:188:9:
assertion failed: self.tail.is_none()
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: <tokio::runtime::time::wheel::Wheel>::remove
   4: <tokio::runtime::time::entry::TimerEntry as core::ops::drop::Drop>::drop
   5: core::ptr::drop_in_place::<core::option::Option<tokio::runtime::Timer>>
   6: core::ptr::drop_in_place::<(tokio::sync::notify::Notified, <pgdog::frontend::client::query_engine::QueryEngine>::read_backend::{closure#0}, <pgdog::frontend::client::Client>::buffer::{closure#0})>
   
 thread 'tokio-rt-worker' (2471830) panicked at /proc/self/cwd/src/runtime/time/entry.rs:181:13:
mark_pending called when the timer entry is in an invalid state
stack backtrace:
   0: __rustc::rust_begin_unwind
   1: core::panicking::panic_fmt
   2: <tokio::runtime::time::handle::Handle>::process_at_time
   3: <tokio::runtime::driver::Driver>::shutdown
   4: tokio::runtime::task::raw::poll::<tokio::runtime::blocking::task::BlockingTask<<tokio::runtime::scheduler::multi_thread::worker::Launch>::launch::{closure#0}>, tokio::runtime::blocking::schedule::BlockingSchedule>
```

## Root cause

When the elapsed time of the tokio timer wheel reaches 12 days the new short sleeps and intervals got queued on the top level 5 of the wheel. But the initially queued timer for i64::MAX ms occupied the 0 slot that is also probed as the now_slot of the current elapsed time. And because of this - we were checking the 0 slot and the 0 slot has the entry so we pick this entry as a closest entry for the next deadline, ignoring next slots that may contain actually closest next timers. 

This can also cause the corruption of the LinkedList storage for slot entries (in prod without debug_asserts) - some of the entries were ignored and not cascaded to the lower levels that. Because of this when such entries were removed from list the wheel wrongly identifies level for it and therefore the wrong LinkedList instance was picked that was caused the changing of shape for the unrelated slot (when the entry is around head/tail) and eventually causing the mess in pointers and some of the checks (see errors above).

The issue is related only to the top level of the wheel because this level queues all the entries for it and further away and because of this the long standing timer go to the top level. 

The issue is not reproducible without setting the long delay (more than default 2^36 ms) and required reaching the 2^30 ms (12 days)

## Solution

I added unit tests to verify how the wheel behaves when reaching last levels of wheel and to verify that the slot with the closest time is picked instead of the slot identified with now. And the integrations tests that challenge couple of timers after setting one long sleep.

The fix is to properly calculate the next slot by rotating the slots buffer on the one step more to ignore exactly slot for now and use the next slots instead. 

The solution copied into alternative timers and both were verified in our app that it works and fixes the hanging.

I purposefully ignored the tokio-util timer wheel implementation since I was not sure if it requires the fix and/or I should fix anything there since it works slightly different and I believe based on the old version of timer wheel from tokio.