### PR TITLE
time: avoid unnecessary current-thread driver wakeups

### DIFF
--- a/benches/time_timeout.rs
+++ b/benches/time_timeout.rs
@@ -1,4 +1,5 @@
 use std::time::{Duration, Instant};
+use std::{future::poll_fn, future::Future, task::Poll};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use tokio::{
@@ -70,6 +71,14 @@ fn multi_thread_scheduler_sleep(c: &mut Criterion) {
     do_sleep_test(c, 8, "multi_thread_sleep-8");
 }
 
+fn single_thread_scheduler_timer_registration(c: &mut Criterion) {
+    do_timer_registration_test(c, 1, "single_thread_timer_registration");
+}
+
+fn multi_thread_scheduler_timer_registration(c: &mut Criterion) {
+    do_timer_registration_test(c, 8, "multi_thread_timer_registration-8");
+}
+
 fn do_sleep_test(c: &mut Criterion, workers: usize, name: &str) {
     let runtime = build_run_time(workers);
 
@@ -98,12 +107,50 @@ async fn spawn_sleep_job(iters: usize, procs: usize) {
     }
 }
 
+fn do_timer_registration_test(c: &mut Criterion, workers: usize, name: &str) {
+    let runtime = build_run_time(workers);
+
+    c.bench_function(name, |b| {
+        b.iter_custom(|iters| {
+            let start = Instant::now();
+            runtime.block_on(async {
+                let mut handles = Vec::with_capacity(workers);
+                let iters = iters as usize;
+                let iters_per_worker = iters / workers;
+                let remainder = iters % workers;
+                for worker in 0..workers {
+                    let worker_iters = iters_per_worker + usize::from(worker < remainder);
+                    handles.push(tokio::spawn(register_timers(worker_iters)));
+                }
+                for handle in handles {
+                    handle.await.unwrap();
+                }
+            });
+            start.elapsed()
+        })
+    });
+}
+
+async fn register_timers(iters: usize) {
+    for _ in 0..iters {
+        let timer = sleep(Duration::from_secs(1));
+        tokio::pin!(timer);
+        poll_fn(|cx| {
+            assert!(timer.as_mut().poll(cx).is_pending());
+            Poll::Ready(())
+        })
+        .await;
+    }
+}
+
 criterion_group!(
     timeout_benchmark,
     single_thread_scheduler_timeout,
     multi_thread_scheduler_timeout,
     single_thread_scheduler_sleep,
-    multi_thread_scheduler_sleep
+    multi_thread_scheduler_sleep,
+    single_thread_scheduler_timer_registration,
+    multi_thread_scheduler_timer_registration
 );
 
 criterion_main!(timeout_benchmark);

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -65,6 +65,20 @@ impl Handle {
             Handle::Disabled => unreachable!(),
         }
     }
+
+    #[cfg(feature = "time")]
+    pub(crate) fn is_current_thread(&self) -> bool {
+        match self {
+            #[cfg(feature = "rt")]
+            Handle::CurrentThread(_) => true,
+
+            #[cfg(feature = "rt-multi-thread")]
+            Handle::MultiThread(_) => false,
+
+            #[cfg(not(feature = "rt"))]
+            Handle::Disabled => unreachable!(),
+        }
+    }
 }
 
 cfg_rt! {

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -482,8 +482,12 @@ impl TimerEntry {
         let tick = self.driver().time_source().deadline_to_tick(deadline);
 
         unsafe {
-            self.driver()
-                .reregister(&self.driver.driver().io, tick, (&self.inner).into());
+            self.driver().reregister(
+                &self.driver.driver().io,
+                tick,
+                (&self.inner).into(),
+                self.driver.is_current_thread(),
+            );
         }
     }
 
@@ -527,8 +531,12 @@ impl TimerEntry {
         }
 
         unsafe {
-            self.driver()
-                .reregister(&self.driver.driver().io, tick, (&self.inner).into());
+            self.driver().reregister(
+                &self.driver.driver().io,
+                tick,
+                (&self.inner).into(),
+                self.driver.is_current_thread(),
+            );
         }
     }
 

