### PR TITLE
macros: support cfg-gated `select!` branches

### DIFF
--- a/tests-build/tests/fail/macros_select_cfg_invalid.rs
+++ b/tests-build/tests/fail/macros_select_cfg_invalid.rs
@@ -1,0 +1,47 @@
+use tests_build::tokio;
+
+async fn cfg_attr_is_rejected() {
+    tokio::select! {
+        #[cfg_attr(all(), allow(unused))]
+        _ = async {} => {},
+    }
+}
+
+async fn arbitrary_attribute_is_rejected() {
+    tokio::select! {
+        #[allow(unused)]
+        _ = async {} => {},
+    }
+}
+
+async fn stacked_cfg_is_rejected() {
+    tokio::select! {
+        #[cfg(all())]
+        #[cfg(all())]
+        _ = async {} => {},
+    }
+}
+
+async fn cfg_before_else_is_rejected() {
+    tokio::select! {
+        #[cfg(all())]
+        else => (),
+    }
+}
+
+async fn cfg_before_biased_is_rejected() {
+    tokio::select! {
+        #[cfg(all())]
+        biased;
+        _ = async {} => {},
+    }
+}
+
+async fn inner_attribute_is_rejected() {
+    tokio::select! {
+        #![cfg(all())]
+        _ = async {} => {},
+    }
+}
+
+fn main() {}

