### PR TITLE
time: saturate on overflow in Interval reset and missed-tick paths

### DIFF
--- a/tokio/src/time/interval.rs
+++ b/tokio/src/time/interval.rs
@@ -334,24 +334,27 @@ impl MissedTickBehavior {
     /// If a tick is missed, this method is called to determine when the next tick should happen.
     fn next_timeout(&self, timeout: Instant, now: Instant, period: Duration) -> Instant {
         match self {
-            Self::Burst => timeout + period,
-            Self::Delay => now + period,
+            Self::Burst => timeout
+                .checked_add(period)
+                .unwrap_or_else(Instant::far_future),
+            Self::Delay => now.checked_add(period).unwrap_or_else(Instant::far_future),
             Self::Skip => {
-                now + period
-                    - Duration::from_nanos(
-                        ((now - timeout).as_nanos() % period.as_nanos())
-                            .try_into()
-                            // This operation is practically guaranteed not to
-                            // fail, as in order for it to fail, `period` would
-                            // have to be longer than `now - timeout`, and both
-                            // would have to be longer than 584 years.
-                            //
-                            // If it did fail, there's not a good way to pass
-                            // the error along to the user, so we just panic.
-                            .expect(
-                                "too much time has elapsed since the interval was supposed to tick",
-                            ),
-                    )
+                let skip = Duration::from_nanos(
+                    ((now - timeout).as_nanos() % period.as_nanos())
+                        .try_into()
+                        // This operation is practically guaranteed not to
+                        // fail, as in order for it to fail, `period` would
+                        // have to be longer than `now - timeout`, and both
+                        // would have to be longer than 584 years.
+                        //
+                        // If it did fail, there's not a good way to pass
+                        // the error along to the user, so we just panic.
+                        .expect(
+                            "too much time has elapsed since the interval was supposed to tick",
+                        ),
+                );
+                now.checked_add(period - skip)
+                    .unwrap_or_else(Instant::far_future)
             }
         }
     }
@@ -492,7 +495,8 @@ impl Interval {
     ///
     /// This method ignores [`MissedTickBehavior`] strategy.
     ///
-    /// This is equivalent to calling `reset_at(Instant::now() + period)`.
+    /// This is equivalent to calling `reset_at(Instant::now() + period)`,
+    /// except that it saturates to a far-future instant on overflow.
     ///
     /// # Examples
     ///
@@ -517,7 +521,11 @@ impl Interval {
     /// # }
     /// ```
     pub fn reset(&mut self) {
-        self.delay.as_mut().reset(Instant::now() + self.period);
+        self.delay.as_mut().reset(
+            Instant::now()
+                .checked_add(self.period)
+                .unwrap_or_else(Instant::far_future),
+        );
     }
 
     /// Resets the interval immediately.
@@ -556,7 +564,8 @@ impl Interval {
     ///
     /// This method ignores [`MissedTickBehavior`] strategy.
     ///
-    /// This is equivalent to calling `reset_at(Instant::now() + after)`.
+    /// This is equivalent to calling `reset_at(Instant::now() + after)`,
+    /// except that it saturates to a far-future instant on overflow.
     ///
     /// # Examples
     ///
@@ -582,7 +591,11 @@ impl Interval {
     /// # }
     /// ```
     pub fn reset_after(&mut self, after: Duration) {
-        self.delay.as_mut().reset(Instant::now() + after);
+        self.delay.as_mut().reset(
+            Instant::now()
+                .checked_add(after)
+                .unwrap_or_else(Instant::far_future),
+        );
     }
 
     /// Resets the interval to a [`crate::time::Instant`] deadline.

--- a/tokio/tests/time_interval.rs
+++ b/tokio/tests/time_interval.rs
@@ -352,6 +352,43 @@ async fn reset_at_bigger_than_interval() {
     check_interval_poll!(i, start, 1701);
 }
 
+// Regression test for overflow when computing deadlines far in the
+// future: `reset`, `reset_after`, and every missed-tick behavior
+// should saturate like `sleep` does, rather than panic.
+#[tokio::test(start_paused = true)]
+async fn reset_saturates_instead_of_panicking() {
+    let start = Instant::now();
+    time::advance(ms(1)).await;
+
+    let mut i = task::spawn(time::interval_at(start, ms(300)));
+    check_interval_poll!(i, start, 0);
+    i.reset_after(Duration::MAX);
+    time::advance(ms(1000)).await;
+    check_interval_poll!(i, start);
+
+    let mut i = task::spawn(time::interval_at(start, Duration::MAX));
+    check_interval_poll!(i, start, 0);
+    i.reset();
+    time::advance(ms(1000)).await;
+    check_interval_poll!(i, start);
+
+    // The first poll of each interval is already 1ms late thanks to
+    // the advance above, entering the missed-tick path with a period
+    // that overflows any deadline. The advance after the first tick
+    // shows that no further tick ever becomes ready.
+    for behavior in [
+        MissedTickBehavior::Burst,
+        MissedTickBehavior::Delay,
+        MissedTickBehavior::Skip,
+    ] {
+        let mut i = task::spawn(time::interval_at(start, Duration::MAX));
+        i.set_missed_tick_behavior(behavior);
+        check_interval_poll!(i, start, 0);
+        time::advance(ms(1000)).await;
+        check_interval_poll!(i, start);
+    }
+}
+
 fn poll_next(interval: &mut task::Spawn<time::Interval>) -> Poll<Instant> {
     interval.enter(|cx, mut interval| interval.poll_tick(cx))
 }


### PR DESCRIPTION
## Motivation

Fixes #8384. `Interval::reset`, `Interval::reset_after`, and
`MissedTickBehavior::next_timeout` computed deadlines with bare `Instant + Duration` adds, which panic on overflow, so an interval with a very large period (or reset far into the future) panicked.

## Solution

This patch avoids the panic by saturating duration arithmetic in the same way that `sleep` and `poll_tick`'s on-time path already do. Also adds a regression test covering both the `reset_after(Duration::MAX)` immediate panic and the missed-tick panic.

## Disclaimer

:robot: Found and patched with LLM assistance, but reviewed with human :eyes: and :brain:.