### PR TITLE
test: cover I/O shutdown waker cycles

### DIFF
--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -5,6 +5,13 @@ use tokio::net::TcpListener;
 use tokio::runtime;
 use tokio_test::{assert_err, assert_pending, assert_ready, task};
 
+use futures::task::{waker_ref, ArcWake};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::task::Context;
+
 #[test]
 fn tcp_doesnt_block() {
     let rt = rt();
@@ -50,6 +57,55 @@ fn drop_wakes() {
 
     assert!(task.is_woken());
     assert_ready!(task.poll());
+}
+
+struct RegistrationWaker {
+    // Keep the registration alive through the waker to recreate the cycle from #3481.
+    _listener: Arc<TcpListener>,
+    dropped: Arc<AtomicBool>,
+}
+
+impl ArcWake for RegistrationWaker {
+    fn wake_by_ref(_: &Arc<Self>) {}
+}
+
+impl Drop for RegistrationWaker {
+    fn drop(&mut self) {
+        self.dropped.store(true, Ordering::SeqCst);
+    }
+}
+
+#[test]
+fn shutdown_drops_waker_holding_registration() {
+    let rt = rt();
+
+    let listener = {
+        let _enter = rt.enter();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+
+        listener.set_nonblocking(true).unwrap();
+
+        Arc::new(TcpListener::from_std(listener).unwrap())
+    };
+
+    let dropped = Arc::new(AtomicBool::new(false));
+    let task = Arc::new(RegistrationWaker {
+        _listener: listener.clone(),
+        dropped: dropped.clone(),
+    });
+    {
+        let waker = waker_ref(&task);
+        let mut cx = Context::from_waker(&waker);
+
+        assert_pending!(listener.poll_accept(&mut cx));
+    }
+
+    drop(listener);
+    drop(task);
+    assert!(!dropped.load(Ordering::SeqCst));
+    drop(rt);
+
+    assert!(dropped.load(Ordering::SeqCst));
 }
 
 fn rt() -> runtime::Runtime {

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -6,10 +6,8 @@ use tokio::runtime;
 use tokio_test::{assert_err, assert_pending, assert_ready, task};
 
 use futures::task::{waker_ref, ArcWake};
-use std::sync::{
-    atomic::{AtomicBool, Ordering},
-    Arc,
-};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::task::Context;
 
 #[test]
@@ -71,7 +69,7 @@ impl ArcWake for RegistrationWaker {
 
 impl Drop for RegistrationWaker {
     fn drop(&mut self) {
-        self.dropped.store(true, Ordering::SeqCst);
+        self.dropped.store(true, Ordering::Relaxed);
     }
 }
 
@@ -102,10 +100,10 @@ fn shutdown_drops_waker_holding_registration() {
 
     drop(listener);
     drop(task);
-    assert!(!dropped.load(Ordering::SeqCst));
+    assert!(!dropped.load(Ordering::Relaxed));
     drop(rt);
 
-    assert!(dropped.load(Ordering::SeqCst));
+    assert!(dropped.load(Ordering::Relaxed));
 }
 
 fn rt() -> runtime::Runtime {
@@ -114,3 +112,4 @@ fn rt() -> runtime::Runtime {
         .build()
         .unwrap()
 }
+

--- a/tokio/tests/io_driver_drop.rs
+++ b/tokio/tests/io_driver_drop.rs
@@ -112,4 +112,3 @@ fn rt() -> runtime::Runtime {
         .build()
         .unwrap()
 }
-


### PR DESCRIPTION
## Motivation

Issue #3481 describes a shutdown cycle where a custom task waker retains the I/O registration that stores it. The shutdown path already clears stored wakers, but this edge case had no regression test.

## Solution

Add an integration test that polls a `TcpListener` with a custom `ArcWake` retaining the same listener. The test verifies that the waker holder remains alive before runtime shutdown and is released when shutdown clears the registration waker.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p tokio --features full --test io_driver_drop`