--- a/tests-build/tests/fail/macros_select_cfg_invalid.stderr
+++ b/tests-build/tests/fail/macros_select_cfg_invalid.stderr
@@ -1,0 +1,77 @@
+error: no rules expected `cfg_attr`
+ --> tests/fail/macros_select_cfg_invalid.rs:5:11
+  |
+5 |         #[cfg_attr(all(), allow(unused))]
+  |           ^^^^^^^^ no rules expected this token in macro call
+  |
+note: while trying to match `cfg`
+ --> $WORKSPACE/tokio/src/macros/select.rs
+  |
+  |     (#[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+  |        ^^^
+
+error: no rules expected `allow`
+  --> tests/fail/macros_select_cfg_invalid.rs:12:11
+   |
+12 |         #[allow(unused)]
+   |           ^^^^^ no rules expected this token in macro call
+   |
+note: while trying to match `cfg`
+  --> $WORKSPACE/tokio/src/macros/select.rs
+   |
+   |     (#[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+   |        ^^^
+
+error: no rules expected `#`
+  --> tests/fail/macros_select_cfg_invalid.rs:20:9
+   |
+20 |         #[cfg(all())]
+   |         ^ no rules expected this token in macro call
+   |
+note: while trying to match meta-variable `$p:pat`
+  --> $WORKSPACE/tokio/src/macros/select.rs
+   |
+   |     (#[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+   |                           ^^^^^^
+
+error: expected identifier, found keyword `else`
+  --> tests/fail/macros_select_cfg_invalid.rs:28:9
+   |
+28 |         else => (),
+   |         ^^^^ expected identifier, found keyword
+
+error: no rules expected `=>`
+  --> tests/fail/macros_select_cfg_invalid.rs:28:14
+   |
+28 |         else => (),
+   |              ^^ no rules expected this token in macro call
+   |
+note: while trying to match `=`
+  --> $WORKSPACE/tokio/src/macros/select.rs
+   |
+   |     (#[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+   |                                  ^
+
+error: no rules expected `;`
+  --> tests/fail/macros_select_cfg_invalid.rs:35:15
+   |
+35 |         biased;
+   |               ^ no rules expected this token in macro call
+   |
+note: while trying to match `=`
+  --> $WORKSPACE/tokio/src/macros/select.rs
+   |
+   |     (#[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+   |                                  ^
+
+error: no rules expected `!`
+  --> tests/fail/macros_select_cfg_invalid.rs:42:10
+   |
+42 |         #![cfg(all())]
+   |          ^ no rules expected this token in macro call
+   |
+note: while trying to match `[`
+  --> $WORKSPACE/tokio/src/macros/select.rs
+   |
+   |     (#[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+   |       ^

--- a/tests-build/tests/macros.rs
+++ b/tests-build/tests/macros.rs
@@ -18,6 +18,12 @@ fn compile_fail_full() {
     #[cfg(feature = "full")]
     t.pass("tests/pass/use_builder_outer.rs");
 
+    #[cfg(any(feature = "full", feature = "rt"))]
+    t.pass("tests/pass/macros_select_cfg.rs");
+
+    #[cfg(any(feature = "full", feature = "rt"))]
+    t.compile_fail("tests/fail/macros_select_cfg_invalid.rs");
+
     #[cfg(feature = "full")]
     t.compile_fail("tests/fail/macros_invalid_input.rs");
 

--- a/tests-build/tests/pass/macros_select_cfg.rs
+++ b/tests-build/tests/pass/macros_select_cfg.rs
@@ -1,0 +1,49 @@
+use std::future;
+
+use tests_build::tokio;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    // These names deliberately overlap with identifiers used by the macro's
+    // expansion. They must continue to refer to the caller's bindings.
+    let start = 1usize;
+    let futures = 2usize;
+    let disabled = 4usize;
+    let mask = 8usize;
+    let output = 16usize;
+    let poll_fn = 32usize;
+    let branch = 64usize;
+    let cx = 128usize;
+
+    let hygienic = tokio::select! {
+        #[cfg(all())]
+        value = future::ready(start + futures + disabled + mask + output + poll_fn + branch + cx) => value,
+    };
+    assert_eq!(hygienic, 255);
+
+    let expected = if cfg!(feature = "full") { 1 } else { 2 };
+    let selected = tokio::select! {
+        #[cfg(feature = "full")]
+        value = future::ready(1usize) => value,
+        #[cfg(not(feature = "full"))]
+        value = future::ready(2usize) => value,
+    };
+    assert_eq!(selected, expected);
+
+    let unresolved = tokio::select! {
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable),
+            if missing::precondition() => missing::handler(binding),
+        value = future::ready(3usize) => value,
+    };
+    assert_eq!(unresolved, 3);
+
+    let nested = tokio::select! {
+        #[cfg(all())]
+        outer = future::ready(4usize) => tokio::select! {
+            #[cfg(all())]
+            inner = future::ready(5usize) => outer + inner,
+        },
+    };
+    assert_eq!(nested, 9);
+}

--- a/tokio/src/macros/select.rs
+++ b/tokio/src/macros/select.rs
@@ -9,7 +9,7 @@ macro_rules! doc {
         /// The `select!` macro accepts one or more branches with the following pattern:
         ///
         /// ```text
-        /// <pattern> = <async expression> (, if <precondition>)? => <handler>,
+        /// (#[cfg(<condition>)])? <pattern> = <async expression> (, if <precondition>)? => <handler>,
         /// ```
         ///
         /// Additionally, the `select!` macro may include a single, optional `else`
@@ -30,16 +30,26 @@ macro_rules! doc {
         /// `<async expression>` is still evaluated but the resulting future is never
         /// polled. This capability is useful when using `select!` within a loop.
         ///
+        /// A branch may also begin with exactly one `#[cfg(...)]` attribute. The
+        /// condition is evaluated in the context of the crate that invokes `select!`.
+        /// When the condition is false, the entire branch is absent: its pattern,
+        /// future, precondition, and handler do not need to resolve or type-check and
+        /// do not affect branch selection. The disabled branch must still be
+        /// syntactically valid. Other branch attributes, including `cfg_attr`, are not
+        /// supported.
+        ///
         /// The complete lifecycle of a `select!` expression is as follows:
         ///
-        /// 1. Evaluate all provided `<precondition>` expressions. If the precondition
-        ///    returns `false`, disable the branch for the remainder of the current call
-        ///    to `select!`. Re-entering `select!` due to a loop clears the "disabled"
-        ///    state.
-        /// 2. Aggregate the `<async expression>`s from each branch, including the
-        ///    disabled ones. If the branch is disabled, `<async expression>` is still
-        ///    evaluated, but the resulting future is not polled.
-        /// 3. If **all** branches are disabled: go to step 6.
+        /// 1. For each branch included by `#[cfg]`, evaluate its provided
+        ///    `<precondition>` expression. If the precondition returns `false`, disable
+        ///    the branch for the remainder of the current call to `select!`. Re-entering
+        ///    `select!` due to a loop clears the "disabled" state.
+        /// 2. Aggregate the `<async expression>`s from each included branch, including
+        ///    those disabled by a precondition. If a branch is disabled by its
+        ///    precondition, `<async expression>` is still evaluated, but the resulting
+        ///    future is not polled.
+        /// 3. If **all** included branches are disabled, or no branch is included: go
+        ///    to step 6.
         /// 4. Concurrently await on the results for all remaining `<async expression>`s.
         /// 5. Once an `<async expression>` returns a value, attempt to apply the value to the
         ///    provided `<pattern>`. If the pattern matches, evaluate the `<handler>` and return.
@@ -85,7 +95,8 @@ macro_rules! doc {
         /// The `select!` macro panics if all branches are disabled **and** there is no
         /// provided `else` branch. A branch is disabled when the provided `if`
         /// precondition returns `false` **or** when the pattern does not match the
-        /// result of `<async expression>`.
+        /// result of `<async expression>`. The macro also panics when `#[cfg]` excludes
+        /// every branch and no `else` branch is provided.
         ///
         /// # Cancellation safety
         ///
@@ -151,6 +162,23 @@ macro_rules! doc {
         /// read data is lost.
         ///
         /// # Examples
+        ///
+        /// Conditionally including branches. The conditions in this example are
+        /// deterministic: `all()` is true and `any()` is false.
+        ///
+        /// ```
+        /// # #[tokio::main(flavor = "current_thread")]
+        /// # async fn main() {
+        /// let value = tokio::select! {
+        ///     #[cfg(any())]
+        ///     _ = unavailable_future() => unreachable!(),
+        ///     #[cfg(all())]
+        ///     value = async { 1 } => value,
+        /// };
+        ///
+        /// assert_eq!(value, 1);
+        /// # }
+        /// ```
         ///
         /// Basic select with two branches.
         ///
@@ -562,6 +590,9 @@ doc! {macro_rules! select {
             biased;
         )?
         $(
+            $(
+                #[cfg($($cfg:tt)*)]
+            )?
             $bind:pat = $fut:expr $(, if $cond:expr)? => $handler:expr,
         )*
         $(
@@ -760,6 +791,12 @@ doc! {macro_rules! select {
     // These rules match a single `select!` branch and normalize it for
     // processing by the first rule.
 
+    (@ { start=$_start:expr; () } ) => {{
+        panic!("all branches are disabled and there is no else branch")
+    }};
+    (@ { start=$_start:expr; () } else => $else:expr $(,)?) => {{
+        $else
+    }};
     (@ { start=$start:expr; $($t:tt)* } ) => {
         // No `else` branch
         $crate::select!(@{ start=$start; $($t)*; panic!("all branches are disabled and there is no else branch") })
@@ -767,6 +804,86 @@ doc! {macro_rules! select {
     (@ { start=$start:expr; $($t:tt)* } else => $else:expr $(,)?) => {
         $crate::select!(@{ start=$start; $($t)*; $else })
     };
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr, if $c:expr => $h:block, $($r:tt)* ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if $c => $h, } $($r)*)
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* } $($r)*)
+        }
+    }};
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr => $h:block, $($r:tt)* ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if true => $h, } $($r)*)
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* } $($r)*)
+        }
+    }};
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr, if $c:expr => $h:block $($r:tt)* ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if $c => $h, } $($r)*)
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* } $($r)*)
+        }
+    }};
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr => $h:block $($r:tt)* ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if true => $h, } $($r)*)
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* } $($r)*)
+        }
+    }};
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr, if $c:expr => $h:expr ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if $c => $h, })
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* })
+        }
+    }};
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr => $h:expr ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if true => $h, })
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* })
+        }
+    }};
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr, if $c:expr => $h:expr, $($r:tt)* ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if $c => $h, } $($r)*)
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* } $($r)*)
+        }
+    }};
+    (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } #[cfg($($meta:tt)*)] $p:pat = $f:expr => $h:expr, $($r:tt)* ) => {{
+        #[cfg($($meta)*)]
+        {
+            $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if true => $h, } $($r)*)
+        }
+        #[cfg(not($($meta)*))]
+        {
+            $crate::select!(@{ start=$start; ($($s)*) $($t)* } $($r)*)
+        }
+    }};
     (@ { start=$start:expr; ( $($s:tt)* ) $($t:tt)* } $p:pat = $f:expr, if $c:expr => $h:block, $($r:tt)* ) => {
         $crate::select!(@{ start=$start; ($($s)* _) $($t)* ($($s)*) $p = $f, if $c => $h, } $($r)*)
     };
