### PR TITLE
time: simplify wheel constants

### DIFF
--- a/tokio/src/runtime/time/wheel/level.rs
+++ b/tokio/src/runtime/time/wheel/level.rs
@@ -36,7 +36,7 @@ pub(crate) struct Expiration {
 /// Level multiplier.
 ///
 /// Being a power of 2 is very important.
-const LEVEL_MULT: usize = 64;
+const LEVEL_MULT: usize = 1 << super::BITS_PER_LEVEL;
 
 impl Level {
     pub(crate) fn new(level: usize) -> Level {
@@ -161,16 +161,16 @@ fn occupied_bit(slot: usize) -> u64 {
 }
 
 fn slot_range(level: usize) -> u64 {
-    LEVEL_MULT.pow(level as u32) as u64
+    1 << (super::BITS_PER_LEVEL * level)
 }
 
 fn level_range(level: usize) -> u64 {
-    LEVEL_MULT as u64 * slot_range(level)
+    1 << (super::BITS_PER_LEVEL * (level + 1))
 }
 
 /// Converts a duration (milliseconds) and a level to a slot position.
 fn slot_for(duration: u64, level: usize) -> usize {
-    ((duration >> (level * 6)) % LEVEL_MULT as u64) as usize
+    ((duration >> (level * super::BITS_PER_LEVEL)) % LEVEL_MULT as u64) as usize
 }
 
 #[cfg(all(test, not(loom)))]

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -44,8 +44,10 @@ pub(crate) struct Wheel {
 /// precision of 1 millisecond.
 const NUM_LEVELS: usize = 6;
 
+const BITS_PER_LEVEL: usize = 6;
+
 /// The maximum duration of a `Sleep`.
-pub(super) const MAX_DURATION: u64 = (1 << (6 * NUM_LEVELS)) - 1;
+const MAX_DURATION: u64 = (1 << (BITS_PER_LEVEL * NUM_LEVELS)) - 1;
 
 impl Wheel {
     /// Creates a new timing wheel.
@@ -273,21 +275,18 @@ impl Wheel {
 }
 
 fn level_for(elapsed: u64, when: u64) -> usize {
-    const SLOT_MASK: u64 = (1 << 6) - 1;
+    const SLOT_MASK: u64 = (1 << BITS_PER_LEVEL) - 1;
 
     // Mask in the trailing bits ignored by the level calculation in order to cap
     // the possible leading zeros
-    let mut masked = elapsed ^ when | SLOT_MASK;
+    let masked = elapsed ^ when | SLOT_MASK;
 
     if masked >= MAX_DURATION {
         // Fudge the timer into the top level
-        masked = MAX_DURATION - 1;
+        return NUM_LEVELS - 1;
     }
 
-    let leading_zeros = masked.leading_zeros() as usize;
-    let significant = 63 - leading_zeros;
-
-    significant / NUM_LEVELS
+    masked.ilog2() as usize / BITS_PER_LEVEL
 }
 
 #[cfg(all(test, not(loom)))]

--- a/tokio/src/runtime/time/wheel/mod.rs
+++ b/tokio/src/runtime/time/wheel/mod.rs
@@ -47,7 +47,7 @@ const NUM_LEVELS: usize = 6;
 const BITS_PER_LEVEL: usize = 6;
 
 /// The maximum duration of a `Sleep`.
-const MAX_DURATION: u64 = (1 << (BITS_PER_LEVEL * NUM_LEVELS)) - 1;
+const MAX_DURATION: u64 = 1 << (BITS_PER_LEVEL * NUM_LEVELS);
 
 impl Wheel {
     /// Creates a new timing wheel.

--- a/tokio/src/runtime/time_alt/wheel/level.rs
+++ b/tokio/src/runtime/time_alt/wheel/level.rs
@@ -37,7 +37,7 @@ pub(crate) struct Expiration {
 /// Level multiplier.
 ///
 /// Being a power of 2 is very important.
-const LEVEL_MULT: usize = 64;
+const LEVEL_MULT: usize = 1 << super::BITS_PER_LEVEL;
 
 impl Level {
     pub(crate) fn new(level: usize) -> Level {
@@ -164,16 +164,16 @@ fn occupied_bit(slot: usize) -> u64 {
 }
 
 fn slot_range(level: usize) -> u64 {
-    LEVEL_MULT.pow(level as u32) as u64
+    1 << (super::BITS_PER_LEVEL * level)
 }
 
 fn level_range(level: usize) -> u64 {
-    LEVEL_MULT as u64 * slot_range(level)
+    1 << (super::BITS_PER_LEVEL * (level + 1))
 }
 
 /// Converts a duration (milliseconds) and a level to a slot position.
 fn slot_for(duration: u64, level: usize) -> usize {
-    ((duration >> (level * 6)) % LEVEL_MULT as u64) as usize
+    ((duration >> (level * super::BITS_PER_LEVEL)) % LEVEL_MULT as u64) as usize
 }
 
 #[cfg(all(test, not(loom)))]

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -35,8 +35,10 @@ pub(crate) struct Wheel {
 /// precision of 1 millisecond.
 const NUM_LEVELS: usize = 6;
 
+const BITS_PER_LEVEL: usize = 6;
+
 /// The maximum duration of a `Sleep`.
-pub(super) const MAX_DURATION: u64 = (1 << (6 * NUM_LEVELS)) - 1;
+const MAX_DURATION: u64 = (1 << (BITS_PER_LEVEL * NUM_LEVELS)) - 1;
 
 impl Wheel {
     /// Creates a new timing wheel.
@@ -217,21 +219,18 @@ impl Wheel {
 }
 
 fn level_for(elapsed: u64, when: u64) -> usize {
-    const SLOT_MASK: u64 = (1 << 6) - 1;
+    const SLOT_MASK: u64 = (1 << BITS_PER_LEVEL) - 1;
 
     // Mask in the trailing bits ignored by the level calculation in order to cap
     // the possible leading zeros
-    let mut masked = elapsed ^ when | SLOT_MASK;
+    let masked = elapsed ^ when | SLOT_MASK;
 
     if masked >= MAX_DURATION {
         // Fudge the timer into the top level
-        masked = MAX_DURATION - 1;
+        return NUM_LEVELS - 1;
     }
 
-    let leading_zeros = masked.leading_zeros() as usize;
-    let significant = 63 - leading_zeros;
-
-    significant / NUM_LEVELS
+    masked.ilog2() as usize / BITS_PER_LEVEL
 }
 
 #[cfg(all(test, not(loom)))]

--- a/tokio/src/runtime/time_alt/wheel/mod.rs
+++ b/tokio/src/runtime/time_alt/wheel/mod.rs
@@ -38,7 +38,7 @@ const NUM_LEVELS: usize = 6;
 const BITS_PER_LEVEL: usize = 6;
 
 /// The maximum duration of a `Sleep`.
-const MAX_DURATION: u64 = (1 << (BITS_PER_LEVEL * NUM_LEVELS)) - 1;
+const MAX_DURATION: u64 = 1 << (BITS_PER_LEVEL * NUM_LEVELS);
 
 impl Wheel {
     /// Creates a new timing wheel.


### PR DESCRIPTION
## Motivation

The timer wheel's literal constant `6` is easily confused for `NUM_LEVELS` and is unclear in how it relates to `LEVEL_MULT`. The `level_for` function incorrectly used `NUM_LEVELS`, for example.

## Solution

Name the literal `6` (`BITS_PER_LEVEL`) and derive other constants from it. I also removed the manual `ilog2` implementation.