--- a/tokio/src/runtime/time/mod.rs
+++ b/tokio/src/runtime/time/mod.rs
@@ -131,6 +131,12 @@ struct InnerState {
     /// The earliest time at which we promise to wake up without unparking.
     next_wake: Option<NonZeroU64>,
 
+    /// Whether the driver may be blocked in `park`.
+    ///
+    /// This is set while preparing to park, before releasing the timer lock, so
+    /// timer registration cannot race with the transition into the I/O driver.
+    driver_parked: bool,
+
     /// Timer wheel.
     wheel: wheel::Wheel,
 }
@@ -150,6 +156,7 @@ impl Driver {
             inner: Inner::Traditional {
                 state: Mutex::new(InnerState {
                     next_wake: None,
+                    driver_parked: false,
                     wheel: wheel::Wheel::new(),
                 }),
                 is_shutdown: AtomicBool::new(false),
@@ -219,8 +226,16 @@ impl Driver {
         let next_wake = lock.wheel.next_expiration_time();
         lock.next_wake =
             next_wake.map(|t| NonZeroU64::new(t).unwrap_or_else(|| NonZeroU64::new(1).unwrap()));
+        lock.driver_parked = !limit.is_some_and(|duration| duration.is_zero());
+        #[cfg(all(test, not(loom), not(target_os = "wasi")))]
+        let driver_parked = lock.driver_parked;
 
         drop(lock);
+
+        #[cfg(all(test, not(loom), not(target_os = "wasi")))]
+        if driver_parked {
+            test_hooks::before_park();
+        }
 
         match next_wake {
             Some(when) => {
@@ -297,6 +312,11 @@ impl Handle {
         let mut waker_list = WakeList::new();
 
         let mut lock = self.inner.lock();
+
+        // The driver has returned from `park`, so timer registrations no longer
+        // need to interrupt the I/O driver. The timer lock makes this transition
+        // atomic with registrations racing with the end of `park`.
+        lock.driver_parked = false;
 
         if now < lock.wheel.elapsed() {
             // Time went backwards! This normally shouldn't happen as the Rust language
@@ -400,6 +420,7 @@ impl Handle {
         unpark: &IoHandle,
         new_tick: u64,
         entry: NonNull<TimerShared>,
+        current_thread: bool,
     ) {
         let waker = unsafe {
             let mut lock = self.inner.lock();
@@ -423,9 +444,10 @@ impl Handle {
                 // the timer entry.
                 match unsafe { lock.wheel.insert(entry) } {
                     Ok(when) => {
-                        if lock
-                            .next_wake
-                            .map_or(true, |next_wake| when < next_wake.get())
+                        if (!current_thread || lock.driver_parked)
+                            && lock
+                                .next_wake
+                                .map_or(true, |next_wake| when < next_wake.get())
                         {
                             unpark.unpark();
                         }
@@ -485,6 +507,28 @@ impl Inner {
 impl fmt::Debug for Inner {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt.debug_struct("Inner").finish()
+    }
+}
+
+#[cfg(all(test, not(loom), not(target_os = "wasi")))]
+mod test_hooks {
+    use std::cell::RefCell;
+
+    thread_local! {
+        static BEFORE_PARK: RefCell<Option<Box<dyn FnOnce()>>> = RefCell::new(None);
+    }
+
+    pub(super) fn set_before_park(hook: impl FnOnce() + 'static) {
+        BEFORE_PARK.with(|slot| {
+            assert!(slot.borrow_mut().replace(Box::new(hook)).is_none());
+        });
+    }
+
+    pub(super) fn before_park() {
+        let hook = BEFORE_PARK.with(|slot| slot.borrow_mut().take());
+        if let Some(hook) = hook {
+            hook();
+        }
     }
 }
 

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -40,6 +40,66 @@ fn rt(start_paused: bool) -> crate::runtime::Runtime {
         .unwrap()
 }
 
+#[cfg(not(loom))]
+fn reset_from_another_thread_wakes_parked_driver(
+    configure: impl FnOnce(&mut crate::runtime::Builder),
+) {
+    use std::future::{poll_fn, Future};
+    use std::sync::{mpsc, Arc as StdArc, Mutex as StdMutex};
+    use std::thread as std_thread;
+    use std::time::Instant as StdInstant;
+
+    let mut builder = crate::runtime::Builder::new_current_thread();
+    builder.enable_time();
+    configure(&mut builder);
+    let rt = builder.build().unwrap();
+
+    let sleep = {
+        let _guard = rt.enter();
+        StdArc::new(StdMutex::new(Box::pin(crate::time::sleep(
+            Duration::from_secs(1),
+        ))))
+    };
+
+    let (parked_tx, parked_rx) = mpsc::sync_channel(0);
+    let (reset_tx, reset_rx) = mpsc::sync_channel(0);
+    super::test_hooks::set_before_park(move || {
+        parked_tx.send(()).unwrap();
+        reset_rx.recv().unwrap();
+    });
+
+    let reset_sleep = sleep.clone();
+    let reset_thread = std_thread::spawn(move || {
+        parked_rx.recv().unwrap();
+        reset_sleep
+            .lock()
+            .unwrap()
+            .as_mut()
+            .reset(crate::time::Instant::now() + Duration::from_millis(10));
+        reset_tx.send(()).unwrap();
+    });
+
+    let start = StdInstant::now();
+    rt.block_on(poll_fn(|cx| sleep.lock().unwrap().as_mut().poll(cx)));
+
+    reset_thread.join().unwrap();
+    assert!(start.elapsed() < Duration::from_millis(500));
+}
+
+#[test]
+#[cfg(not(loom))]
+fn reset_from_another_thread_wakes_timer_only_driver() {
+    reset_from_another_thread_wakes_parked_driver(|_| {});
+}
+
+#[test]
+#[cfg(all(not(loom), feature = "net"))]
+fn reset_from_another_thread_wakes_mio_driver() {
+    reset_from_another_thread_wakes_parked_driver(|builder| {
+        builder.enable_io();
+    });
+}
+
 #[test]
 fn single_timer() {
     model(|| {


### PR DESCRIPTION
Fixes #5207.

## Motivation

Registering a timer wakes the I/O driver when the new deadline precedes the
driver's current wake deadline. That wake is necessary while the driver may be
blocked in `park`, but the current-thread scheduler also takes this path while
it is actively polling tasks. In that state, the driver cannot be parked and
the wake adds avoidable work to timer registration.

## Solution

Track whether the traditional timer driver may be parked under the timer-wheel
lock. A current-thread timer registration skips the I/O-driver wake only while
the driver is known to be active. Registrations racing with entry into `park`,
including a reset to an earlier deadline from another thread, continue to wake
the driver. Multi-thread runtimes retain the existing behavior.

The regression tests use a test-only one-shot hook after the parked state is
published and before the underlying parker is entered. They deterministically
reset a timer from another thread and cover both the timer-only parker and the
Mio-enabled current-thread driver.

## Performance

I added timer-registration cases to Tokio's existing `time_timeout` Criterion
benchmark. Both revisions used the same benchmark harness on CPU 0, with 100
samples, a 5-second warm-up, and a 15-second measurement period.

Each iteration constructs a pending timer, polls it once to register it, and
then drops it. In a baseline-first run, this benchmark case decreased from
197.84 ns to 103.55 ns, a 47.7% reduction. A candidate-first reverse run
measured 101.12 ns for the candidate and 199.54 ns for the baseline, a 49.3%
reduction, confirming the result independently of run order.

The eight-worker benchmark did not detect a statistically significant change
in either order.

## Validation

The focused stable and `tokio_unstable` time tests pass. Four traditional
time-driver, thirteen alternative-timer, and four current-thread scheduler
Loom tests pass with Tokio's CI flags. All-target, all-feature Clippy with
`-D warnings`, the repository rustfmt check, a release build, and the WASI
`rt,time` build also pass locally.
