### PR TITLE
io: handle empty vectored writes in simplex

### DIFF
--- a/tokio-util/src/io/simplex.rs
+++ b/tokio-util/src/io/simplex.rs
@@ -291,6 +291,10 @@ impl AsyncWrite for Sender {
             return Poll::Ready(Err(IoError::new(IoErrorKind::BrokenPipe, CLOSED_ERROR_MSG)));
         }
 
+        if bufs.iter().all(|buf| buf.is_empty()) {
+            return Poll::Ready(Ok(0));
+        }
+
         let free = inner
             .backpressure_boundary
             .checked_sub(inner.buf.len())

--- a/tokio-util/tests/io_simplex.rs
+++ b/tokio-util/tests/io_simplex.rs
@@ -354,3 +354,16 @@ async fn poll_write_vectored_3() {
     let n = assert_ready!(tx.poll_write_vectored(&mut noop_context(), io_slices)).unwrap();
     assert_eq!(n, 0);
 }
+
+/// The `Sender::poll_write_vectored` should return `Poll::Ready(Ok(0))`
+/// if all the input buffers have zero length, even when the channel is full.
+#[tokio::test]
+async fn poll_write_vectored_4() {
+    let (mut tx, _rx) = simplex::new(1);
+    tx.write_all(&[1]).await.unwrap();
+
+    let io_slices = &[IoSlice::new(&[]), IoSlice::new(&[])];
+    tokio::pin!(tx);
+    let n = assert_ready!(tx.poll_write_vectored(&mut noop_context(), io_slices)).unwrap();
+    assert_eq!(n, 0);
+}


### PR DESCRIPTION
## Motivation

`Sender::poll_write` returns `Ok(0)` for an empty buffer even when the simplex is full. `poll_write_vectored` currently checks `free == 0` first, so an all-empty vectored write returns `Pending` until the receiver frees capacity.

This makes empty scalar and vectored writes behave differently.

## Solution

Return `Ready(Ok(0))` for all-empty `IoSlice`s after the closed-channel check and before the capacity check. This preserves `BrokenPipe` for closed senders.

The change matches the existing zero-length behavior in Tokio's in-memory stream implementation.

## Tests

- Added a regression test with capacity 1, one byte already written, and two empty `IoSlice`s.
- `cargo fmt --all -- --check`
- `cargo test -p tokio-util --features full`
- `cargo clippy -p tokio-util --features full --all-targets -- -D warnings`