### PR TITLE
Inline mpsc list push

### DIFF
--- a/tokio/src/sync/mpsc/list.rs
+++ b/tokio/src/sync/mpsc/list.rs
@@ -71,6 +71,7 @@ pub(crate) fn channel<T>() -> (Tx<T>, Rx<T>) {
 
 impl<T> Tx<T> {
     /// Pushes a value into the list.
+    #[inline]
     pub(crate) fn push(&self, value: T) {
         // First, claim a slot for the value. `Acquire` is used here to
         // synchronize with the `fetch_add` in `reclaim_blocks`.


### PR DESCRIPTION
## Summary

This marks the private `Tx<T>::push` helper in the mpsc list implementation as inline.

## Why this can improve performance

`Tx<T>::push` is a small helper used by the mpsc send path. Inlining it gives the optimizer a better chance to see through the list push and remove call overhead in tight send/receive loops.

## Validation

- `git diff --check`
- `cargo check -p tokio --features sync`

## Benchmark

Current machine, release microbenchmark, 9 samples, median:

| Benchmark | Base | This change | Delta |
|---|---:|---:|---:|
| 1024 mpsc `try_send`/`try_recv` pairs | 42,345.643 ns | 42,033.164 ns | 0.74% faster |
