### PR TITLE
taskdump: fix deadlock in task dumps due to `Barrier::wait_timeout` issue

### DIFF
--- a/tokio/src/loom/std/barrier.rs
+++ b/tokio/src/loom/std/barrier.rs
@@ -241,7 +241,8 @@ impl BarrierWaitResult {
     }
 }
 
-#[cfg(test)]
+// Requires OS threads, which are unavailable on wasm targets.
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use super::Barrier;
     use std::sync::Arc;

--- a/tokio/src/loom/std/barrier.rs
+++ b/tokio/src/loom/std/barrier.rs
@@ -179,6 +179,25 @@ impl Barrier {
                 let (guard, timeout_result) = self.cvar.wait_timeout(lock, timeout).unwrap();
                 lock = guard;
                 if timeout_result.timed_out() {
+                    // The generation may have advanced while we were timing out,
+                    // meaning the barrier was completed by another thread and we
+                    // were released as part of that rendezvous rather than
+                    // actually timing out. Treat it as a successful wait.
+                    if local_gen != lock.generation_id {
+                        break;
+                    }
+                    // Otherwise we really timed out. Roll back the `count += 1`
+                    // performed above before returning. `count` is reset to 0
+                    // only on the leader path (the `else` branch below), so a
+                    // generation that never reaches `num_threads` would
+                    // otherwise leak this arrival. A later generation could then
+                    // cross `num_threads` with fewer than `num_threads` threads
+                    // actually present and elect a spurious leader. This cannot
+                    // underflow: we hold the lock and the generation is
+                    // unchanged since our own `count += 1`, so no leader has
+                    // reset `count`, and it therefore still includes this thread.
+                    debug_assert!(lock.count > 0);
+                    lock.count -= 1;
                     return None;
                 }
             }