@@ -798,8 +915,16 @@ doc! {macro_rules! select {
         $else
     }};
 
+    (biased; #[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+        $crate::select!(@{ start=0; () } #[cfg($($meta)*)] $p = $($t)*)
+    };
+
     (biased; $p:pat = $($t:tt)* ) => {
         $crate::select!(@{ start=0; () } $p = $($t)*)
+    };
+
+    (#[cfg($($meta:tt)*)] $p:pat = $($t:tt)* ) => {
+        $crate::select!(@{ start={ $crate::macros::support::thread_rng_n(BRANCHES) }; () } #[cfg($($meta)*)] $p = $($t)*)
     };
 
     ( $p:pat = $($t:tt)* ) => {

--- a/tokio/tests/macros_select.rs
+++ b/tokio/tests/macros_select.rs
@@ -427,8 +427,12 @@ async fn use_future_in_if_condition_biased() {
 #[maybe_tokio_test]
 async fn many_branches() {
     let num = tokio::select! {
+        #[cfg(any())]
+        _ = async { 0 } => unreachable!(),
         x = async { 1 } => x,
         x = async { 1 } => x,
+        #[cfg(any())]
+        _ = async { 0 } => unreachable!(),
         x = async { 1 } => x,
         x = async { 1 } => x,
         x = async { 1 } => x,
@@ -491,6 +495,8 @@ async fn many_branches() {
         x = async { 1 } => x,
         x = async { 1 } => x,
         x = async { 1 } => x,
+        #[cfg(any())]
+        _ = async { 0 } => unreachable!(),
     };
 
     assert_eq!(1, num);
@@ -627,6 +633,344 @@ async fn mut_ref_patterns() {
             assert_eq!(*foo, "2");
         },
     };
+
+    tokio::select! {
+        #[cfg(all())]
+        Some(ref mut foo) = async { Some("1".to_string()) } => {
+            assert_eq!(*foo, "1");
+            *foo = "2".to_string();
+            assert_eq!(*foo, "2");
+        },
+    };
+}
+
+#[maybe_tokio_test]
+async fn cfg_disabled_branch_forms_do_not_resolve() {
+    let non_terminal = tokio::select! {
+        // Block handler, condition, trailing comma.
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable),
+            if missing::precondition() => { missing::handler(binding) },
+
+        // Block handler, trailing comma.
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable) => {
+            missing::handler(binding)
+        },
+
+        // Block handler, condition, no trailing comma.
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable),
+            if missing::precondition() => { missing::handler(binding) }
+
+        // Block handler, no trailing comma.
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable) => {
+            missing::handler(binding)
+        }
+
+        // Expression handler, condition, trailing comma.
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable),
+            if missing::precondition() => missing::handler(binding),
+
+        // Expression handler, trailing comma.
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable) =>
+            missing::handler(binding),
+
+        else => 1usize,
+    };
+
+    let expression_condition_terminal = tokio::select! {
+        value = async { 2usize } => value,
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable),
+            if missing::precondition() => missing::handler(binding)
+    };
+
+    let expression_terminal = tokio::select! {
+        value = async { 3usize } => value,
+        #[cfg(any())]
+        missing::Pattern(binding) = missing::future::<missing::Type>(missing_variable) =>
+            missing::handler(binding)
+    };
+
+    assert_eq!(
+        [
+            non_terminal,
+            expression_condition_terminal,
+            expression_terminal,
+        ],
+        [1, 2, 3]
+    );
+}
+
+#[maybe_tokio_test]
+async fn cfg_branches_before_between_and_after_enabled_branches() {
+    let value = tokio::select! {
+        biased;
+
+        #[cfg(any())]
+        _ = async { 0usize } => 0,
+        _ = std::future::pending::<usize>(), if false => 1,
+        #[cfg(any())]
+        _ = async { 0usize } => 0,
+        value = async { 2usize } => value,
+        #[cfg(any())]
+        _ = async { 0usize } => 0,
+    };
+
+    assert_eq!(value, 2);
+}
+
+#[maybe_tokio_test]
+async fn cfg_compound_predicates_and_survivor_orders() {
+    let included = tokio::select! {
+        #[cfg(all(all(), not(any())))]
+        value = async { String::from("included") } => value,
+        _ = std::future::pending::<String>() => unreachable!(),
+    };
+
+    let excluded = tokio::select! {
+        value = async { String::from("ordinary") } => value,
+        #[cfg(any(any(), not(all())))]
+        _ = async { String::from("excluded") } => unreachable!(),
+    };
+
+    assert_eq!(included, "included");
+    assert_eq!(excluded, "ordinary");
+}
+
+#[maybe_tokio_test]
+async fn cfg_true_branch_preserves_precondition_semantics() {
+    use std::cell::Cell;
+
+    let constructions = Cell::new(0);
+    let value = tokio::select! {
+        #[cfg(all())]
+        _ = {
+            constructions.set(constructions.get() + 1);
+            std::future::pending::<()>()
+        }, if false => 0,
+        else => 1,
+    };
+
+    assert_eq!(value, 1);
+    assert_eq!(constructions.get(), 1);
+}
+
+#[maybe_tokio_test]
+async fn cfg_all_disabled_uses_else() {
+    let unbiased = tokio::select! {
+        #[cfg(any())]
+        missing::Pattern(value) = missing::future::<missing::Type>(missing_variable),
+            if missing::precondition() => missing::handler(value),
+        else => 11usize,
+    };
+
+    let biased = tokio::select! {
+        biased;
+
+        #[cfg(any())]
+        missing::Pattern(value) = missing::future::<missing::Type>(missing_variable),
+            if missing::precondition() => missing::handler(value),
+        else => 12usize,
+    };
+
+    assert_eq!(unbiased, 11);
+    assert_eq!(biased, 12);
+}
+
+#[cfg(panic = "unwind")]
+#[cfg(not(target_family = "wasm"))] // wasm currently doesn't support unwinding
+#[maybe_tokio_test]
+async fn cfg_all_disabled_without_else_panics() {
+    use futures::FutureExt;
+
+    let panic = std::panic::AssertUnwindSafe(async {
+        tokio::select! {
+            #[cfg(any())]
+            missing::Pattern(value) = missing::future::<missing::Type>(missing_variable),
+                if missing::precondition() => missing::handler(value),
+        }
+    })
+    .catch_unwind()
+    .await
+    .expect_err("select! should panic when cfg excludes every branch");
+
+    let message = panic
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic.downcast_ref::<String>().map(String::as_str));
+    assert_eq!(
+        message,
+        Some("all branches are disabled and there is no else branch")
+    );
+}
+
+#[maybe_tokio_test]
+async fn cfg_biased_first_branch_disabled() {
+    let value = tokio::select! {
+        biased;
+
+        #[cfg(any())]
+        _ = async { 0usize } => 0,
+        value = async { 1usize } => value,
+        _ = async { 2usize } => 2,
+    };
+
+    assert_eq!(value, 1);
+}
+
+#[maybe_tokio_test]
+async fn cfg_preserves_all_branch_grammar_forms() {
+    let block_condition_comma = tokio::select! {
+        #[cfg(all())]
+        value = async { 1usize }, if true => { value },
+        _ = std::future::pending::<usize>() => unreachable!(),
+    };
+
+    let block_comma = tokio::select! {
+        #[cfg(all())]
+        value = async { 2usize } => { value },
+        _ = std::future::pending::<usize>() => unreachable!(),
+    };
+
+    let block_condition_no_comma = tokio::select! {
+        #[cfg(all())]
+        value = async { 3usize }, if true => { value }
+        _ = std::future::pending::<usize>() => unreachable!(),
+    };
+
+    let block_no_comma = tokio::select! {
+        #[cfg(all())]
+        value = async { 4usize } => { value }
+        _ = std::future::pending::<usize>() => unreachable!(),
+    };
+
+    let expression_condition_terminal = tokio::select! {
+        #[cfg(all())]
+        value = async { 5usize }, if true => value
+    };
+
+    let expression_terminal = tokio::select! {
+        #[cfg(all())]
+        value = async { 6usize } => value
+    };
+
+    let expression_condition_comma = tokio::select! {
+        #[cfg(all())]
+        value = async { 7usize }, if true => match value {
+            7 => value,
+            _ => unreachable!(),
+        },
+        _ = std::future::pending::<usize>() => unreachable!(),
+    };
+
+    let expression_comma = tokio::select! {
+        #[cfg(all())]
+        value = async { 8usize } => match value {
+            8 => value,
+            _ => unreachable!(),
+        },
+        _ = std::future::pending::<usize>() => unreachable!(),
+    };
+
+    assert_eq!(
+        [
+            block_condition_comma,
+            block_comma,
+            block_condition_no_comma,
+            block_no_comma,
+            expression_condition_terminal,
+            expression_terminal,
+            expression_condition_comma,
+            expression_comma,
+        ],
+        [1, 2, 3, 4, 5, 6, 7, 8]
+    );
+}
+
+#[maybe_tokio_test]
+async fn cfg_nested_selects() {
+    let value = tokio::select! {
+        #[cfg(all())]
+        outer = async { 2usize } => tokio::select! {
+            #[cfg(any())]
+            _ = async { 0usize } => 0,
+            #[cfg(all())]
+            inner = async { 3usize } => outer + inner,
+        },
+    };
+
+    assert_eq!(value, 5);
+}
+
+#[test]
+fn cfg_disabled_branch_has_no_future_or_output_storage() {
+    let baseline = async {
+        tokio::select! {
+            value = std::future::pending::<usize>() => value,
+        }
+    };
+
+    let with_disabled = async {
+        tokio::select! {
+            #[cfg(any())]
+            value = async { [0u8; 4096] } => value.len(),
+            value = std::future::pending::<usize>() => value,
+        }
+    };
+
+    assert_eq!(
+        std::mem::size_of_val(&with_disabled),
+        std::mem::size_of_val(&baseline)
+    );
+}
+
+#[maybe_tokio_test]
+async fn cfg_heavy_branch_list() {
+    let value = tokio::select! {
+        biased;
+
+        #[cfg(any())]
+        _ = async { 0usize } => 0,
+        #[cfg(any())]
+        _ = async { 1usize } => 1,
+        #[cfg(any())]
+        _ = async { 2usize } => 2,
+        #[cfg(any())]
+        _ = async { 3usize } => 3,
+        #[cfg(any())]
+        _ = async { 4usize } => 4,
+        #[cfg(any())]
+        _ = async { 5usize } => 5,
+        #[cfg(any())]
+        _ = async { 6usize } => 6,
+        #[cfg(any())]
+        _ = async { 7usize } => 7,
+        #[cfg(any())]
+        _ = async { 8usize } => 8,
+        #[cfg(any())]
+        _ = async { 9usize } => 9,
+        #[cfg(any())]
+        _ = async { 10usize } => 10,
+        #[cfg(any())]
+        _ = async { 11usize } => 11,
+        #[cfg(any())]
+        _ = async { 12usize } => 12,
+        #[cfg(any())]
+        _ = async { 13usize } => 13,
+        #[cfg(any())]
+        _ = async { 14usize } => 14,
+        #[cfg(any())]
+        _ = async { 15usize } => 15,
+        #[cfg(all())]
+        value = async { 16usize } => value,
+    };
+
+    assert_eq!(value, 16);
 }
 
 #[cfg(tokio_unstable)]
