### PR TITLE
runtime: add `Handle::has_time_driver`

### DIFF
--- a/tests-integration/Cargo.toml
+++ b/tests-integration/Cargo.toml
@@ -30,6 +30,10 @@ name = "macros_select"
 name = "rt_yield"
 required-features = ["rt", "macros", "sync"]
 
+[[test]]
+name = "rt_handle_time"
+required-features = ["rt"]
+
 [features]
 # For mem check
 rt-net = ["tokio/rt", "tokio/rt-multi-thread", "tokio/net"]
@@ -46,6 +50,7 @@ full = [
     "macros",
     "rt",
     "rt-multi-thread",
+    "time",
 
     "tokio/full",
     "tokio-test"
@@ -54,6 +59,7 @@ macros = ["tokio/macros"]
 sync = ["tokio/sync"]
 rt = ["tokio/rt"]
 rt-multi-thread = ["rt", "tokio/rt-multi-thread"]
+time = ["tokio/time"]
 
 [dependencies]
 tokio = { version = "1.0.0", path = "../tokio" }

--- a/tests-integration/tests/rt_handle_time.rs
+++ b/tests-integration/tests/rt_handle_time.rs
@@ -1,0 +1,13 @@
+#![warn(rust_2018_idioms)]
+
+use tokio::runtime::{Builder, Handle};
+
+#[test]
+fn has_time_driver_matches_time_feature() {
+    let runtime = Builder::new_current_thread().enable_all().build().unwrap();
+
+    assert_eq!(runtime.handle().has_time_driver(), cfg!(feature = "time"));
+    runtime.block_on(async {
+        assert_eq!(Handle::current().has_time_driver(), cfg!(feature = "time"));
+    });
+}

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -77,6 +77,16 @@ impl Driver {
 }
 
 impl Handle {
+    #[cfg(feature = "time")]
+    pub(crate) fn has_time_driver(&self) -> bool {
+        self.time.is_some()
+    }
+
+    #[cfg(not(feature = "time"))]
+    pub(crate) const fn has_time_driver(&self) -> bool {
+        false
+    }
+
     pub(crate) fn unpark(&self) {
         #[cfg(feature = "time")]
         if let Some(handle) = &self.time {

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -77,11 +77,6 @@ impl Driver {
 }
 
 impl Handle {
-    #[cfg(feature = "time")]
-    pub(crate) fn has_time_driver(&self) -> bool {
-        self.time.is_some()
-    }
-
     #[cfg(not(feature = "time"))]
     pub(crate) const fn has_time_driver(&self) -> bool {
         false
@@ -115,6 +110,10 @@ impl Handle {
     }
 
     cfg_time! {
+        pub(crate) fn has_time_driver(&self) -> bool {
+            self.time.is_some()
+        }
+
         /// Returns a reference to the time driver handle.
         ///
         /// Panics if no time driver is present.

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -466,6 +466,36 @@ impl Handle {
         }
     }
 
+    /// Returns whether the runtime has a time driver enabled.
+    ///
+    /// A time driver is enabled by calling [`Builder::enable_time`] or
+    /// [`Builder::enable_all`] before building the runtime. Use this method to
+    /// check whether the runtime was configured with a time driver before
+    /// creating a timer, such as with `tokio::time::timeout`.
+    ///
+    /// This method only reports the runtime's configuration. It does not
+    /// indicate whether the runtime is still running, and remains `true` after
+    /// shutdown if the time driver was enabled.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime::Builder;
+    ///
+    /// let runtime = Builder::new_current_thread()
+    ///     .enable_time()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// assert!(runtime.handle().has_time_driver());
+    /// ```
+    ///
+    /// [`Builder::enable_time`]: crate::runtime::Builder::enable_time
+    /// [`Builder::enable_all`]: crate::runtime::Builder::enable_all
+    pub fn has_time_driver(&self) -> bool {
+        self.inner.has_time_driver()
+    }
+
     /// Returns the [`Id`] of the current `Runtime`.
     ///
     /// # Examples

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -468,7 +468,7 @@ impl Handle {
 
     /// Returns whether the runtime has a time driver enabled.
     ///
-    /// A time driver is enabled by calling [`Builder::enable_time`] or
+    /// A time driver is enabled by calling `Builder::enable_time` or
     /// [`Builder::enable_all`] before building the runtime. Use this method to
     /// check whether the runtime was configured with a time driver before
     /// creating a timer, such as with `tokio::time::timeout`.
@@ -480,6 +480,8 @@ impl Handle {
     /// # Examples
     ///
     /// ```
+    /// # #[cfg(feature = "time")]
+    /// # {
     /// use tokio::runtime::Builder;
     ///
     /// let runtime = Builder::new_current_thread()
@@ -488,9 +490,9 @@ impl Handle {
     ///     .unwrap();
     ///
     /// assert!(runtime.handle().has_time_driver());
+    /// # }
     /// ```
     ///
-    /// [`Builder::enable_time`]: crate::runtime::Builder::enable_time
     /// [`Builder::enable_all`]: crate::runtime::Builder::enable_all
     pub fn has_time_driver(&self) -> bool {
         self.inner.has_time_driver()

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -473,6 +473,13 @@ impl Handle {
     /// check whether the runtime was configured with a time driver before
     /// creating a timer, such as with `tokio::time::timeout`.
     ///
+    /// When Tokio is built without the `time` feature, this method always
+    /// returns `false`.
+    ///
+    /// Timer creation uses the current runtime context. When using this method
+    /// to guard timer creation, ensure this handle refers to the current
+    /// runtime.
+    ///
     /// This method only reports the runtime's configuration. It does not
     /// indicate whether the runtime is still running, and remains `true` after
     /// shutdown if the time driver was enabled.

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -66,7 +66,7 @@ impl Handle {
         }
     }
 
-    #[cfg_attr(not(feature = "full"), allow(dead_code))]
+    #[cfg_attr(not(feature = "rt"), allow(dead_code))]
     pub(crate) fn has_time_driver(&self) -> bool {
         self.driver().has_time_driver()
     }

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -66,6 +66,7 @@ impl Handle {
         }
     }
 
+    #[cfg_attr(not(feature = "full"), allow(dead_code))]
     pub(crate) fn has_time_driver(&self) -> bool {
         self.driver().has_time_driver()
     }

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -65,6 +65,10 @@ impl Handle {
             Handle::Disabled => unreachable!(),
         }
     }
+
+    pub(crate) fn has_time_driver(&self) -> bool {
+        self.driver().has_time_driver()
+    }
 }
 
 cfg_rt! {

--- a/tokio/tests/rt_handle_time.rs
+++ b/tokio/tests/rt_handle_time.rs
@@ -70,6 +70,28 @@ fn has_time_driver_is_true_when_enabled() {
 
 #[cfg(feature = "time")]
 #[test]
+fn has_time_driver_reports_the_current_runtime() {
+    assert!(tokio::runtime::Handle::try_current().is_err());
+
+    let disabled = Builder::new_current_thread().build().unwrap();
+    let enabled = Builder::new_current_thread().enable_time().build().unwrap();
+
+    let disabled_guard = disabled.enter();
+    assert!(!tokio::runtime::Handle::current().has_time_driver());
+
+    {
+        let enabled_guard = enabled.enter();
+        assert!(tokio::runtime::Handle::current().has_time_driver());
+        drop(enabled_guard);
+    }
+
+    assert!(!tokio::runtime::Handle::current().has_time_driver());
+    drop(disabled_guard);
+    assert!(tokio::runtime::Handle::try_current().is_err());
+}
+
+#[cfg(feature = "time")]
+#[test]
 fn has_time_driver_can_guard_timeout_creation() {
     let runtime = Builder::new_current_thread().build().unwrap();
     let handle = runtime.handle().clone();

--- a/tokio/tests/rt_handle_time.rs
+++ b/tokio/tests/rt_handle_time.rs
@@ -1,0 +1,133 @@
+#![warn(rust_2018_idioms)]
+#![cfg(feature = "rt")]
+
+use tokio::runtime::Builder;
+
+#[test]
+fn has_time_driver_is_false_when_disabled() {
+    let runtime = Builder::new_current_thread().build().unwrap();
+
+    assert!(!runtime.handle().has_time_driver());
+
+    #[cfg(feature = "rt-multi-thread")]
+    {
+        let runtime = Builder::new_multi_thread().build().unwrap();
+
+        assert!(!runtime.handle().has_time_driver());
+    }
+}
+
+#[test]
+fn has_time_driver_is_preserved_by_handle_clones() {
+    let runtime = Builder::new_current_thread().build().unwrap();
+    let handle = runtime.handle().clone();
+
+    assert!(!handle.has_time_driver());
+}
+
+#[cfg(feature = "time")]
+#[test]
+fn has_time_driver_is_true_when_enabled() {
+    let runtime = Builder::new_current_thread().enable_time().build().unwrap();
+    let handle = runtime.handle().clone();
+
+    assert!(runtime.handle().has_time_driver());
+    assert!(handle.has_time_driver());
+
+    runtime.block_on(async {
+        assert!(tokio::runtime::Handle::current().has_time_driver());
+    });
+
+    #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+    {
+        let runtime = Builder::new_multi_thread()
+            .enable_alt_timer()
+            .build()
+            .unwrap();
+        let handle = runtime.handle().clone();
+
+        assert!(runtime.handle().has_time_driver());
+        assert!(handle.has_time_driver());
+
+        runtime.block_on(async {
+            assert!(tokio::runtime::Handle::current().has_time_driver());
+        });
+    }
+
+    #[cfg(feature = "rt-multi-thread")]
+    {
+        let runtime = Builder::new_multi_thread().enable_time().build().unwrap();
+        let handle = runtime.handle().clone();
+
+        assert!(runtime.handle().has_time_driver());
+        assert!(handle.has_time_driver());
+
+        runtime.block_on(async {
+            assert!(tokio::runtime::Handle::current().has_time_driver());
+        });
+    }
+}
+
+#[cfg(feature = "time")]
+#[test]
+fn has_time_driver_can_guard_timeout_creation() {
+    let runtime = Builder::new_current_thread().build().unwrap();
+    let handle = runtime.handle().clone();
+
+    let result = runtime.block_on(async {
+        if handle.has_time_driver() {
+            Some(tokio::time::timeout(std::time::Duration::from_secs(1), async { 42 }).await)
+        } else {
+            None
+        }
+    });
+
+    assert!(result.is_none());
+
+    let runtime = Builder::new_current_thread().enable_time().build().unwrap();
+    let handle = runtime.handle().clone();
+
+    let result = runtime.block_on(async {
+        if handle.has_time_driver() {
+            Some(tokio::time::timeout(std::time::Duration::from_secs(1), async { 42 }).await)
+        } else {
+            None
+        }
+    });
+
+    assert_eq!(result.unwrap().unwrap(), 42);
+}
+
+#[cfg(feature = "time")]
+#[test]
+fn has_time_driver_reports_configuration_after_shutdown() {
+    let runtime = Builder::new_current_thread().enable_time().build().unwrap();
+    let handle = runtime.handle().clone();
+
+    drop(runtime);
+
+    assert!(handle.has_time_driver());
+
+    #[cfg(feature = "rt-multi-thread")]
+    {
+        let runtime = Builder::new_multi_thread().enable_time().build().unwrap();
+        let handle = runtime.handle().clone();
+
+        drop(runtime);
+
+        assert!(handle.has_time_driver());
+    }
+
+    #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+    {
+        let runtime = Builder::new_multi_thread()
+            .enable_alt_timer()
+            .build()
+            .unwrap();
+        let handle = runtime.handle().clone();
+
+        drop(runtime);
+
+        assert!(handle.has_time_driver());
+    }
+}


### PR DESCRIPTION
## Motivation

Libraries that run on caller-provided Tokio runtimes cannot currently
determine whether a runtime was configured with a time driver without
attempting timer construction and catching a panic.

Closes #8361.

## Solution

Add `Handle::has_time_driver`, backed by the runtime's existing driver
handle. It reports construction-time timer configuration for current-thread
and multi-thread runtimes, cloned and current handles, and the unstable
alternative timer.

The method remains available when Tokio is built without the `time` feature
and returns `false` in that configuration. Timer constructors use the current
runtime context, so callers using this method as a guard must query the handle
for the current runtime. The result does not report runtime liveness and
remains `true` after shutdown when the time driver was enabled.

Tests cover enabled and disabled drivers, nested runtime contexts, handle
clones, timeout guarding, shutdown, and supported feature/configuration
variants. A dedicated `tests-integration` target verifies an `rt`-only build
without the `time` feature.
