### PR TITLE
net: add `UnixSocket::set_permissions`

### DIFF
--- a/tokio/src/net/unix/socket.rs
+++ b/tokio/src/net/unix/socket.rs
@@ -3,6 +3,9 @@ use std::path::Path;
 
 use std::os::unix::io::{AsFd, AsRawFd, BorrowedFd, FromRawFd, IntoRawFd, RawFd};
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::fs::Permissions;
+
 use crate::net::{UnixDatagram, UnixListener, UnixStream};
 
 cfg_net_unix! {
@@ -242,6 +245,33 @@ impl UnixSocket {
         };
 
         UnixDatagram::from_mio(mio)
+    }
+
+    /// Sets the permissions of the socket.
+    ///
+    /// Calling this function on a socket that has already been bound will return an error.
+    ///
+    /// This calls the `fchmod(2)` operating-system function.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn set_permissions(&self, perm: Permissions) -> io::Result<()> {
+        use std::fs::File;
+        use std::mem::ManuallyDrop;
+
+        let is_bound = self.inner.local_addr()?.as_pathname().is_some();
+
+        // After binding, the file is a separate inode so `fchmod` would silently no-op
+        if is_bound {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "set_permissions cannot be called on a bound socket",
+            ));
+        }
+
+        // Safety: `self` keeps the descriptor open, and `file` neither escapes this
+        // function nor is dropped, so the descriptor is not closed.
+        let file = ManuallyDrop::new(unsafe { File::from_raw_fd(self.as_raw_fd()) });
+
+        file.set_permissions(perm)
     }
 }
 

--- a/tokio/tests/uds_socket.rs
+++ b/tokio/tests/uds_socket.rs
@@ -119,3 +119,43 @@ async fn assert_usage() -> std::io::Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
+async fn set_permissions_applies_on_bind() -> io::Result<()> {
+    use std::fs::Permissions;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("permissions.sock");
+
+    let socket = UnixSocket::new_stream()?;
+    socket.set_permissions(Permissions::from_mode(0o600))?;
+    socket.bind(&sock_path)?;
+
+    let mode = std::fs::metadata(&sock_path)?.permissions().mode();
+    assert_eq!(mode & 0o777, 0o600);
+
+    Ok(())
+}
+
+#[tokio::test]
+#[cfg(any(target_os = "linux", target_os = "android"))]
+#[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
+async fn set_permissions_after_bind_fails() -> io::Result<()> {
+    use std::fs::Permissions;
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = tempfile::tempdir().unwrap();
+    let sock_path = dir.path().join("permissions.sock");
+
+    let socket = UnixSocket::new_stream()?;
+    socket.bind(&sock_path)?;
+
+    assert!(socket
+        .set_permissions(Permissions::from_mode(0o600))
+        .is_err());
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Setting permissions on a socket after binding leaves a window where the socket sits with default permissions. Anything that connects in that window keeps its connection. This method adds a way to set permissions before binding without having to write unsafe code.

## Solution

New method `UnixSocket::set_permissions` which calls `fchmod(2)` on the socket fd. Must be called before binding, so the file is created with the mode already set. Signature mirrors `std::fs::File::set_permissions`. Linux/Android only, since fchmod on a socket fd doesn't work everywhere. 

Refs: #4422