### PR TITLE
rt: rescue overdue timers when the driver cannot wake up

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/park.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/park.rs
@@ -47,10 +47,34 @@ const PARKED_CONDVAR: usize = 1;
 const PARKED_DRIVER: usize = 2;
 const NOTIFIED: usize = 3;
 
+/// How often the rescue sentinel checks whether the driver overslept.
+#[cfg(all(feature = "time", not(loom)))]
+const RESCUE_INTERVAL: Duration = Duration::from_millis(250);
+
+/// Grace (in ms, the timer tick unit) past the promised wake-up before the
+/// driver counts as overslept, to avoid racing a wake-up already in flight.
+#[cfg(all(feature = "time", not(loom)))]
+const RESCUE_GRACE_MS: u64 = 100;
+
 /// Shared across multiple Parker handles
 struct Shared {
     /// Shared driver. Only one thread at a time can use this
     driver: TryLock<Driver>,
+
+    /// Set while one condvar-parked worker acts as the rescue sentinel.
+    #[cfg(all(feature = "time", not(loom)))]
+    sentinel: std::sync::atomic::AtomicBool,
+}
+
+#[cfg(all(feature = "time", not(loom)))]
+impl Shared {
+    fn claim_sentinel(&self) -> bool {
+        !self.sentinel.swap(true, SeqCst)
+    }
+
+    fn release_sentinel(&self) {
+        self.sentinel.store(false, SeqCst);
+    }
 }
 
 impl Parker {
@@ -62,6 +86,8 @@ impl Parker {
                 condvar: Condvar::new(),
                 shared: Arc::new(Shared {
                     driver: TryLock::new(driver),
+                    #[cfg(all(feature = "time", not(loom)))]
+                    sentinel: std::sync::atomic::AtomicBool::new(false),
                 }),
             }),
         }