@@ -219,5 +238,41 @@ impl BarrierWaitResult {
     #[must_use]
     pub(crate) fn is_leader(&self) -> bool {
         self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Barrier;
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    // A `wait_timeout` that times out must roll back the arrival it recorded so
+    // it does not leak into `count`. `count` is reset to 0 only when a leader is
+    // elected, so a leaked arrival would let a later generation cross
+    // `num_threads` with fewer than `num_threads` threads actually present and
+    // elect a spurious leader.
+    #[test]
+    fn wait_timeout_rolls_back_arrival() {
+        let barrier = Barrier::new(2);
+
+        // A lone thread times out: only 1 of the 2 required threads arrived.
+        assert!(barrier.wait_timeout(Duration::from_millis(50)).is_none());
+
+        // A second lone thread must also time out. If the first arrival had
+        // leaked, this call would push `count` from 1 to `num_threads` and
+        // wrongly be elected leader instead of timing out.
+        assert!(barrier.wait_timeout(Duration::from_millis(50)).is_none());
+
+        // A genuine rendezvous still completes and elects exactly one leader.
+        let barrier = Arc::new(Barrier::new(2));
+        let other = barrier.clone();
+        let handle = thread::spawn(move || other.wait_timeout(Duration::from_secs(10)));
+        let a = barrier
+            .wait_timeout(Duration::from_secs(10))
+            .expect("rendezvous timed out");
+        let b = handle.join().unwrap().expect("rendezvous timed out");
+        assert!(a.is_leader() ^ b.is_leader());
     }
 }

--- a/tokio/src/loom/std/barrier.rs
+++ b/tokio/src/loom/std/barrier.rs
@@ -173,29 +173,28 @@ impl Barrier {
         let local_gen = lock.generation_id;
         lock.count += 1;
         if lock.count < self.num_threads {
-            // We need a while loop to guard against spurious wakeups.
+            // We need a loop to guard against spurious wakeups.
             // https://en.wikipedia.org/wiki/Spurious_wakeup
-            while local_gen == lock.generation_id {
+            loop {
                 let (guard, timeout_result) = self.cvar.wait_timeout(lock, timeout).unwrap();
                 lock = guard;
+
+                // The barrier completed (possibly concurrently with our
+                // timeout), so we were released as part of the rendezvous.
+                if local_gen != lock.generation_id {
+                    break;
+                }
+
                 if timeout_result.timed_out() {
-                    // The generation may have advanced while we were timing out,
-                    // meaning the barrier was completed by another thread and we
-                    // were released as part of that rendezvous rather than
-                    // actually timing out. Treat it as a successful wait.
-                    if local_gen != lock.generation_id {
-                        break;
-                    }
-                    // Otherwise we really timed out. Roll back the `count += 1`
-                    // performed above before returning. `count` is reset to 0
-                    // only on the leader path (the `else` branch below), so a
-                    // generation that never reaches `num_threads` would
-                    // otherwise leak this arrival. A later generation could then
-                    // cross `num_threads` with fewer than `num_threads` threads
-                    // actually present and elect a spurious leader. This cannot
-                    // underflow: we hold the lock and the generation is
-                    // unchanged since our own `count += 1`, so no leader has
-                    // reset `count`, and it therefore still includes this thread.
+                    // Roll back the `count += 1` performed above before
+                    // returning. `count` is reset to 0 only on the leader path
+                    // (the `else` branch below), so a generation that never
+                    // reaches `num_threads` would otherwise leak this arrival,
+                    // letting a later generation cross `num_threads` with fewer
+                    // than `num_threads` threads actually present and elect a
+                    // spurious leader. Cannot underflow: we hold the lock and
+                    // the generation is unchanged since our own `count += 1`, so
+                    // no leader has reset `count` and it still includes us.
                     debug_assert!(lock.count > 0);
                     lock.count -= 1;
                     return None;
@@ -238,42 +237,5 @@ impl BarrierWaitResult {
     #[must_use]
     pub(crate) fn is_leader(&self) -> bool {
         self.0
-    }
-}
-
-// Requires OS threads, which are unavailable on wasm targets.
-#[cfg(all(test, not(target_family = "wasm")))]
-mod tests {
-    use super::Barrier;
-    use std::sync::Arc;
-    use std::thread;
-    use std::time::Duration;
-
-    // A `wait_timeout` that times out must roll back the arrival it recorded so
-    // it does not leak into `count`. `count` is reset to 0 only when a leader is
-    // elected, so a leaked arrival would let a later generation cross
-    // `num_threads` with fewer than `num_threads` threads actually present and
-    // elect a spurious leader.
-    #[test]
-    fn wait_timeout_rolls_back_arrival() {
-        let barrier = Barrier::new(2);
-
-        // A lone thread times out: only 1 of the 2 required threads arrived.
-        assert!(barrier.wait_timeout(Duration::from_millis(50)).is_none());
-
-        // A second lone thread must also time out. If the first arrival had
-        // leaked, this call would push `count` from 1 to `num_threads` and
-        // wrongly be elected leader instead of timing out.
-        assert!(barrier.wait_timeout(Duration::from_millis(50)).is_none());
-
-        // A genuine rendezvous still completes and elects exactly one leader.
-        let barrier = Arc::new(Barrier::new(2));
-        let other = barrier.clone();
-        let handle = thread::spawn(move || other.wait_timeout(Duration::from_secs(10)));
-        let a = barrier
-            .wait_timeout(Duration::from_secs(10))
-            .expect("rendezvous timed out");
-        let b = handle.join().unwrap().expect("rendezvous timed out");
-        assert!(a.is_leader() ^ b.is_leader());
     }
 }

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -202,3 +202,69 @@ fn notified_during_tracing() {
         );
     });
 }
+
+/// Regression test for an arrival leak in the task-dump barrier's
+/// `wait_timeout` (`loom::std::barrier`).
+///
+/// When a worker is wedged and never reaches the dump barrier, the healthy
+/// workers repeatedly time out waiting for it. If a timed-out arrival is not
+/// rolled back, `count` (reset to zero only when a leader is elected) leaks,
+/// and a later barrier round crosses `num_threads` with fewer than
+/// `num_threads` workers actually present. That elects a spurious leader which
+/// traces tasks without the exclusive access the barrier guarantees, un-setting
+/// the notified bit of a task another worker is about to run and panicking that
+/// worker via `assert!(next.is_notified())` — the same assert as #6051.
+///
+/// This drives that scenario and ensures the runtime survives. In a debug build
+/// the panic aborts the whole process via the worker's abort-on-panic guard, so
+/// this test crashes without the fix and passes with it.
+#[test]
+fn wedged_worker_during_tracing() {
+    let rt = runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(4)
+        .build()
+        .unwrap();
+
+    // Permanently occupy one worker so only 3 of the 4 workers ever reach the
+    // dump barrier — the condition that leaks `count` without the fix.
+    rt.spawn(async {
+        loop {
+            std::hint::spin_loop();
+        }
+    });
+
+    // Keep the remaining workers continuously polling tasks, each burning a
+    // little CPU before yielding, to widen the window in which a spurious leader
+    // would trace a task another worker is actively polling.
+    for _ in 0..12 {
+        rt.spawn(async {
+            loop {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_micros(20);
+                while std::time::Instant::now() < deadline {
+                    std::hint::spin_loop();
+                }
+                tokio::task::yield_now().await;
+            }
+        });
+    }
+
+    // Continuously request dumps. With a permanently wedged worker a dump never
+    // completes, so this future is expected never to resolve.
+    let handle = rt.handle().clone();
+    rt.spawn(async move {
+        loop {
+            let _ = handle.dump().await;
+        }
+    });
+
+    // Bound the test on the *test thread's* wall clock rather than a runtime
+    // timer: the busy workers above would starve an in-runtime timer, and the
+    // point is only to give the buggy spurious-leader race time to fire (it
+    // aborts a worker within a fraction of a second without the fix).
+    std::thread::sleep(std::time::Duration::from_secs(5));
+
+    // Tear down without joining the wedged worker, which never returns:
+    // `shutdown_background` is `shutdown_timeout(0)`, so it skips all joins.
+    rt.shutdown_background();
+}


### PR DESCRIPTION
## Motivation

`Barrier::wait_timeout` (in `loom/std/barrier.rs`, used to coordinate workers during a multi-thread runtime task dump) increments `count` on arrival but, on timeout, returns without rolling it back. `count` is reset to `0` only on the leader path, so a generation that never reaches `num_threads` (e.g. a wedged worker that never arrives, the common case when a dump is requested) leaks the arrival. A later generation can then cross `num_threads` with fewer than `num_threads` threads actually present and elect a spurious leader; for the task-dump barrier that leader traces tasks without the exclusive access the barrier guarantees, tripping `assert!(next.is_notified())` in `transition_to_running` on a runtime worker thread.

## Solution

On timeout, recheck the generation: if it advanced, the barrier completed concurrently and this thread was released as part of that rendezvous, so treat it as a successful wait. Otherwise decrement `count` before returning `None`, so
a timed-out generation self-heals back to `count == 0`.

Adds `wait_timeout_rolls_back_arrival`, verified to pass with the fix and to fail (`assertion failed: ..is_none()`) when only the fix is reverted.

credits to @MashPlant who found and fix it within the company private repo.