### PR TITLE
Inline time sleep constructor

### DIFF
--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -119,6 +119,7 @@ pub fn sleep_until(deadline: Instant) -> Sleep {
 // Alias for old name in 0.x
 #[cfg_attr(docsrs, doc(alias = "delay_for"))]
 #[cfg_attr(docsrs, doc(alias = "wait"))]
+#[inline]
 #[track_caller]
 pub fn sleep(duration: Duration) -> Sleep {
     let location = trace::caller_location();


### PR DESCRIPTION
## Summary

This adds `#[inline]` to `tokio::time::sleep`.

## Why this can improve performance

`sleep` is a small constructor wrapper around deadline calculation and `Sleep::new_timeout`. Marking it inline lets callers avoid the wrapper call in hot timer-construction paths while preserving the existing `#[track_caller]` behavior.

## Validation

- `git diff --check`
- `cargo check --manifest-path tokio/Cargo.toml --lib --features time`

## Benchmark

Draft note: this is a small inline hint for a tiny public constructor wrapper. I am submitting it as a draft for maintainer feedback rather than claiming a broad runtime benchmark speedup.
