### PR TITLE
fs: skip io_uring path gracefully when IO driver is disabled

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -1017,20 +1017,20 @@ impl Inner {
         ))]
         {
             if let Ok(handle) = crate::runtime::Handle::try_current() {
-                let driver_handle = handle.inner.driver().io();
+                if let Some(driver_handle) = handle.inner.driver().try_io() {
+                    if driver_handle.is_uring_ready(io_uring::opcode::Read::CODE) {
+                        // Fast path: uring already initialized and Read supported.
+                        let fd: crate::io::uring::utils::ArcFd = std;
+                        return Ok(spawn(Self::uring_read(fd, buf, max_buf_size)));
+                    }
 
-                if driver_handle.is_uring_ready(io_uring::opcode::Read::CODE) {
-                    // Fast path: uring already initialized and Read supported.
-                    let fd: crate::io::uring::utils::ArcFd = std;
-                    return Ok(spawn(Self::uring_read(fd, buf, max_buf_size)));
+                    if !driver_handle.is_uring_probed() {
+                        // Not yet probed: lazy init inside an async task so
+                        // `File::from_std()` can still benefit from io-uring.
+                        return Ok(spawn(Self::lazy_init_read(std, buf, max_buf_size)));
+                    }
+                    // Probed but unsupported: fall through to spawn_blocking.
                 }
-
-                if !driver_handle.is_uring_probed() {
-                    // Not yet probed: lazy init inside an async task so
-                    // `File::from_std()` can still benefit from io-uring.
-                    return Ok(spawn(Self::lazy_init_read(std, buf, max_buf_size)));
-                }
-                // Probed but unsupported: fall through to spawn_blocking.
             }
         }
 
@@ -1084,12 +1084,14 @@ impl Inner {
     ))]
     async fn lazy_init_read(std: Arc<StdFile>, buf: Buf, max_buf_size: usize) -> (Operation, Buf) {
         let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Read::CODE)
