### PR TITLE
sync: avoid atomic reader count in broadcast slots

### DIFF
--- a/benches/sync_broadcast.rs
+++ b/benches/sync_broadcast.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 use tokio::sync::{broadcast, Notify};
 
 use criterion::measurement::WallTime;
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion};
+use criterion::{
+    black_box, criterion_group, criterion_main, BenchmarkGroup, Criterion, Throughput,
+};
 
 fn rt() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_multi_thread()
@@ -77,6 +79,38 @@ fn bench_contention(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(contention, bench_contention);
+fn bench_try_recv(c: &mut Criterion) {
+    let mut group = c.benchmark_group("try_recv");
+    const MESSAGES: usize = 256;
+
+    for receiver_count in [1usize, 4, 16] {
+        group.throughput(Throughput::Elements((MESSAGES * receiver_count) as u64));
+        group.bench_function(receiver_count.to_string(), |b| {
+            let (tx, first_rx) = broadcast::channel::<usize>(MESSAGES);
+            let mut receivers = Vec::with_capacity(receiver_count);
+            receivers.push(first_rx);
+
+            for _ in 1..receiver_count {
+                receivers.push(tx.subscribe());
+            }
+
+            b.iter(|| {
+                for message in 0..MESSAGES {
+                    tx.send(black_box(message)).unwrap();
+                }
+
+                for rx in &mut receivers {
+                    for _ in 0..MESSAGES {
+                        black_box(rx.try_recv().unwrap());
+                    }
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(contention, bench_contention, bench_try_recv);
 
 criterion_main!(contention);

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -142,7 +142,7 @@ use std::future::Future;
 use std::marker::PhantomPinned;
 use std::pin::Pin;
 use std::ptr::NonNull;
-use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release, SeqCst};
+use std::sync::atomic::Ordering::{AcqRel, Acquire, Relaxed, Release};
 use std::task::{ready, Context, Poll, Waker};
 
 /// Sending-half of the [`broadcast`] channel.
@@ -408,16 +408,15 @@ struct Slot<T> {
     ///
     /// When this goes to zero, the value is released.
     ///
-    /// An atomic is used as it is mutated concurrently with the slot read lock
-    /// acquired.
-    rem: AtomicUsize,
+    /// Access is protected by the slot mutex.
+    rem: usize,
 
     /// Uniquely identifies the `send` stored in the slot.
     pos: u64,
 
     /// The value being broadcast.
     ///
-    /// The value is set by `send` when the write lock is held. When a reader
+    /// The value is set by `send` while the slot mutex is held. When a reader
     /// drops, `rem` is decremented. When it hits zero, the value is dropped.
     val: Option<T>,
 }
@@ -584,7 +583,7 @@ impl<T> Sender<T> {
 
         let buffer = (0..capacity).map(|i| {
             Mutex::new(Slot {
-                rem: AtomicUsize::new(0),
+                rem: 0,
                 pos: (i as u64).wrapping_sub(capacity as u64),
                 val: None,
             })
@@ -680,7 +679,7 @@ impl<T> Sender<T> {
         slot.pos = pos;
 
         // Set remaining receivers
-        slot.rem.with_mut(|v| *v = rem);
+        slot.rem = rem;
 
         // Write the value
         slot.val = Some(value);
@@ -782,7 +781,7 @@ impl<T> Sender<T> {
         while low < high {
             let mid = low + (high - low) / 2;
             let idx = base_idx.wrapping_add(mid) & self.shared.mask;
-            if self.shared.buffer[idx].lock().rem.load(SeqCst) == 0 {
+            if self.shared.buffer[idx].lock().rem == 0 {
                 low = mid + 1;
             } else {
                 high = mid;
@@ -824,7 +823,7 @@ impl<T> Sender<T> {
         let tail = self.shared.tail.lock();
 
         let idx = (tail.pos.wrapping_sub(1) & self.shared.mask as u64) as usize;
-        self.shared.buffer[idx].lock().rem.load(SeqCst) == 0
+        self.shared.buffer[idx].lock().rem == 0
     }
 
     /// Returns the number of active receivers.
@@ -1750,7 +1749,8 @@ impl<'a, T> RecvGuard<'a, T> {
 impl<'a, T> Drop for RecvGuard<'a, T> {
     fn drop(&mut self) {
         // Decrement the remaining counter
-        if 1 == self.slot.rem.fetch_sub(1, SeqCst) {
+        self.slot.rem -= 1;
+        if self.slot.rem == 0 {
             self.slot.val = None;
         }
     }


### PR DESCRIPTION
## Motivation

Broadcast slots used to allow multiple receivers to hold read locks concurrently, so the remaining-reader count needed to be atomic.

Since `4b174ce2`, each slot is protected by an exclusive mutex. However, every successful receive still performs a sequentially consistent atomic read-modify-write while holding that mutex.

## Solution

Store the remaining-reader count as a `usize` and update it while the slot mutex is held. All existing accesses already hold the same mutex, including sender initialization, `len`, `is_empty`, and `RecvGuard::drop`.

This also adds a focused `try_recv` benchmark with 1, 4, and 16 receivers. Each iteration sends 256 messages and drains them from every receiver. Throughput counts each delivered receiver-message pair as one element.

On an M1 Pro, comparing point estimates against the atomic implementation:

| Receivers | Atomic | `usize` | Speedup |
| ---: | ---: | ---: | ---: |
| 1 | 20.555 us | 16.310 us | 1.26x as fast |
| 4 | 49.993 us | 28.458 us | 1.76x as fast |
| 16 | 176.78 us | 91.283 us | 1.94x as fast |

The speedup column is calculated directly from the displayed point estimates. Criterion found the 1 and 16 receiver changes statistically significant. The 4 receiver run was noisy despite the lower point estimate.

## Testing

- `cargo test -p tokio --test sync_broadcast --features full`
- `cargo test -p tokio --lib --features full broadcast`
- broadcast Loom suite with the repository's CI settings
- `cargo clippy --workspace --tests --no-deps --features 'full,test-util'`
- `cargo clippy -p benches --benches --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
