### PR TITLE
Fix UAF in io_uring submit: handle EAGAIN like EBUSY

### DIFF
--- a/tokio/src/runtime/io/driver/uring.rs
+++ b/tokio/src/runtime/io/driver/uring.rs
@@ -117,6 +117,14 @@ impl UringContext {
                 Err(ref e) if e.raw_os_error() == Some(libc::EBUSY) => {
                     self.dispatch_completions();
                 }
+                // EAGAIN means the kernel ran out of resources; drain completions
+                // and retry, same as EBUSY. Otherwise, the SQE remains queued in
+                // the kernel ring while we remove_op() and drop the associated data,
+                // leading to a use-after-free when the kernel eventually executes
+                // the stale SQE.
+                Err(ref e) if e.raw_os_error() == Some(libc::EAGAIN) => {
+                    self.dispatch_completions();
+                }
                 // For other errors, we currently return the error as is.
                 Err(e) => {
                     return Err(e);


### PR DESCRIPTION
Fixes #8255

When the kernel returns EAGAIN from io_uring_enter, the SQE is already queued in the submission ring. submit() returned the error, and register_op's submit_or_remove closure called remove_op() + Op::poll dropped the data the SQE points to. A later successful submit executing the stale SQE against freed memory causes use-after-free.