### PR TITLE
Complete zero-length in-memory stream operations immediately

### DIFF
--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -250,6 +250,10 @@ impl SimplexStream {
         cx: &mut task::Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<std::io::Result<()>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
         if self.buffer.has_remaining() {
             let max = self.buffer.remaining().min(buf.remaining());
             buf.put_slice(&self.buffer[..max]);
@@ -278,6 +282,10 @@ impl SimplexStream {
         if self.is_closed {
             return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()));
         }
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
         let avail = self.max_buf_size - self.buffer.len();
         if avail == 0 {
             self.write_waker = Some(cx.waker().clone());
@@ -300,6 +308,10 @@ impl SimplexStream {
         if self.is_closed {
             return Poll::Ready(Err(std::io::ErrorKind::BrokenPipe.into()));
         }
+        if bufs.iter().all(|buf| buf.is_empty()) {
+            return Poll::Ready(Ok(0));
+        }
+
         let avail = self.max_buf_size - self.buffer.len();
         if avail == 0 {
             self.write_waker = Some(cx.waker().clone());

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -1,6 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
+use std::io::IoSlice;
+
 use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test]
@@ -99,6 +101,22 @@ async fn max_write_size() {
 
     // drop b only after task t1 finishes writing
     drop(b);
+}
+
+#[tokio::test]
+async fn zero_length_ops_complete_when_stream_would_block() {
+    let (mut reader, _peer) = duplex(1);
+    let mut empty = [];
+    assert_eq!(reader.read(&mut empty).await.unwrap(), 0);
+
+    let (mut writer, _peer) = duplex(1);
+    writer.write_all(b"x").await.unwrap();
+    assert_eq!(writer.write(&[]).await.unwrap(), 0);
+
+    let (mut writer, _peer) = duplex(1);
+    writer.write_all(b"x").await.unwrap();
+    let bufs = [IoSlice::new(&[]), IoSlice::new(&[])];
+    assert_eq!(writer.write_vectored(&bufs).await.unwrap(), 0);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #8321 by completing zero-length in-memory stream operations immediately when they do not need capacity from the stream.

## Details

Zero-length reads and writes do not transfer bytes, so they should not wait for the in-memory stream to become readable or writable. This updates the in-memory stream poll helpers to return immediately for empty reads, empty writes, and all-empty vectored writes while preserving the existing closed-stream checks.

## Validation

- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p tokio --test io_mem_stream --features full`