### PR TITLE
time: cap driver park timeout on Windows

### DIFF
--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -255,6 +255,19 @@ impl Driver {
         handle.process(rt_handle.clock());
     }
 
+    /// Caps the actual OS sleep on Windows: relative waits do not elapse
+    /// while the system is suspended, while `Instant` deadlines do, so an
+    /// uncapped sleep can miss a deadline by up to the suspend duration.
+    /// Only applies to real sleeps, never to paused-clock auto-advance.
+    fn cap_park_duration(duration: Duration) -> Duration {
+        if cfg!(windows) {
+            const MAX_PARK_DURATION: Duration = Duration::from_secs(1);
+            std::cmp::min(duration, MAX_PARK_DURATION)
+        } else {
+            duration
+        }
+    }
+
     cfg_test_util! {
         fn park_thread_timeout(&mut self, rt_handle: &driver::Handle, duration: Duration) {
             let handle = rt_handle.time();
@@ -274,14 +287,14 @@ impl Driver {
                     }
                 }
             } else {
-                self.park.park_timeout(rt_handle, duration);
+                self.park.park_timeout(rt_handle, Self::cap_park_duration(duration));
             }
         }
     }
 
     cfg_not_test_util! {
         fn park_thread_timeout(&mut self, rt_handle: &driver::Handle, duration: Duration) {
-            self.park.park_timeout(rt_handle, duration);
+            self.park.park_timeout(rt_handle, Self::cap_park_duration(duration));
         }
     }
 }


### PR DESCRIPTION
In function of #8342.

On Windows the driver parks with a relative timeout (GQCS), and relative
waits don't elapse while the system is suspended. Timer deadlines use
`Instant` (QPC), which does. So after a long suspend the driver can oversleep
the next timer by up to the suspend duration, unless I/O wakes it.

Cap the parked sleep at 1s when a timer is pending. No timers = still parks
forever, so no new idle wakeups.

Can be removed once mio can wait on an absolute deadline. We think
`NtAssociateWaitCompletionPacket` + an absolute waitable timer would do it,
untested theory for now.