### PR TITLE
net: surface UDP receive errors through try_* methods

### DIFF
--- a/tokio/src/io/interest.rs
+++ b/tokio/src/io/interest.rs
@@ -1,7 +1,5 @@
 #![cfg_attr(not(feature = "net"), allow(dead_code, unreachable_pub))]
 
-use crate::io::ready::Ready;
-
 use std::fmt;
 use std::ops;
 
@@ -241,7 +239,7 @@ impl Interest {
             // There is no error interest in mio, because error events are always reported.
             // But mio interests cannot be empty and an interest is needed just for the registration.
             //
-            // read readiness is filtered out in `Interest::mask` or `Ready::from_interest` if
+            // read readiness is filtered out in `Ready::from_interest` if
             // the read interest was not specified by the user.
             mio_add(&mut mio, mio::Interest::READABLE);
         }
@@ -253,17 +251,6 @@ impl Interest {
         //
         // in both cases, `mio` is Some already
         mio.unwrap_or(mio::Interest::READABLE)
-    }
-
-    pub(crate) fn mask(self) -> Ready {
-        match self {
-            Interest::READABLE => Ready::READABLE | Ready::READ_CLOSED,
-            Interest::WRITABLE => Ready::WRITABLE | Ready::WRITE_CLOSED,
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            Interest::PRIORITY => Ready::PRIORITY | Ready::READ_CLOSED,
-            Interest::ERROR => Ready::ERROR,
-            _ => Ready::EMPTY,
-        }
     }
 }
 

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -889,7 +889,7 @@ impl UdpSocket {
     pub fn try_recv(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.io
             .registration()
-            .try_io(Interest::READABLE, || self.io.recv(buf))
+            .try_io(Interest::READABLE | Interest::ERROR, || self.io.recv(buf))
     }
 
     cfg_io_util! {
@@ -943,7 +943,7 @@ impl UdpSocket {
         /// }
         /// ```
         pub fn try_recv_buf<B: BufMut>(&self, buf: &mut B) -> io::Result<usize> {
-            self.io.registration().try_io(Interest::READABLE, || {
+            self.io.registration().try_io(Interest::READABLE | Interest::ERROR, || {
                 let dst = buf.chunk_mut();
                 let dst =
                     unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
@@ -1069,7 +1069,7 @@ impl UdpSocket {
         /// }
         /// ```
         pub fn try_recv_buf_from<B: BufMut>(&self, buf: &mut B) -> io::Result<(usize, SocketAddr)> {
-            self.io.registration().try_io(Interest::READABLE, || {
+            self.io.registration().try_io(Interest::READABLE | Interest::ERROR, || {
                 let dst = buf.chunk_mut();
                 let dst =
                     unsafe { &mut *(dst as *mut _ as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) };
@@ -1442,7 +1442,7 @@ impl UdpSocket {
     pub fn try_recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.io
             .registration()
-            .try_io(Interest::READABLE, || self.io.recv_from(buf))
+            .try_io(Interest::READABLE | Interest::ERROR, || self.io.recv_from(buf))
     }
 
     /// Tries to read or write from the socket using a user-provided IO operation.
@@ -1661,7 +1661,7 @@ impl UdpSocket {
     pub fn try_peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.io
             .registration()
-            .try_io(Interest::READABLE, || self.io.peek(buf))
+            .try_io(Interest::READABLE | Interest::ERROR, || self.io.peek(buf))
     }
 
     /// Receives data from the socket, without removing it from the input queue.
@@ -1811,7 +1811,7 @@ impl UdpSocket {
     pub fn try_peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.io
             .registration()
-            .try_io(Interest::READABLE, || self.io.peek_from(buf))
+            .try_io(Interest::READABLE | Interest::ERROR, || self.io.peek_from(buf))
     }
 
     /// Retrieve the sender of the data at the head of the input queue, waiting if empty.
@@ -1877,7 +1877,7 @@ impl UdpSocket {
     pub fn try_peek_sender(&self) -> io::Result<SocketAddr> {
         self.io
             .registration()
-            .try_io(Interest::READABLE, || self.peek_sender_inner())
+            .try_io(Interest::READABLE | Interest::ERROR, || self.peek_sender_inner())
     }
 
     #[inline]

--- a/tokio/src/net/udp.rs
+++ b/tokio/src/net/udp.rs
@@ -1442,7 +1442,9 @@ impl UdpSocket {
     pub fn try_recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.io
             .registration()
-            .try_io(Interest::READABLE | Interest::ERROR, || self.io.recv_from(buf))
+            .try_io(Interest::READABLE | Interest::ERROR, || {
+                self.io.recv_from(buf)
+            })
     }
 
     /// Tries to read or write from the socket using a user-provided IO operation.
@@ -1811,7 +1813,9 @@ impl UdpSocket {
     pub fn try_peek_from(&self, buf: &mut [u8]) -> io::Result<(usize, SocketAddr)> {
         self.io
             .registration()
-            .try_io(Interest::READABLE | Interest::ERROR, || self.io.peek_from(buf))
+            .try_io(Interest::READABLE | Interest::ERROR, || {
+                self.io.peek_from(buf)
+            })
     }
 
     /// Retrieve the sender of the data at the head of the input queue, waiting if empty.
@@ -1877,7 +1881,9 @@ impl UdpSocket {
     pub fn try_peek_sender(&self) -> io::Result<SocketAddr> {
         self.io
             .registration()
-            .try_io(Interest::READABLE | Interest::ERROR, || self.peek_sender_inner())
+            .try_io(Interest::READABLE | Interest::ERROR, || {
+                self.peek_sender_inner()
+            })
     }
 
     #[inline]

--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -290,7 +290,7 @@ impl ScheduledIo {
 
         ReadyEvent {
             tick: TICK.unpack(curr) as u8,
-            ready: interest.mask() & Ready::from_usize(READINESS.unpack(curr)),
+            ready: Ready::from_interest(interest) & Ready::from_usize(READINESS.unpack(curr)),
             is_shutdown: SHUTDOWN.unpack(curr) != 0,
         }
     }

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -14,11 +14,27 @@ use std::future::poll_fn;
 use std::io;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::{io::ReadBuf, net::UdpSocket, time};
+use tokio::{
+    io::{Interest, ReadBuf, Ready},
+    net::UdpSocket,
+    time,
+};
 use tokio_test::assert_ok;
 
 const MSG: &[u8] = b"hello";
 const MSG_LEN: usize = MSG.len();
+
+fn assert_connection_refused_or_reset(err: &io::Error) {
+    assert!(
+        // Linux/BSD returns ECONNREFUSED, but Windows will usually return ECONNRESET instead.
+        matches!(
+            err.kind(),
+            io::ErrorKind::ConnectionRefused | io::ErrorKind::ConnectionReset
+        ),
+        "unexpected error kind: {:?}",
+        err.kind()
+    );
+}
 
 #[tokio::test]
 async fn send_recv() -> std::io::Result<()> {
@@ -74,15 +90,40 @@ async fn send_to_recv_closed_returns_err() -> std::io::Result<()> {
         .await
         .expect("timed out instead of returning error")
         .unwrap_err();
-    let errno = err.kind();
 
-    assert!(
-        // Linux/BSD returns ECONNREFUSED, but Windows will usually return ECONNRESET instead.
-        matches!(
-            errno,
-            io::ErrorKind::ConnectionRefused | io::ErrorKind::ConnectionReset
-        )
-    );
+    assert_connection_refused_or_reset(&err);
+    Ok(())
+}
+
+// Regression test for https://github.com/tokio-rs/tokio/issues/8082: the
+// `try_*` receive methods must surface socket errors (e.g. ECONNREFUSED after
+// the peer is gone) the same way the async `recv` methods do, instead of
+// swallowing them and returning `WouldBlock`.
+#[tokio::test]
+#[cfg_attr(
+    target_os = "wasi",
+    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/13933"
+)]
+async fn send_to_try_recv_closed_returns_err() -> std::io::Result<()> {
+    let sender = UdpSocket::bind("127.0.0.1:0").await?;
+    let receiver = UdpSocket::bind("127.0.0.1:0").await?;
+
+    let receiver_addr = receiver.local_addr()?;
+    drop(receiver);
+    sender.connect(receiver_addr).await?;
+    sender.send(MSG).await?;
+
+    let interest = time::timeout(
+        Duration::from_secs(5),
+        sender.ready(Interest::READABLE | Interest::ERROR),
+    )
+    .await
+    .expect("timed out instead of returning error")
+    .unwrap();
+    assert_eq!(interest, Ready::ERROR);
+
+    let err = sender.try_recv(&mut [0u8; 32]).unwrap_err();
+    assert_connection_refused_or_reset(&err);
     Ok(())
 }
 

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -15,7 +15,7 @@ use std::io;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::{
-    io::{Interest, ReadBuf, Ready},
+    io::{Interest, ReadBuf},
     net::UdpSocket,
     time,
 };
@@ -120,7 +120,10 @@ async fn send_to_try_recv_closed_returns_err() -> std::io::Result<()> {
     .await
     .expect("timed out instead of returning error")
     .unwrap();
-    assert_eq!(interest, Ready::ERROR);
+    // On Linux the ICMP error surfaces as `Ready::ERROR`, but kqueue-based
+    // targets (macOS/BSD) may instead wake the read filter as `Ready::READABLE`.
+    // Either way the socket must report readiness so `try_recv` can surface the error.
+    assert!(interest.is_error() || interest.is_readable());
 
     let err = sender.try_recv(&mut [0u8; 32]).unwrap_err();
     assert_connection_refused_or_reset(&err);


### PR DESCRIPTION
Fixes #8082.

`try_io` computed readiness via `Interest::mask()`, which matched on exact enum values and fell through to `Ready::EMPTY` for combined interests like `READABLE | ERROR`. As a result the UDP `try_*` methods returned `WouldBlock` instead of the real socket error after the peer is gone.

This makes `ScheduledIo::ready_event` use `Ready::from_interest()` (the same helper the async path uses), removes the now-redundant `Interest::mask()`, and passes `Interest::ERROR` through the seven UDP `try_*` receive methods. Adds a regression test next to the #8001 tests.