@@ -649,6 +993,23 @@ mod unstable {
         let rt2_values = rt2.block_on(async { (select_0_to_9().await, select_0_to_9().await) });
 
         assert_eq!(rt1_values, rt2_values);
+    }
+
+    #[test]
+    fn cfg_disabled_branches_do_not_change_randomized_selection() {
+        let seed = b"cfg-disabled branches do not affect branch count";
+        let plain = tokio::runtime::Builder::new_current_thread()
+            .rng_seed(RngSeed::from_bytes(seed))
+            .build()
+            .unwrap()
+            .block_on(async { collect_plain_sequence().await });
+        let with_disabled = tokio::runtime::Builder::new_current_thread()
+            .rng_seed(RngSeed::from_bytes(seed))
+            .build()
+            .unwrap()
+            .block_on(async { collect_cfg_sequence().await });
+
+        assert_eq!(plain, with_disabled);
     }
 
     #[test]
@@ -708,6 +1069,36 @@ mod unstable {
             x = async { 9 } => x,
         )
     }
+
+    async fn collect_plain_sequence() -> Vec<u8> {
+        let mut values = Vec::with_capacity(256);
+        for _ in 0..256 {
+            values.push(tokio::select! {
+                value = async { 0u8 } => value,
+                value = async { 1u8 } => value,
+                value = async { 2u8 } => value,
+            });
+        }
+        values
+    }
+
+    async fn collect_cfg_sequence() -> Vec<u8> {
+        let mut values = Vec::with_capacity(256);
+        for _ in 0..256 {
+            values.push(tokio::select! {
+                #[cfg(any())]
+                _ = async { 10u8 } => 10,
+                value = async { 0u8 } => value,
+                #[cfg(any())]
+                _ = async { 11u8 } => 11,
+                value = async { 1u8 } => value,
+                value = async { 2u8 } => value,
+                #[cfg(any())]
+                _ = async { 12u8 } => 12,
+            });
+        }
+        values
+    }
 }
 
 #[tokio::test]
