### PR TITLE
runtime: avoid tsan race in RNG seed generator

### DIFF
--- a/tokio/src/util/rand/rt.rs
+++ b/tokio/src/util/rand/rt.rs
@@ -1,47 +1,62 @@
 use super::{FastRand, RngSeed};
 
-use std::sync::Mutex;
+use crate::loom::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering::Relaxed;
 
 /// A deterministic generator for seeds (and other generators).
 ///
 /// Given the same initial seed, the generator will output the same sequence of seeds.
 ///
-/// Since the seed generator will be kept in a runtime handle, we need to wrap `FastRand`
-/// in a Mutex to make it thread safe. Different to the `FastRand` that we keep in a
-/// thread local store, the expectation is that seed generation will not need to happen
-/// very frequently, so the cost of the mutex should be minimal.
 #[derive(Debug)]
 pub(crate) struct RngSeedGenerator {
-    /// Internal state for the seed generator. We keep it in a Mutex so that we can safely
-    /// use it across multiple threads.
-    state: Mutex<FastRand>,
+    /// Internal state for the seed generator.
+    state: AtomicU64,
 }
 
 impl RngSeedGenerator {
     /// Returns a new generator from the provided seed.
     pub(crate) fn new(seed: RngSeed) -> Self {
         Self {
-            state: Mutex::new(FastRand::from_seed(seed)),
+            state: AtomicU64::new(pack_seed(seed)),
         }
     }
 
     /// Returns the next seed in the sequence.
     pub(crate) fn next_seed(&self) -> RngSeed {
-        let mut rng = self
-            .state
-            .lock()
-            .expect("RNG seed generator is internally corrupt");
+        let mut current = self.state.load(Relaxed);
 
-        let s = rng.fastrand();
-        let r = rng.fastrand();
+        loop {
+            let mut rng = FastRand::from_seed(unpack_seed(current));
+            let s = rng.fastrand();
+            let r = rng.fastrand();
+            let next = pack_state(rng.one, rng.two);
 
-        RngSeed::from_pair(s, r)
+            match self
+                .state
+                .compare_exchange_weak(current, next, Relaxed, Relaxed)
+            {
+                Ok(_) => return RngSeed::from_pair(s, r),
+                Err(actual) => current = actual,
+            }
+        }
     }
 
     /// Directly creates a generator using the next seed.
     pub(crate) fn next_generator(&self) -> Self {
         RngSeedGenerator::new(self.next_seed())
     }
+}
+
+fn pack_seed(seed: RngSeed) -> u64 {
+    pack_state(seed.s, seed.r)
+}
+
+fn pack_state(s: u32, r: u32) -> u64 {
+    ((s as u64) << 32) | r as u64
+}
+
+fn unpack_seed(seed: u64) -> RngSeed {
+    RngSeed::from_pair((seed >> 32) as u32, seed as u32)
 }
 
 impl FastRand {
@@ -57,5 +72,25 @@ impl FastRand {
         self.two = seed.r;
 
         old_seed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn seed_generator_matches_fastrand_sequence() {
+        let seed = RngSeed::from_pair(1, 2);
+        let generator = RngSeedGenerator::new(seed.clone());
+        let mut rng = FastRand::from_seed(seed);
+
+        for _ in 0..8 {
+            let expected = RngSeed::from_pair(rng.fastrand(), rng.fastrand());
+            let actual = generator.next_seed();
+
+            assert_eq!(actual.s, expected.s);
+            assert_eq!(actual.r, expected.r);
+        }
     }
 }


### PR DESCRIPTION
## What changed

This replaces the mutex-protected `FastRand` inside `RngSeedGenerator` with an atomic packed seed state.

Previously, `RngSeedGenerator::next_seed()` locked a shared `FastRand` and mutated it to produce the next pair of random seed values. This was thread-safe, but under ThreadSanitizer it could show up as a false positive data race, especially when Tokio is built with synchronization primitives that TSan does not fully recognize.

The new implementation stores the generator state in an `AtomicU64`, packing the two `u32` RNG state values into one atomic value. `next_seed()` now advances the RNG state using a compare-exchange loop.

## Why

This avoids shared non-atomic mutation in `RngSeedGenerator::next_seed()`, making the synchronization visible to ThreadSanitizer while preserving the deterministic seed sequence.

This should reduce false positive TSan reports pointing at Tokio internals when users are trying to find races in their own code.

## Validation

- Added a unit test to verify that `RngSeedGenerator` still produces the same sequence as the previous `FastRand`-based implementation.
- Ran:

```text
cargo fmt --check
cargo test -p tokio --features full util::rand --lib
cargo test -p tokio --features full,parking_lot util::rand::rt::tests::seed_generator_matches_fastrand_sequence --lib
RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --features full rng_seed --test rt_basic

Closes #7299