### PR TITLE
net: add Safety docs and Default impls for named pipe options

### DIFF
--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -112,6 +112,8 @@ impl NamedPipeServer {
     /// This function will consume ownership of the handle given, passing
     /// responsibility for closing the handle to the returned object.
     ///
+    /// # Safety
+    ///
     /// This function is also unsafe as the primitives currently returned have
     /// the contract that they are the sole owner of the file descriptor they
     /// are wrapping. Usage of this function could accidentally allow violating
@@ -984,6 +986,8 @@ impl NamedPipeClient {
     ///
     /// This function will consume ownership of the handle given, passing
     /// responsibility for closing the handle to the returned object.
+    ///
+    /// # Safety
     ///
     /// This function is also unsafe as the primitives currently returned have
     /// the contract that they are the sole owner of the file descriptor they
@@ -2365,6 +2369,12 @@ impl ServerOptions {
     }
 }
 
+impl Default for ServerOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// A builder suitable for building and interacting with named pipes from the
 /// client side.
 ///
@@ -2584,6 +2594,12 @@ impl ClientOptions {
 
     fn get_flags(&self) -> u32 {
         self.security_qos_flags | windows_sys::FILE_FLAG_OVERLAPPED
+    }
+}
+
+impl Default for ClientOptions {
+    fn default() -> Self {
+        Self::new()
     }
 }
 


### PR DESCRIPTION
## Motivation

`cargo clippy --features full` with `tokio_unstable` reports four warnings
in `tokio::net::windows::named_pipe`:

- `missing_safety_doc` on `NamedPipeServer::from_raw_handle` and
  `NamedPipeClient::from_raw_handle`
- `new_without_default` on `ServerOptions` and `ClientOptions`

## Solution

- Add `# Safety` sections to both `from_raw_handle` doc comments (existing
  paragraph moved under the heading, no rewording).
- Add `impl Default for ServerOptions` and `impl Default for ClientOptions`,
  both delegating to `Self::new()`.

After the change, `RUSTFLAGS="--cfg tokio_unstable" cargo clippy --package tokio --features full` produces zero warnings.

## Testing

Windows, `RUSTFLAGS="--cfg tokio_unstable" cargo clippy -p tokio --features full`:

- master (060cc4e): 4 warnings in `tokio/src/net/windows/named_pipe.rs`: `:128` and `:1001` missing a `# Safety` section, `:1764` and `:2394` `new_without_default`
- this branch (dfa0313): 0 warnings

Full tokio CI matrix on a fork branch at this commit: 79/79 jobs green.