@@ -725,12 +1116,22 @@ async fn select_into_future() {
     tokio::select! {
         () = NotAFuture => {},
     }
+
+    tokio::select! {
+        #[cfg(all())]
+        () = NotAFuture => {},
+    }
 }
 
 // regression test for https://github.com/tokio-rs/tokio/issues/6721
 #[tokio::test]
 async fn temporary_lifetime_extension() {
     tokio::select! {
+        () = &mut std::future::ready(()) => {},
+    }
+
+    tokio::select! {
+        #[cfg(all())]
         () = &mut std::future::ready(()) => {},
     }
 }


### PR DESCRIPTION
## Motivation

`select!` cannot currently conditionally compile individual branches. Existing workarounds either duplicate the surrounding invocation or leave disabled branches in generated state, which can require unavailable code to resolve and can alter randomized selection.

Fixes #3974.

## Solution

Accept one branch-level `#[cfg(...)]` and filter cfg-disabled branches during normalization, before generating future/output storage, branch counts, masks, polling, and handler dispatch. This keeps enabled ordinals dense, preserves randomized fairness, and leaves the existing branch grammar and no-cfg path unchanged.

Add integration and downstream compile tests for disabled unresolved code, cfg-enabled behavior, caller-context features, grammar compatibility, preconditions, `biased;`, `else`, all-disabled semantics, storage, the 64-branch boundary, macro hygiene, and deterministic randomized selection.
