### PR TITLE
codec: fix broken length_delimited builder doc examples

### DIFF
--- a/tokio-util/src/codec/length_delimited.rs
+++ b/tokio-util/src/codec/length_delimited.rs
@@ -675,18 +675,21 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # use tokio::io::AsyncRead;
     /// use tokio_util::codec::LengthDelimitedCodec;
+    /// use tokio_stream::StreamExt;
     ///
-    /// # fn bind_read<T: AsyncRead>(io: T) {
-    /// LengthDelimitedCodec::builder()
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() {
+    /// let io: &[u8] = b"\x00\x0bhello world";
+    /// let mut reader = LengthDelimitedCodec::builder()
     ///     .length_field_offset(0)
     ///     .length_field_type::<u16>()
     ///     .length_adjustment(0)
-    ///     .num_skip(0)
     ///     .new_read(io);
+    ///
+    /// let frame = reader.next().await.unwrap().unwrap();
+    /// assert_eq!(&frame[..], b"hello world");
     /// # }
-    /// # pub fn main() {}
     /// ```
     pub fn new() -> Builder {
         Builder {
@@ -949,14 +952,20 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// use tokio_util::codec::LengthDelimitedCodec;
+    /// use bytes::{Bytes, BytesMut};
+    /// use tokio_util::codec::{Decoder, Encoder, LengthDelimitedCodec};
+    ///
     /// # pub fn main() {
-    /// LengthDelimitedCodec::builder()
+    /// let mut codec = LengthDelimitedCodec::builder()
     ///     .length_field_offset(0)
     ///     .length_field_type::<u16>()
     ///     .length_adjustment(0)
-    ///     .num_skip(0)
     ///     .new_codec();
+    ///
+    /// let mut buf = BytesMut::new();
+    /// codec.encode(Bytes::from_static(b"hello world"), &mut buf).unwrap();
+    /// let frame = codec.decode(&mut buf).unwrap().unwrap();
+    /// assert_eq!(&frame[..], b"hello world");
     /// # }
     /// ```
     pub fn new_codec(&self) -> LengthDelimitedCodec {
@@ -975,18 +984,21 @@ impl Builder {
     /// # Examples
     ///
     /// ```
-    /// # use tokio::io::AsyncRead;
     /// use tokio_util::codec::LengthDelimitedCodec;
+    /// use tokio_stream::StreamExt;
     ///
-    /// # fn bind_read<T: AsyncRead>(io: T) {
-    /// LengthDelimitedCodec::builder()
+    /// # #[tokio::main(flavor = "current_thread")]
+    /// # async fn main() {
+    /// let io: &[u8] = b"\x00\x0bhello world";
+    /// let mut reader = LengthDelimitedCodec::builder()
     ///     .length_field_offset(0)
     ///     .length_field_type::<u16>()
     ///     .length_adjustment(0)
-    ///     .num_skip(0)
     ///     .new_read(io);
+    ///
+    /// let frame = reader.next().await.unwrap().unwrap();
+    /// assert_eq!(&frame[..], b"hello world");
     /// # }
-    /// # pub fn main() {}
     /// ```
     pub fn new_read<T>(&self, upstream: T) -> FramedRead<T, LengthDelimitedCodec>
     where


### PR DESCRIPTION
The `Builder::new`, `new_codec`, and `new_read` doc examples combine `length_adjustment(0)` with `num_skip(0)`. This leaves the length header bytes in the buffer without accounting for them, so decoding returns a frame that includes the raw header at the front and is short at the back, corrupting the following frame.

## Motivation

Copying these examples as written produces a `LengthDelimitedCodec` that silently corrupts every frame after the first, since the length header is never skipped but the byte count returned by `decode` isn't adjusted to account for it.

## Solution

Drop `num_skip(0)` so the default (skip the header) behavior applies, and turn all three examples into executable doctests that perform a real encode/decode round-trip and assert on the payload, so this class of bug is caught automatically going forward. `new_write` was already correct and is unchanged.

Fixes #8348

Note: aware of #8349 which addresses the same issue — opening this as an independent fix.
