### PR TITLE
rt: fix `shared` to `sharded` in sharded list code

### DIFF
--- a/tokio/src/runtime/task/list.rs
+++ b/tokio/src/runtime/task/list.rs
@@ -74,9 +74,9 @@ struct OwnedTasksInner<S: 'static> {
 
 impl<S: 'static> OwnedTasks<S> {
     pub(crate) fn new(num_cores: usize) -> Self {
-        let shard_size = Self::gen_shared_list_size(num_cores);
+        let sharded_size = Self::gen_sharded_list_size(num_cores);
         Self {
-            list: ShardedList::new(shard_size),
+            list: ShardedList::new(sharded_size),
             closed: AtomicBool::new(false),
             id: get_next_id(),
         }
@@ -224,11 +224,11 @@ impl<S: 'static> OwnedTasks<S> {
     /// nodes in the intrusive linked list will diminish. Furthermore,
     /// the construction time of the sharded list will also increase with a higher number of shards.
     ///
-    /// Due to the above reasons, we set a maximum value for the shared list size,
-    /// denoted as `MAX_SHARED_LIST_SIZE`.
-    fn gen_shared_list_size(num_cores: usize) -> usize {
-        const MAX_SHARED_LIST_SIZE: usize = 1 << 16;
-        usize::min(MAX_SHARED_LIST_SIZE, num_cores.next_power_of_two() * 4)
+    /// Due to the above reasons, we set a maximum value for the sharded list size,
+    /// denoted as `MAX_SHARDED_LIST_SIZE`.
+    fn gen_sharded_list_size(num_cores: usize) -> usize {
+        const MAX_SHARDED_LIST_SIZE: usize = 1 << 16;
+        usize::min(MAX_SHARDED_LIST_SIZE, num_cores.next_power_of_two() * 4)
     }
 }
 

--- a/tokio/src/util/sharded_list.rs
+++ b/tokio/src/util/sharded_list.rs
@@ -116,7 +116,7 @@ impl<L: ShardedListItem> ShardedList<L> {
         self.len() == 0
     }
 
-    /// Gets the shard size of this `SharedList`.
+    /// Gets the shard size of this `ShardedList`.
     ///
     /// Used to help us to decide the parameter `shard_id` of the `pop_back` method.
     pub(crate) fn shard_size(&self) -> usize {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

In tokio/src/runtime/task/list.rs, 'sharded' is mistakenly spelled as 'shared' in a function name, a constant, and doc comments.
tokio/src/util/sharded_list.rs has the same typo in a doc comment.

These typoes have existed since #6001.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Renamed the affected function, constant, and variables, and fixed the doc comments from `shared` to `sharded`.

Confirmed via `git grep` that no other occurrences of this typo exist.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