@@ -90,7 +116,7 @@ impl Parker {
         if let Some(mut driver) = self.inner.shared.driver.try_lock() {
             self.inner.park_driver(&mut driver, handle, Some(duration))
         } else if !duration.is_zero() {
-            self.inner.park_condvar(Some(duration));
+            self.inner.park_condvar(Some(duration), handle);
             HadDriver::No
         } else {
             // https://github.com/tokio-rs/tokio/issues/6536
@@ -143,7 +169,7 @@ impl Inner {
         if let Some(mut driver) = self.shared.driver.try_lock() {
             self.park_driver(&mut driver, handle, None)
         } else {
-            self.park_condvar(None);
+            self.park_condvar(None, handle);
             HadDriver::No
         }
     }
@@ -155,7 +181,10 @@ impl Inner {
     /// # Panics
     ///
     /// Panics if `duration` is `Some` and the duration is zero.
-    fn park_condvar(&self, duration: Option<Duration>) {
+    fn park_condvar(&self, duration: Option<Duration>, handle: &driver::Handle) {
+        #[cfg(not(all(feature = "time", not(loom))))]
+        let _ = handle;
+
         // Otherwise we need to coordinate going to sleep
         let mut m = self.mutex.lock();
 
@@ -177,6 +206,16 @@ impl Inner {
                 return;
             }
             Err(actual) => panic!("inconsistent park state; actual = {actual}"),
+        }
+
+        // At most one condvar-parked worker acts as rescue sentinel: a
+        // bounded park so overdue timers still fire if the driver owner
+        // cannot wake up in time (tokio-rs/tokio#8342).
+        #[cfg(all(feature = "time", not(loom)))]
+        if duration.is_none() && handle.time.is_some() && self.shared.claim_sentinel() {
+            self.park_condvar_sentinel(m, handle);
+            self.shared.release_sentinel();
+            return;
         }
 
         let timeout_at = duration.map(|d| {
@@ -223,6 +262,83 @@ impl Inner {
 
             // spurious wakeup, go back to sleep
         }
+    }
+
+    /// Bounded condvar park for the rescue sentinel. Checks for overdue
+    /// timers on claim, after every wake-up and on wait expiry; expiry-only
+    /// checking could be starved since notifications restart the wait.
+    #[cfg(all(feature = "time", not(loom)))]
+    fn park_condvar_sentinel<'a>(
+        &'a self,
+        mut m: crate::loom::sync::MutexGuard<'a, ()>,
+        handle: &driver::Handle,
+    ) {
+        loop {
+            // Rescuing runs wakers, which can unpark this parker and lock
+            // `self.mutex`, so release it first. A racing unpark leaves the
+            // sticky NOTIFIED behind, re-checked before sleeping.
+            drop(m);
+
+            if self.rescue_overdue_timers(handle) {
+                // Rescued timers may have queued tasks on this worker,
+                // return to the worker loop to poll them.
+                let old = self.state.swap(EMPTY, SeqCst);
+                debug_assert!(
+                    old == PARKED_CONDVAR || old == NOTIFIED,
+                    "inconsistent sentinel park state; actual = {old}"
+                );
+                return;
+            }
+
+            m = self.mutex.lock();
+
+            if self
+                .state
+                .compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst)
+                .is_ok()
+            {
+                return;
+            }
+
+            let (m2, _) = self.condvar.wait_timeout(m, RESCUE_INTERVAL).unwrap();
+            m = m2;
+
+            if self
+                .state
+                .compare_exchange(NOTIFIED, EMPTY, SeqCst, SeqCst)
+                .is_ok()
+            {
+                return;
+            }
+
+            // Timed out or woken spuriously: re-check.
+        }
+    }
+
+    /// Re-posts the driver wake-up and fires overdue timers if the driver
+    /// overslept the cached deadline. Returns `true` if it had overslept.
+    #[cfg(all(feature = "time", not(loom)))]
+    fn rescue_overdue_timers(&self, handle: &driver::Handle) -> bool {
+        let Some(time_handle) = handle.time.as_ref() else {
+            return false;
+        };
+        let Some(next_wake) = time_handle.next_wake_cached() else {
+            return false;
+        };
+
+        let now = time_handle.time_source().now(handle.clock());
+        if now <= next_wake.get().saturating_add(RESCUE_GRACE_MS) {
+            return false;
+        }
+
+        // Wake the driver in case it is sleeping out a stale relative
+        // timeout in the OS poll; harmless if already awake.
+        handle.unpark();
+
+        // Fires with the timer lock, does not need the driver lock.
+        time_handle.rescue_overdue(handle.clock());
+
+        true
     }
 
     fn park_driver(

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -21,7 +21,7 @@ mod wheel;
 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
 use super::time_alt;
 
-use crate::loom::sync::atomic::{AtomicBool, Ordering};
+use crate::loom::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use crate::loom::sync::Mutex;
 use crate::runtime::driver::{self, IoHandle, IoStack};
 use crate::time::error::Error;
@@ -97,6 +97,10 @@ enum Inner {
         // The state is split like this so `Handle` can access `is_shutdown` without locking the mutex
         state: Mutex<InnerState>,
 
+        /// Lock-free mirror of `InnerState::next_wake` (`0` when none), so
+        /// parked workers can detect an overdue deadline without locking.
+        next_wake_cached: AtomicU64,
+
         /// True if the driver is being shutdown.
         is_shutdown: AtomicBool,
 
@@ -152,6 +156,7 @@ impl Driver {
                     next_wake: None,
                     wheel: wheel::Wheel::new(),
                 }),
+                next_wake_cached: AtomicU64::new(0),
                 is_shutdown: AtomicBool::new(false),
 
                 #[cfg(feature = "test-util")]
@@ -219,6 +224,7 @@ impl Driver {
         let next_wake = lock.wheel.next_expiration_time();
         lock.next_wake =
             next_wake.map(|t| NonZeroU64::new(t).unwrap_or_else(|| NonZeroU64::new(1).unwrap()));
+        handle.inner.set_next_wake_cached(lock.next_wake);
 
         drop(lock);
 
@@ -293,6 +299,31 @@ impl Handle {
         self.process_at_time(now);
     }
 
+    /// Cached earliest pending timer expiration. Lock-free, may be stale.
+    pub(crate) fn next_wake_cached(&self) -> Option<NonZeroU64> {
+        match &self.inner {
+            Inner::Traditional {
+                next_wake_cached, ..
+            } => NonZeroU64::new(next_wake_cached.load(Ordering::SeqCst)),
+            #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+            Inner::Alternative { .. } => None,
+        }
+    }
+
+    /// Fires expired timers off the wheel without needing the resource
+    /// driver. Used by parked workers when the driver overslept.
+    pub(crate) fn rescue_overdue(&self, clock: &Clock) {
+        if self.is_shutdown() {
+            return;
+        }
+
+        match &self.inner {
+            Inner::Traditional { .. } => self.process(clock),
+            #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+            Inner::Alternative { .. } => {}
+        }
+    }
+
     pub(self) fn process_at_time(&self, mut now: u64) {
         let mut waker_list = WakeList::new();
 
@@ -330,6 +361,7 @@ impl Handle {
             .wheel
             .poll_at()
             .map(|t| NonZeroU64::new(t).unwrap_or_else(|| NonZeroU64::new(1).unwrap()));
+        self.inner.set_next_wake_cached(lock.next_wake);
 
         drop(lock);
 
@@ -423,6 +455,8 @@ impl Handle {
                 // the timer entry.
                 match unsafe { lock.wheel.insert(entry) } {
                     Ok(when) => {
+                        self.inner.lower_next_wake_cached(when);
+
                         if lock
                             .next_wake
                             .map(|next_wake| when < next_wake.get())
@@ -470,6 +504,36 @@ impl Inner {
             Inner::Traditional { state, .. } => state.lock(),
             #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
             Inner::Alternative { .. } => unreachable!("unreachable in alternative timer"),
+        }
+    }
+
+    /// Mirror update, must be called while holding the driver lock.
+    fn set_next_wake_cached(&self, next_wake: Option<NonZeroU64>) {
+        match self {
+            Inner::Traditional {
+                next_wake_cached, ..
+            } => {
+                next_wake_cached.store(next_wake.map_or(0, NonZeroU64::get), Ordering::SeqCst);
+            }
+            #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+            Inner::Alternative { .. } => {}
+        }
+    }
+
+    /// Lowers the mirror if `when` is earlier. Writers hold the driver
+    /// lock, so load + store is enough.
+    fn lower_next_wake_cached(&self, when: u64) {
+        match self {
+            Inner::Traditional {
+                next_wake_cached, ..
+            } => {
+                let curr = next_wake_cached.load(Ordering::SeqCst);
+                if curr == 0 || when < curr {
+                    next_wake_cached.store(when.max(1), Ordering::SeqCst);
+                }
+            }
+            #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+            Inner::Alternative { .. } => {}
         }
     }
 

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -300,6 +300,7 @@ impl Handle {
     }
 
     /// Cached earliest pending timer expiration. Lock-free, may be stale.
+    #[cfg(all(feature = "rt-multi-thread", not(loom)))]
     pub(crate) fn next_wake_cached(&self) -> Option<NonZeroU64> {
         match &self.inner {
             Inner::Traditional {
@@ -312,6 +313,7 @@ impl Handle {
 
     /// Fires expired timers off the wheel without needing the resource
     /// driver. Used by parked workers when the driver overslept.
+    #[cfg(all(feature = "rt-multi-thread", not(loom)))]
     pub(crate) fn rescue_overdue(&self, clock: &Clock) {
         if self.is_shutdown() {
             return;


### PR DESCRIPTION
In function of #8342.

Hang dump in #8342: all workers parked in `WaitOnAddress`, nobody in
`NtRemoveIoCompletion`. The worker holding the driver lock missed a wake-up
around suspend/resume while blocked inside `Driver::park`, and with it stuck,
timers and I/O are dead runtime-wide. The park/idle protocol itself audits
clean and ~1500 freeze/thaw chaos cycles never wedged it, but injecting that
one fault reproduces the dump exactly.

Fix: one condvar-parked worker acts as rescue sentinel, parking with a 250ms
bounded wait. When a lock-free mirror of the next timer deadline says the
driver overslept, it re-posts the driver unpark and fires overdue timers off
the wheel (needs the timer lock, not the driver lock). No extra wakeups under
load. Fault-injection validated: full timer throughput through a 60s
stalled-owner fault, first rescue after ~270ms.

Prior art: Go sysmon retakes netpoll when it didn't run for 10ms+:
https://github.com/golang/go/blob/go1.24.0/src/runtime/proc.go#L6169