### PR TITLE
rt: make `enable_io` available whenever `rt` is enabled

### DIFF
--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1825,48 +1825,44 @@ impl Builder {
             None
         }
     }
-}
 
-cfg_rt! {
-    impl Builder {
-        /// Enables the I/O driver.
-        ///
-        /// Doing this enables using net, process, signal, and some I/O types on
-        /// the runtime.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use tokio::runtime;
-        ///
-        /// let rt = runtime::Builder::new_current_thread()
-        ///     .enable_io()
-        ///     .build()
-        ///     .unwrap();
-        /// ```
-        pub fn enable_io(&mut self) -> &mut Self {
-            self.enable_io = true;
-            self
-        }
+    /// Enables the I/O driver.
+    ///
+    /// Doing this enables using net, process, signal, and some I/O types on
+    /// the runtime.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime;
+    ///
+    /// let rt = runtime::Builder::new_current_thread()
+    ///     .enable_io()
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn enable_io(&mut self) -> &mut Self {
+        self.enable_io = true;
+        self
+    }
 
-        /// Enables the I/O driver and configures the max number of events to be
-        /// processed per tick.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// use tokio::runtime;
-        ///
-        /// let rt = runtime::Builder::new_current_thread()
-        ///     .enable_io()
-        ///     .max_io_events_per_tick(1024)
-        ///     .build()
-        ///     .unwrap();
-        /// ```
-        pub fn max_io_events_per_tick(&mut self, capacity: usize) -> &mut Self {
-            self.nevents = capacity;
-            self
-        }
+    /// Enables the I/O driver and configures the max number of events to be
+    /// processed per tick.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tokio::runtime;
+    ///
+    /// let rt = runtime::Builder::new_current_thread()
+    ///     .enable_io()
+    ///     .max_io_events_per_tick(1024)
+    ///     .build()
+    ///     .unwrap();
+    /// ```
+    pub fn max_io_events_per_tick(&mut self, capacity: usize) -> &mut Self {
+        self.nevents = capacity;
+        self
     }
 }
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1839,7 +1839,7 @@ cfg_rt! {
         /// ```
         /// use tokio::runtime;
         ///
-        /// let rt = runtime::Builder::new_multi_thread()
+        /// let rt = runtime::Builder::new_current_thread()
         ///     .enable_io()
         ///     .build()
         ///     .unwrap();

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1827,7 +1827,7 @@ impl Builder {
     }
 }
 
-cfg_io_driver! {
+cfg_rt! {
     impl Builder {
         /// Enables the I/O driver.
         ///


### PR DESCRIPTION
## Motivation

`Builder::enable_io` and `Builder::max_io_events_per_tick` sit inside `cfg_io_driver!`, so they exist only under `rt` and (`net`, or Unix + `process`, or Unix + `signal`). That is the feature line #2973 is about.

The gate is not load-bearing. The state it guards is already unconditional: `enable_io` and `nevents` on `Builder` (builder.rs:63-64) carry no cfg, and under `cfg_not_io_driver!` `create_io_stack` ignores the flag entirely, so setting it with no I/O driver compiled in is a no-op rather than an error.

`enable_all` (builder.rs:396) already depends on that. The method itself is ungated and only the inner `self.enable_io()` call carries the `net`/`process`/`signal` cfg. So under bare `rt` today, `enable_all()` compiles and quietly skips I/O, while `enable_io()` does not exist at all.

## Solution

Move the two methods into the main `impl Builder` block and drop the gate.

The first version of this PR replaced `cfg_io_driver!` with `cfg_rt!`, but as pointed out on #2973, `builder.rs` is itself inside `cfg_rt!` in `runtime/mod.rs`, so that gate would not have gated anything. Removing it says the same thing without the indirection. `cfg_io_driver!` is unchanged, as are its seven other call sites.

This only widens where the methods exist, so it is not a breaking change, and it reduces the documented requirement to `rt`.

The `enable_io` example also moves from `Builder::new_multi_thread` to `new_current_thread`, matching the neighbouring `max_io_events_per_tick` example. The old one needs `rt-multi-thread`, and once the methods are available under bare `rt` the doctest gets compiled in configurations that do not have it. That surfaced as an E0599 on wasm32-unknown-unknown and wasm32-wasip1.

Verified with `cargo check -p tokio` under `rt`, `rt`+`net`, `rt`+`time`, `rt`+`signal`, `rt`+`process`, `full` and `--no-default-features`; a scratch crate on `features = ["rt"]` fails on master with E0599 `no method named enable_io` and builds with this change; `cargo hack check --feature-powerset --depth 2` clean across 106 combinations; `rustfmt --check` and `cargo +1.71 check` clean.

Fixes: #2973