-            .await
-            .unwrap_or_default()
-        {
+        let use_uring = match handle.inner.driver().try_io() {
+            Some(driver_handle) => driver_handle
+                .check_and_init(io_uring::opcode::Read::CODE)
+                .await
+                .unwrap_or_default(),
+            None => false,
+        };
+        if use_uring {
             let fd: crate::io::uring::utils::ArcFd = std;
             Self::uring_read(fd, buf, max_buf_size).await
         } else {

--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -1017,7 +1017,9 @@ impl Inner {
         ))]
         {
             if let Ok(handle) = crate::runtime::Handle::try_current() {
-                if let Some(driver_handle) = handle.inner.driver().try_io() {
+                let driver = handle.inner.driver();
+                if driver.has_io() {
+                    let driver_handle = driver.io();
                     if driver_handle.is_uring_ready(io_uring::opcode::Read::CODE) {
                         // Fast path: uring already initialized and Read supported.
                         let fd: crate::io::uring::utils::ArcFd = std;
@@ -1084,14 +1086,14 @@ impl Inner {
     ))]
     async fn lazy_init_read(std: Arc<StdFile>, buf: Buf, max_buf_size: usize) -> (Operation, Buf) {
         let handle = crate::runtime::Handle::current();
-        let use_uring = match handle.inner.driver().try_io() {
-            Some(driver_handle) => driver_handle
+        let driver = handle.inner.driver();
+        if driver.has_io()
+            && driver
+                .io()
                 .check_and_init(io_uring::opcode::Read::CODE)
                 .await
-                .unwrap_or_default(),
-            None => false,
-        };
-        if use_uring {
+                .unwrap_or_default()
+        {
             let fd: crate::io::uring::utils::ArcFd = std;
             Self::uring_read(fd, buf, max_buf_size).await
         } else {

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -533,12 +533,16 @@ impl OpenOptions {
             ))]
             Kind::Uring(opts) => {
                 let handle = crate::runtime::Handle::current();
-                let driver_handle = handle.inner.driver().io();
+                let use_uring = match handle.inner.driver().try_io() {
+                    Some(driver_handle) => {
+                        driver_handle
+                            .check_and_init(io_uring::opcode::OpenAt::CODE)
+                            .await?
+                    }
+                    None => false,
+                };
 
-                if driver_handle
-                    .check_and_init(io_uring::opcode::OpenAt::CODE)
-                    .await?
-                {
+                if use_uring {
                     Op::open(path, opts)?.await
                 } else {
                     let opts = opts.clone().into();

--- a/tokio/src/fs/open_options.rs
+++ b/tokio/src/fs/open_options.rs
@@ -533,16 +533,14 @@ impl OpenOptions {
             ))]
             Kind::Uring(opts) => {
                 let handle = crate::runtime::Handle::current();
-                let use_uring = match handle.inner.driver().try_io() {
-                    Some(driver_handle) => {
-                        driver_handle
-                            .check_and_init(io_uring::opcode::OpenAt::CODE)
-                            .await?
-                    }
-                    None => false,
-                };
+                let driver = handle.inner.driver();
 
-                if use_uring {
+                if driver.has_io()
+                    && driver
+                        .io()
+                        .check_and_init(io_uring::opcode::OpenAt::CODE)
+                        .await?
+                {
                     Op::open(path, opts)?.await
                 } else {
                     let opts = opts.clone().into();

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -76,12 +76,13 @@ pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
         use crate::fs::read_uring;
 
         let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Read::CODE)
-            .await?
-        {
-            return read_uring(path).await;
+        if let Some(driver_handle) = handle.inner.driver().try_io() {
+            if driver_handle
+                .check_and_init(io_uring::opcode::Read::CODE)
+                .await?
+            {
+                return read_uring(path).await;
+            }
         }
     }
 

--- a/tokio/src/fs/read.rs
+++ b/tokio/src/fs/read.rs
@@ -76,13 +76,14 @@ pub async fn read(path: impl AsRef<Path>) -> io::Result<Vec<u8>> {
         use crate::fs::read_uring;
 
         let handle = crate::runtime::Handle::current();
-        if let Some(driver_handle) = handle.inner.driver().try_io() {
-            if driver_handle
+        let driver = handle.inner.driver();
+        if driver.has_io()
+            && driver
+                .io()
                 .check_and_init(io_uring::opcode::Read::CODE)
                 .await?
-            {
-                return read_uring(path).await;
-            }
+        {
+            return read_uring(path).await;
         }
     }
 

--- a/tokio/src/fs/rename.rs
+++ b/tokio/src/fs/rename.rs
@@ -25,15 +25,16 @@ pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<
         use crate::runtime::driver::op::Op;
 
         let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
 
         type RenameOp = Op<Rename>;
 
-        if driver_handle
-            .check_and_init(io_uring::opcode::RenameAt::CODE)
-            .await?
-        {
-            return RenameOp::rename(from, to)?.await;
+        if let Some(driver_handle) = handle.inner.driver().try_io() {
+            if driver_handle
+                .check_and_init(io_uring::opcode::RenameAt::CODE)
+                .await?
+            {
+                return RenameOp::rename(from, to)?.await;
+            }
         }
     }
 

--- a/tokio/src/fs/rename.rs
+++ b/tokio/src/fs/rename.rs
@@ -25,16 +25,17 @@ pub async fn rename(from: impl AsRef<Path>, to: impl AsRef<Path>) -> io::Result<
         use crate::runtime::driver::op::Op;
 
         let handle = crate::runtime::Handle::current();
+        let driver = handle.inner.driver();
 
         type RenameOp = Op<Rename>;
 
-        if let Some(driver_handle) = handle.inner.driver().try_io() {
-            if driver_handle
+        if driver.has_io()
+            && driver
+                .io()
                 .check_and_init(io_uring::opcode::RenameAt::CODE)
                 .await?
-            {
-                return RenameOp::rename(from, to)?.await;
-            }
+        {
+            return RenameOp::rename(from, to)?.await;
         }
     }
 

--- a/tokio/src/fs/try_exists.rs
+++ b/tokio/src/fs/try_exists.rs
@@ -43,12 +43,13 @@ pub async fn try_exists(path: impl AsRef<Path>) -> io::Result<bool> {
     ))]
     {
         let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Statx::CODE)
-            .await?
-        {
-            return try_exists_uring(path).await;
+        if let Some(driver_handle) = handle.inner.driver().try_io() {
+            if driver_handle
+                .check_and_init(io_uring::opcode::Statx::CODE)
+                .await?
+            {
+                return try_exists_uring(path).await;
+            }
         }
     }
 

--- a/tokio/src/fs/try_exists.rs
+++ b/tokio/src/fs/try_exists.rs
@@ -43,13 +43,14 @@ pub async fn try_exists(path: impl AsRef<Path>) -> io::Result<bool> {
     ))]
     {
         let handle = crate::runtime::Handle::current();
-        if let Some(driver_handle) = handle.inner.driver().try_io() {
-            if driver_handle
+        let driver = handle.inner.driver();
+        if driver.has_io()
+            && driver
+                .io()
                 .check_and_init(io_uring::opcode::Statx::CODE)
                 .await?
-            {
-                return try_exists_uring(path).await;
-            }
+        {
+            return try_exists_uring(path).await;
         }
     }
 

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -36,12 +36,13 @@ pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Re
     ))]
     {
         let handle = crate::runtime::Handle::current();
-        let driver_handle = handle.inner.driver().io();
-        if driver_handle
-            .check_and_init(io_uring::opcode::Write::CODE)
-            .await?
-        {
-            return write_uring(path, contents).await;
+        if let Some(driver_handle) = handle.inner.driver().try_io() {
+            if driver_handle
+                .check_and_init(io_uring::opcode::Write::CODE)
+                .await?
+            {
+                return write_uring(path, contents).await;
+            }
         }
     }
 

--- a/tokio/src/fs/write.rs
+++ b/tokio/src/fs/write.rs
@@ -36,13 +36,14 @@ pub async fn write(path: impl AsRef<Path>, contents: impl AsRef<[u8]>) -> io::Re
     ))]
     {
         let handle = crate::runtime::Handle::current();
-        if let Some(driver_handle) = handle.inner.driver().try_io() {
-            if driver_handle
+        let driver = handle.inner.driver();
+        if driver.has_io()
+            && driver
+                .io()
                 .check_and_init(io_uring::opcode::Write::CODE)
                 .await?
-            {
-                return write_uring(path, contents).await;
-            }
+        {
+            return write_uring(path, contents).await;
         }
     }
 

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -93,6 +93,10 @@ impl Handle {
                 .as_ref()
                 .expect("A Tokio 1.x context was found, but IO is disabled. Call `enable_io` on the runtime builder to enable IO.")
         }
+
+        pub(crate) fn try_io(&self) -> Option<&crate::runtime::io::Handle> {
+            self.io.as_ref()
+        }
     }
 
     cfg_signal_internal_and_unix! {

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -93,7 +93,9 @@ impl Handle {
                 .as_ref()
                 .expect("A Tokio 1.x context was found, but IO is disabled. Call `enable_io` on the runtime builder to enable IO.")
         }
+    }
 
