### PR TITLE
sync: preserve FIFO lock order when coop budget is exhausted

### DIFF
--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -397,17 +397,13 @@ impl Semaphore {
     fn poll_acquire(
         &self,
         cx: &mut Context<'_>,
-        num_permits: usize,
+        _num_permits: usize,
         node: Pin<&mut Waiter>,
         queued: bool,
     ) -> Poll<Result<(), AcquireError>> {
         let mut acquired = 0;
 
-        let needed = if queued {
-            node.state.load(Acquire) << Self::PERMIT_SHIFT
-        } else {
-            num_permits << Self::PERMIT_SHIFT
-        };
+        let needed = node.state.load(Acquire) << Self::PERMIT_SHIFT;
 
         let mut lock = None;
         // First, try to take the requested number of permits from the
@@ -461,6 +457,7 @@ impl Semaphore {
                                 )
                             });
 
+                            node.assign_permits(&mut acquired);
                             return Poll::Ready(Ok(()));
                         } else if lock.is_none() {
                             break self.waiters.lock();
@@ -587,24 +584,24 @@ impl Future for Acquire<'_> {
 
         let (node, semaphore, needed, queued) = self.project();
 
-        // First, ensure the current task has enough budget to proceed.
-        #[cfg(all(tokio_unstable, feature = "tracing"))]
-        let coop = ready!(trace_poll_op!(
-            "poll_acquire",
-            crate::task::coop::poll_proceed(cx),
-        ));
-
-        #[cfg(not(all(tokio_unstable, feature = "tracing")))]
-        let coop = ready!(crate::task::coop::poll_proceed(cx));
-
         let result = match semaphore.poll_acquire(cx, needed, node, *queued) {
             Poll::Pending => {
                 *queued = true;
                 Poll::Pending
             }
             Poll::Ready(r) => {
-                coop.made_progress();
                 r?;
+
+                #[cfg(all(tokio_unstable, feature = "tracing"))]
+                let coop = ready!(trace_poll_op!(
+                    "poll_acquire",
+                    crate::task::coop::poll_proceed(cx),
+                ));
+
+                #[cfg(not(all(tokio_unstable, feature = "tracing")))]
+                let coop = ready!(crate::task::coop::poll_proceed(cx));
+
+                coop.made_progress();
                 *queued = false;
                 Poll::Ready(Ok(()))
             }

--- a/tokio/tests/sync_mutex.rs
+++ b/tokio/tests/sync_mutex.rs
@@ -176,3 +176,28 @@ async fn mutex_debug() {
     let _guard = m.lock().await;
     assert_eq!(format!("{m:?}"), r#"Mutex { data: <locked> }"#)
 }
+
+#[test]
+fn mutex_fifo_with_coop_budget() {
+    let m = Arc::new(Mutex::new(()));
+
+    let mut t0 = spawn(m.clone().lock_owned());
+    let g0 = assert_ready!(t0.poll());
+
+    let m_a = Arc::clone(&m);
+    let mut t_a = spawn(async move {
+        for _ in 0..128 {
+            tokio::task::coop::consume_budget().await;
+        }
+        m_a.lock_owned().await
+    });
+    assert_pending!(t_a.poll());
+
+    let mut t_b = spawn(m.clone().lock_owned());
+    assert_pending!(t_b.poll());
+
+    drop(g0);
+
+    assert!(t_a.is_woken());
+    assert!(!t_b.is_woken());
+}


### PR DESCRIPTION
Fixes #8365

### Problem
`Mutex` (and `Semaphore`) documentation states that lock acquisition operates on a guaranteed FIFO basis. However, in `Acquire::poll`, the cooperative-scheduling budget check `coop::poll_proceed(cx)` was performed *before* calling `semaphore.poll_acquire(...)`.

If a task's coop budget was exhausted before polling `lock().await`:
1. `coop::poll_proceed(cx)` returned `Poll::Pending`.
2. The future returned early without attempting `semaphore.poll_acquire(...)`.
3. The task's waiter node was never inserted into the semaphore's FIFO wait queue (`waiters.queue`).
4. If another task with remaining budget subsequently called `lock().await`, its waiter node was inserted into `waiters.queue` first.
5. When the lock was released, the second task acquired the lock before the first task, violating FIFO ordering.

### Solution
- Move `coop::poll_proceed(cx)` in `Acquire::poll` to run after `semaphore.poll_acquire(...)`. This ensures the waiter node is inserted into `waiters.queue` on its initial `poll()`, establishing its exact FIFO queue position.
- Update fast-path permit acquisition in `poll_acquire` to assign obtained permits to `node.state` via `node.assign_permits(...)`, ensuring state consistency if a coop budget yield occurs when returning ready.
- Update `needed` calculation in `poll_acquire` to load remaining permits directly from `node.state`.
- Add unit test `mutex_fifo_with_coop_budget` in `tests/sync_mutex.rs` verifying FIFO acquisition order when coop budget is depleted.
