### PR TITLE
runtime: fix idle bookkeeping when a task dump wakes parked workers

### DIFF
--- a/tokio/src/runtime/scheduler/multi_thread/idle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/idle.rs
@@ -92,6 +92,10 @@ impl Idle {
         // Acquire the lock
         let mut lock = shared.synced.lock();
 
+        // A worker that is already tracked as a sleeper would be counted twice,
+        // which corrupts `num_unparked` and the sleeper list.
+        debug_assert!(!lock.idle.sleepers.contains(&worker));
+
         // Decrement the number of unparked threads
         let ret = State::dec_num_unparked(&self.state, is_searching);
 
@@ -194,6 +198,7 @@ impl State {
         }
 
         let prev = State(cell.fetch_sub(dec, SeqCst));
+        debug_assert!(prev.num_unparked() > 0, "{prev:?}");
         is_searching && prev.num_searching() == 1
     }
 

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1256,8 +1256,12 @@ impl Core {
     /// Returns `true` if the transition happened.
     fn transition_from_parked(&mut self, worker: &Worker) -> bool {
         // If a task is in the lifo slot/run queue, then we must unpark regardless of
-        // being notified
-        if self.has_tasks() {
+        // being notified. The same applies when this worker has been woken to be
+        // traced for a task dump: a dump unparks the worker threads directly,
+        // without going through `Idle`, so the worker performs that transition
+        // itself here. Otherwise it is counted as a sleeper a second time when it
+        // parks again after tracing.
+        if self.has_tasks() || self.is_traced {
             // When a worker wakes, it should only transition to the "searching"
             // state when the wake originates from another worker *or* a new task
             // is pushed. We do *not* want the worker to transition to "searching"

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1228,7 +1228,7 @@ impl Core {
     ///
     /// Returns true if the transition happened, false if there is work to do first.
     fn transition_to_parked(&mut self, worker: &Worker) -> bool {
-        // Workers should not park if they have work to do
+        // Workers should not park if they have work to do or are about to be traced
         if self.has_tasks() || self.is_traced {
             return false;
         }
@@ -1256,11 +1256,8 @@ impl Core {
     /// Returns `true` if the transition happened.
     fn transition_from_parked(&mut self, worker: &Worker) -> bool {
         // If a task is in the lifo slot/run queue, then we must unpark regardless of
-        // being notified. The same applies when this worker has been woken to be
-        // traced for a task dump: a dump unparks the worker threads directly,
-        // without going through `Idle`, so the worker performs that transition
-        // itself here. Otherwise it is counted as a sleeper a second time when it
-        // parks again after tracing.
+        // being notified. Same when woken to be traced: a dump unparks worker
+        // threads without going through `Idle`, so the worker does it here.
         if self.has_tasks() || self.is_traced {
             // When a worker wakes, it should only transition to the "searching"
             // state when the wake originates from another worker *or* a new task

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -202,3 +202,109 @@ fn notified_during_tracing() {
         );
     });
 }
+
+/// Regression tests for the scheduler's idle bookkeeping across a dump.
+///
+/// Requesting a dump wakes every worker thread directly, without going through
+/// the multi-threaded scheduler's idle bookkeeping. A worker that was parked
+/// when the dump began must therefore perform the logical unpark itself, or the
+/// bookkeeping is corrupted the next time it parks: it is recorded as a sleeper
+/// twice and the count of unparked workers underflows. After that, the runtime
+/// believes every worker is busy and never notifies one of newly spawned work.
+mod dump_of_parked_workers {
+    use super::*;
+
+    use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+    use std::sync::{mpsc, Arc};
+    use std::time::{Duration, Instant};
+
+    const TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// Observes the worker threads entering and leaving the park path.
+    #[derive(Default)]
+    struct ParkState {
+        /// Number of workers currently in the park path.
+        parked: AtomicUsize,
+        /// Number of times a worker has entered the park path.
+        entries: AtomicUsize,
+    }
+
+    impl ParkState {
+        fn wait_until(&self, mut condition: impl FnMut(&Self) -> bool, message: &str) {
+            let deadline = Instant::now() + TIMEOUT;
+            while !condition(self) {
+                assert!(Instant::now() < deadline, "{message}");
+                std::thread::yield_now();
+            }
+        }
+
+        fn wait_for_all_workers_parked(&self, worker_threads: usize) {
+            self.wait_until(
+                |state| state.parked.load(SeqCst) == worker_threads,
+                "not every worker reached the park path",
+            );
+        }
+    }
+
+    fn assert_dump_preserves_idle_bookkeeping(worker_threads: usize) {
+        let park_state = Arc::new(ParkState::default());
+
+        let rt = runtime::Builder::new_multi_thread()
+            .enable_all()
+            .worker_threads(worker_threads)
+            .on_thread_park({
+                let park_state = park_state.clone();
+                move || {
+                    park_state.entries.fetch_add(1, SeqCst);
+                    park_state.parked.fetch_add(1, SeqCst);
+                }
+            })
+            .on_thread_unpark({
+                let park_state = park_state.clone();
+                move || {
+                    park_state.parked.fetch_sub(1, SeqCst);
+                }
+            })
+            .build()
+            .unwrap();
+
+        // Dump only once every worker is idle. That is the state in which the
+        // dump wakes worker threads that the scheduler still counts as parked.
+        park_state.wait_for_all_workers_parked(worker_threads);
+        let entries_before_dump = park_state.entries.load(SeqCst);
+
+        rt.block_on(rt.handle().dump());
+
+        // Every worker leaves the park path to be traced, then parks again.
+        park_state.wait_until(
+            |state| state.entries.load(SeqCst) >= entries_before_dump + worker_threads,
+            "not every worker was woken for the dump",
+        );
+        park_state.wait_for_all_workers_parked(worker_threads);
+
+        let (tx, rx) = mpsc::channel();
+        rt.spawn(async move {
+            let _ = tx.send(());
+        });
+
+        assert!(
+            rx.recv_timeout(TIMEOUT).is_ok(),
+            "the runtime did not run a task spawned after a dump"
+        );
+    }
+
+    #[test]
+    fn one_worker() {
+        assert_dump_preserves_idle_bookkeeping(1);
+    }
+
+    #[test]
+    fn two_workers() {
+        assert_dump_preserves_idle_bookkeeping(2);
+    }
+
+    #[test]
+    fn many_workers() {
+        assert_dump_preserves_idle_bookkeeping(8);
+    }
+}


### PR DESCRIPTION
## Motivation

On the multi-threaded runtime, a task dump taken while a worker is idle corrupts the scheduler's idle bookkeeping, after which tasks spawned from outside the runtime never run.

`Handle::dump` calls `notify_all`, which unparks worker threads directly instead of going through `Idle`, so a parked worker is woken for tracing while the scheduler still counts it as a sleeper. `transition_from_parked` doesn't account
for that: with no tasks queued it returns without performing the logical unpark, so when the worker parks again after tracing it is pushed onto `sleepers` twice and `num_unparked` is decremented twice, underflowing. From then on
`notify_should_wakeup` is always false and no worker is ever notified of new work.

## Solution

Treat a worker woken for tracing like a worker woken with tasks queued and perform the logical unpark. This mirrors `transition_to_parked`, which already refuses to park a worker that is about to be traced.

The regression tests in `tokio/tests/dump.rs` park every worker, take a dump, wait for the workers to be traced and re-park, then assert that a task spawned from outside the runtime still runs. 

The `current_thread` scheduler is unaffected; it has no idle bookkeeping of this kind.
