### PR TITLE
Tokio test mock write hang 8329

### DIFF
--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -372,7 +372,11 @@ impl Mock {
         }
     }
 
-    /// Pull the next handle action when the current queue has no matching Write.
+    /// Pull the next already-available handle action when the current queue has
+    /// no matching Write.
+    ///
+    /// Only actions that are ready now are accepted. If the handle has nothing
+    /// queued yet, or is closed, the write is unexpected and this panics.
     ///
     /// See <https://github.com/tokio-rs/tokio/issues/8329>.
     fn poll_next_action_for_write(&mut self, cx: &mut task::Context<'_>) -> Poll<()> {
@@ -381,8 +385,7 @@ impl Mock {
                 self.inner.actions.push_back(action);
                 Poll::Ready(())
             }
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(None) => {
+            Poll::Pending | Poll::Ready(None) => {
                 panic!("unexpected write {}", self.pmsg());
             }
         }

--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -246,8 +246,9 @@ impl Inner {
     fn write(&mut self, mut src: &[u8]) -> io::Result<usize> {
         let mut ret = 0;
 
+        // Empty queue: let poll_write pull from the handle or panic if closed.
         if self.actions.is_empty() {
-            return Err(io::ErrorKind::BrokenPipe.into());
+            return Ok(0);
         }
 
         if let Some(&mut Action::Wait(..)) = self.action() {
@@ -354,6 +355,22 @@ impl Mock {
             _ => {}
         }
     }
+
+    /// Pull the next handle action when the current queue has no matching Write.
+    ///
+    /// See <https://github.com/tokio-rs/tokio/issues/8329>.
+    fn poll_next_action_for_write(&mut self, cx: &mut task::Context<'_>) -> Poll<()> {
+        match self.inner.poll_action(cx) {
+            Poll::Ready(Some(action)) => {
+                self.inner.actions.push_back(action);
+                Poll::Ready(())
+            }
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => {
+                panic!("unexpected write {}", self.pmsg());
+            }
+        }
+    }
 }
 
 impl AsyncRead for Mock {
@@ -410,6 +427,11 @@ impl AsyncWrite for Mock {
         cx: &mut task::Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
+        // Empty writes must not go through the "no matching Write" path.
+        if buf.is_empty() {
+            return Poll::Ready(Ok(0));
+        }
+
         loop {
             if let Some(ref mut sleep) = self.inner.sleep {
                 ready!(Pin::new(sleep).poll(cx));
@@ -417,20 +439,6 @@ impl AsyncWrite for Mock {
 
             // If a sleep is set, it has already fired
             self.inner.sleep = None;
-
-            if self.inner.actions.is_empty() {
-                match self.inner.poll_action(cx) {
-                    Poll::Pending => {
-                        // do not propagate pending
-                    }
-                    Poll::Ready(Some(action)) => {
-                        self.inner.actions.push_back(action);
-                    }
-                    Poll::Ready(None) => {
-                        panic!("unexpected write {}", self.pmsg());
-                    }
-                }
-            }
 
             match self.inner.write(buf) {
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
@@ -465,21 +473,8 @@ impl AsyncWrite for Mock {
                     }
                 }
                 Ok(0) => {
-                    // TODO: Is this correct?
-                    if !self.inner.actions.is_empty() {
-                        return Poll::Pending;
-                    }
-
-                    // TODO: Extract
-                    match ready!(self.inner.poll_action(cx)) {
-                        Some(action) => {
-                            self.inner.actions.push_back(action);
-                            continue;
-                        }
-                        None => {
-                            panic!("unexpected write {}", self.pmsg());
-                        }
-                    }
+                    ready!(self.poll_next_action_for_write(cx));
+                    continue;
                 }
                 ret => {
                     self.maybe_wakeup_reader();

--- a/tokio-test/src/io.rs
+++ b/tokio-test/src/io.rs
@@ -71,6 +71,7 @@ struct Inner {
     waiting: Option<Instant>,
     sleep: Option<Pin<Box<Sleep>>>,
     read_wait: Option<Waker>,
+    write_wait: Option<Waker>,
     rx: UnboundedReceiverStream<Action>,
     name: String,
 }
@@ -201,6 +202,7 @@ impl Inner {
             actions,
             sleep: None,
             read_wait: None,
+            write_wait: None,
             rx,
             waiting: None,
             name,
@@ -290,6 +292,14 @@ impl Inner {
         Ok(ret)
     }
 
+    fn has_write_side_action(&self) -> bool {
+        self.actions.iter().any(|action| match action {
+            Action::Write(data) => !data.is_empty(),
+            Action::WriteError(Some(_)) | Action::Wait(_) => true,
+            _ => false,
+        })
+    }
+
     fn remaining_wait(&mut self) -> Option<Duration> {
         match self.action() {
             Some(&mut Action::Wait(dur)) => Some(dur),
@@ -356,6 +366,12 @@ impl Mock {
         }
     }
 
+    fn maybe_wakeup_writer(&mut self) {
+        if let Some(waker) = self.inner.write_wait.take() {
+            waker.wake();
+        }
+    }
+
     /// Pull the next handle action when the current queue has no matching Write.
     ///
     /// See <https://github.com/tokio-rs/tokio/issues/8329>.
@@ -408,14 +424,19 @@ impl AsyncRead for Mock {
                                 continue;
                             }
                             None => {
+                                self.maybe_wakeup_writer();
                                 return Poll::Ready(Ok(()));
                             }
                         }
                     } else {
+                        self.maybe_wakeup_writer();
                         return Poll::Ready(Ok(()));
                     }
                 }
-                Err(e) => return Poll::Ready(Err(e)),
+                Err(e) => {
+                    self.maybe_wakeup_writer();
+                    return Poll::Ready(Err(e));
+                }
             }
         }
     }
@@ -473,6 +494,14 @@ impl AsyncWrite for Mock {
                     }
                 }
                 Ok(0) => {
+                    // A later Write/WriteError/Wait is blocked behind Read(s).
+                    // Park until a read makes progress; do not treat this as an
+                    // unexpected write.
+                    if self.inner.has_write_side_action() {
+                        self.inner.write_wait = Some(cx.waker().clone());
+                        return Poll::Pending;
+                    }
+
                     ready!(self.poll_next_action_for_write(cx));
                     continue;
                 }

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -240,10 +240,7 @@ async fn write_skips_queued_read_to_match_builder_write() {
 #[tokio::test]
 async fn write_error_behind_queued_read() {
     let error = io::Error::new(io::ErrorKind::Other, "no thanks!");
-    let mock = Builder::new()
-        .read(b"payload")
-        .write_error(error)
-        .build();
+    let mock = Builder::new().read(b"payload").write_error(error).build();
     let (mut reader, mut writer) = tokio::io::split(mock);
 
     let write = tokio::spawn(async move { writer.write_all(b"x").await });

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -170,3 +170,69 @@ async fn multiple_wait() {
         start.elapsed().as_millis()
     );
 }
+
+// https://github.com/tokio-rs/tokio/issues/8329
+#[tokio::test(flavor = "current_thread")]
+#[should_panic(expected = "unexpected write")]
+async fn unexpected_write_panics_when_only_read_is_scripted() {
+    let mut mock = Builder::new().read(b"z").build();
+    let _ = mock.write_all(b"w").await;
+}
+
+#[tokio::test]
+async fn write_with_handle_behind_queued_read() {
+    let (mut mock, mut handle) = Builder::new().read(b"z").build_with_handle();
+    handle.write(b"w");
+
+    mock.write_all(b"w").await.expect("write");
+
+    let mut buf = [0; 1];
+    mock.read_exact(&mut buf).await.expect("read");
+    assert_eq!(&buf, b"z");
+}
+
+#[tokio::test]
+async fn write_drains_interleaved_handle_read_before_write() {
+    // A single poll_action would enqueue only the Read and then hang; the write
+    // path must keep draining until a Write is available.
+    let (mut mock, mut handle) = Builder::new().build_with_handle();
+    handle.read(b"z");
+    handle.write(b"w");
+
+    mock.write_all(b"w").await.expect("write");
+
+    let mut buf = [0; 1];
+    mock.read_exact(&mut buf).await.expect("read");
+    assert_eq!(&buf, b"z");
+}
+
+#[test]
+fn write_with_handle_after_pending() {
+    use tokio_test::task;
+
+    let (mock, mut handle) = Builder::new().build_with_handle();
+    let mut write = task::spawn(async move {
+        let mut mock = mock;
+        mock.write_all(b"hello ").await
+    });
+
+    assert!(
+        write.poll().is_pending(),
+        "write should wait for a handle action"
+    );
+
+    handle.write(b"hello ");
+
+    assert!(matches!(write.poll(), std::task::Poll::Ready(Ok(()))));
+}
+
+#[tokio::test]
+async fn write_skips_queued_read_to_match_builder_write() {
+    let mut mock = Builder::new().read(b"z").write(b"w").build();
+
+    mock.write_all(b"w").await.expect("write");
+
+    let mut buf = [0; 1];
+    mock.read_exact(&mut buf).await.expect("read");
+    assert_eq!(&buf, b"z");
+}

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -207,23 +207,19 @@ async fn write_drains_interleaved_handle_read_before_write() {
 }
 
 #[test]
-fn write_with_handle_after_pending() {
+#[should_panic(expected = "unexpected write")]
+fn write_before_handle_action_panics() {
     use tokio_test::task;
 
-    let (mock, mut handle) = Builder::new().build_with_handle();
+    // Actions must already be queued; waiting for a later handle write is not
+    // supported.
+    let (mock, _handle) = Builder::new().build_with_handle();
     let mut write = task::spawn(async move {
         let mut mock = mock;
         mock.write_all(b"hello ").await
     });
 
-    assert!(
-        write.poll().is_pending(),
-        "write should wait for a handle action"
-    );
-
-    handle.write(b"hello ");
-
-    assert!(matches!(write.poll(), std::task::Poll::Ready(Ok(()))));
+    let _ = write.poll();
 }
 
 #[tokio::test]

--- a/tokio-test/tests/io.rs
+++ b/tokio-test/tests/io.rs
@@ -236,3 +236,27 @@ async fn write_skips_queued_read_to_match_builder_write() {
     mock.read_exact(&mut buf).await.expect("read");
     assert_eq!(&buf, b"z");
 }
+
+#[tokio::test]
+async fn write_error_behind_queued_read() {
+    let error = io::Error::new(io::ErrorKind::Other, "no thanks!");
+    let mock = Builder::new()
+        .read(b"payload")
+        .write_error(error)
+        .build();
+    let (mut reader, mut writer) = tokio::io::split(mock);
+
+    let write = tokio::spawn(async move { writer.write_all(b"x").await });
+
+    let mut buf = vec![0; 7];
+    reader.read_exact(&mut buf).await.expect("read");
+    assert_eq!(&buf[..], b"payload");
+
+    match write.await.expect("join") {
+        Err(error) => {
+            assert_eq!(error.kind(), io::ErrorKind::Other);
+            assert_eq!(format!("{error}"), "no thanks!");
+        }
+        Ok(()) => panic!("error not received"),
+    }
+}


### PR DESCRIPTION
## Motivation

`tokio_test::io::Mock` documents that writing unexpected data panics. Instead,
`poll_write` could hang forever when the action queue had `Read`s but no matching
`Write`: it returned `Poll::Pending` without registering a waker.

The same path also failed to drain handle actions while the queue was non-empty,
so a handle `Write` queued behind a `Read` never became visible and hung as well.

Fixes: #8329

## Solution

When `Inner::write` makes no progress (`Ok(0)`), pull the next action from the
handle and retry:

- handle still open with no action yet → `Pending` (waker registered)
- handle closed → panic (`unexpected write`), matching the docs
- handle yields more actions → keep draining so an interleaved handle `Read`
  before a `Write` still completes

Also treat an empty action queue as `Ok(0)` instead of `BrokenPipe`, so delayed
handle writes can wait instead of failing, and short-circuit empty write buffers
so they do not go through the unexpected-write path.

Regression tests cover the panic case, write-behind-read via handle, interleaved
handle read/write, delayed handle write after `Pending`, and builder
`.read().write()` interleaving.