+    cfg_io_uring! {
         pub(crate) fn try_io(&self) -> Option<&crate::runtime::io::Handle> {
             self.io.as_ref()
         }

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -96,8 +96,8 @@ impl Handle {
     }
 
     cfg_io_uring! {
-        pub(crate) fn try_io(&self) -> Option<&crate::runtime::io::Handle> {
-            self.io.as_ref()
+        pub(crate) fn has_io(&self) -> bool {
+            self.io.as_ref().is_some()
         }
     }
 

--- a/tokio/tests/fs_io_driver.rs
+++ b/tokio/tests/fs_io_driver.rs
@@ -1,0 +1,78 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", not(target_os = "wasi")))] // WASI does not support all fs operations
+
+//! `tokio::fs` must work on a runtime with or without an IO driver. When the
+//! io_uring path is compiled in (`tokio_unstable` + `io-uring`) it is only
+//! probed on runtimes that have one; otherwise the blocking fallback is used.
+
+use std::path::Path;
+use tempfile::tempdir;
+use tokio::fs::{self, File, OpenOptions};
+use tokio::io::AsyncReadExt;
+use tokio::runtime::Builder;
+
+// Every fs operation that probes the io_uring driver before falling back.
+async fn exercise_fs(dir: &Path) {
+    let path = dir.join("file");
+    fs::write(&path, b"hello").await.unwrap();
+    assert_eq!(fs::read(&path).await.unwrap(), b"hello");
+
+    let mut buf = String::new();
+    let mut file = OpenOptions::new().read(true).open(&path).await.unwrap();
+    file.read_to_string(&mut buf).await.unwrap();
+    assert_eq!(buf, "hello");
+
+    buf.clear();
+    let mut file = File::from_std(std::fs::File::open(&path).unwrap());
+    file.read_to_string(&mut buf).await.unwrap();
+    assert_eq!(buf, "hello");
+
+    let renamed = dir.join("renamed");
+    fs::rename(&path, &renamed).await.unwrap();
+    assert!(!fs::try_exists(&path).await.unwrap());
+    assert!(fs::try_exists(&renamed).await.unwrap());
+}
+
+fn run(configure: impl Fn(&mut Builder) -> &mut Builder) {
+    for mut builder in [Builder::new_current_thread(), Builder::new_multi_thread()] {
+        let rt = configure(&mut builder).build().unwrap();
+        let dir = tempdir().unwrap();
+        rt.block_on(exercise_fs(dir.path()));
+    }
+}
+
+#[test]
+fn io_disabled() {
+    run(|builder| builder);
+}
+
+#[test]
+fn io_enabled() {
+    run(Builder::enable_io);
+}
+
+#[test]
+#[cfg(all(tokio_unstable, feature = "io-uring", target_os = "linux"))]
+fn io_uring_enabled() {
+    run(Builder::enable_io_uring);
+
+    // On a kernel with io_uring, `read` must still take the io_uring path:
+    // the blocking fallback would spawn a blocking thread, the uring path does not.
+    if io_uring_available() {
+        let rt = Builder::new_current_thread()
+            .enable_io_uring()
+            .build()
+            .unwrap();
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("file");
+        std::fs::write(&path, b"hello").unwrap();
+
+        assert_eq!(rt.block_on(fs::read(&path)).unwrap(), b"hello");
+        assert_eq!(rt.metrics().num_blocking_threads(), 0);
+    }
+}
+
+#[cfg(all(tokio_unstable, feature = "io-uring", target_os = "linux"))]
+fn io_uring_available() -> bool {
+    io_uring::IoUring::new(2).is_ok()
+}


### PR DESCRIPTION
## Motivation

When a Tokio runtime is built without `enable_io()` and the crate is compiled
with `tokio_unstable` + `io-uring`, filesystem operations like `tokio::fs::read`
panic before reaching the existing `spawn_blocking` fallback:

```
A Tokio 1.x context was found, but IO is disabled.
Call `enable_io` on the runtime builder to enable IO.
```

The seven `tokio::fs` callsites that probe the io_uring driver all call
`driver().io()`, which panics via `.expect()` on a disabled IO handle.

Fixes #8164

Related: #8165 fixes the same panic for `read`, `write`, `OpenOptions::open`
and `File` reads and was approved in May, but has been conflicted since July.
This PR also covers `rename` and `try_exists`.

## Solution

Add `driver::Handle::has_io() -> bool` next to the panicking `io()` accessor
and guard each io_uring probe with it, so a runtime without an IO driver falls
through to the existing blocking path.

## Changes

- `runtime/driver.rs`: add `has_io()` (gated by `cfg_io_uring!`)
- `fs/read.rs`, `fs/write.rs`, `fs/rename.rs`, `fs/try_exists.rs`,
  `fs/open_options.rs`, `fs/file.rs` (`poll_read_inner` and `lazy_init_read`):
  probe io_uring only when `has_io()`
- `tests/fs_io_driver.rs`: `io_disabled`, `io_enabled`, `io_uring_enabled`
  run `write` / `read` / `OpenOptions::open` / `File::from_std` read / `rename` /
  `try_exists` on both schedulers. Not gated on the `io-uring` feature, so CI
  runs it with and without io_uring compiled in. `io_uring_enabled` also
  checks the uring path is still taken (no blocking thread spawned).

All source changes are inside the existing
`#[cfg(all(tokio_unstable, feature = "io-uring", ...))]` blocks; the
`spawn_blocking` fallback is unchanged.

## Testing

- with fix, Linux (WSL2 6.6, io_uring), `--cfg tokio_unstable --features full,test-util,io-uring`, all `fs_*` tests: pass (3/3 in `fs_io_driver`)
- with fix, without the `io-uring` feature; without `tokio_unstable`; on Windows both ways; under miri (`--features full`): 2/2 each
- with fix, `kernel.io_uring_disabled=2` (EPERM): 3/3 pass (io_uring_available returns false, assertion skipped)
- tests only on the merge-base ea91b33 (no fix), `io-uring` + `tokio_unstable`: `io_disabled` fails with the panic above at `tokio/src/fs/write.rs:39:51`; `io_enabled` / `io_uring_enabled` pass
- tests only on the merge-base without `io-uring`: pass
- `cargo fmt --check` clean; `cargo clippy --all-features -Dwarnings` clean