### PR TITLE
fs: retain buffered data when a write fails

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -52,6 +52,35 @@ cfg_io_uring! {
 /// in-memory buffer. See the [`sync_all`] method for telling the OS to write
 /// the data to disk.
 ///
+/// # Errors while writing
+///
+/// Writes are buffered and performed in the background, so a write that
+/// appears to succeed may fail later. When it does, `File` behaves like
+/// [`BufWriter`]: the bytes that could not be written are kept, and the error
+/// is reported by every operation until a [`flush`] retries them successfully.
+///
+/// Reads, writes and seeks never retry: while data is pending they report the
+/// error and leave the bytes alone, because any of them would otherwise
+/// discard the data or move the cursor out from under it.
+///
+/// [`flush`] retries. So do [`set_len`], [`sync_all`], [`sync_data`],
+/// [`try_clone`] and [`into_std`], which flush first — they fail only if the
+/// retry itself fails.
+///
+/// This means a failed write is not lost if the cause is recoverable: freeing
+/// disk space and calling [`flush`] again writes the retained data.
+///
+/// Retained data is *not* written when the `File` is dropped, and is discarded
+/// by [`into_std`] and [`try_into_std`]. Call [`flush`] and check its result
+/// before doing any of those if the data matters.
+///
+/// [`BufWriter`]: std::io::BufWriter
+/// [`set_len`]: fn@crate::fs::File::set_len
+/// [`sync_data`]: fn@crate::fs::File::sync_data
+/// [`try_clone`]: fn@crate::fs::File::try_clone
+/// [`into_std`]: fn@crate::fs::File::into_std
+/// [`try_into_std`]: fn@crate::fs::File::try_into_std
+///
 /// Reading and writing to a `File` is usually done using the convenience
 /// methods found on the [`AsyncReadExt`] and [`AsyncWriteExt`] traits.
 ///
@@ -104,7 +133,22 @@ struct Inner {
     /// Errors from writes/flushes are returned in write/flush calls. If a write
     /// error is observed while performing a read, it is saved until the next
     /// write / flush call.
+    ///
+    /// While `unflushed_write` is set, this error is reported by every
+    /// operation but is *not* cleared, because the data it refers to is still
+    /// buffered and has not reached the file yet. It is cleared only when a
+    /// flush finally succeeds, or when the retained data is explicitly
+    /// discarded.
     last_write_err: Option<io::ErrorKind>,
+
+    /// Set when a write failed and the bytes it could not write are still held
+    /// in the `Buf` inside `State::Idle`.
+    ///
+    /// This distinguishes a non-empty idle buffer holding *unwritten write
+    /// data* from one holding *unconsumed read-ahead*, which is the only thing
+    /// a non-empty idle buffer could mean before. Every path that would
+    /// otherwise discard the buffer or seek relative to it has to check this.
+    unflushed_write: bool,
 
     pos: u64,
 }
@@ -285,6 +329,7 @@ impl File {
             inner: Mutex::new(Inner {
                 state: State::Idle(Some(Buf::with_capacity(0))),
                 last_write_err: None,
+                unflushed_write: false,
                 pos: 0,
             }),
             max_buf_size: DEFAULT_MAX_BUF_SIZE,
@@ -316,7 +361,13 @@ impl File {
     /// [`AsyncWriteExt`]: trait@crate::io::AsyncWriteExt
     pub async fn sync_all(&self) -> io::Result<()> {
         let mut inner = self.inner.lock().await;
-        inner.complete_inflight().await;
+        inner.complete_inflight(&self.std).await;
+
+        // Reporting success here while a failed write is still buffered would
+        // claim data reached the disk when it never reached the file.
+        if let Some(e) = inner.take_pending_write_err() {
+            return Err(e);
+        }
 
         let std = self.std.clone();
         asyncify(move || std.sync_all()).await
@@ -351,7 +402,12 @@ impl File {
     /// [`AsyncWriteExt`]: trait@crate::io::AsyncWriteExt
     pub async fn sync_data(&self) -> io::Result<()> {
         let mut inner = self.inner.lock().await;
-        inner.complete_inflight().await;
+        inner.complete_inflight(&self.std).await;
+
+        // See `sync_all`.
+        if let Some(e) = inner.take_pending_write_err() {
+            return Err(e);
+        }
 
         let std = self.std.clone();
         asyncify(move || std.sync_data()).await
@@ -389,7 +445,17 @@ impl File {
     /// [`AsyncWriteExt`]: trait@crate::io::AsyncWriteExt
     pub async fn set_len(&self, size: u64) -> io::Result<()> {
         let mut inner = self.inner.lock().await;
-        inner.complete_inflight().await;
+        inner.complete_inflight(&self.std).await;
+
+        // `complete_inflight` swallows a write error into `last_write_err`.
+        // If the data behind it is still buffered, truncating now would
+        // silently drop it.
+        if inner.unflushed_write {
+            let e = inner
+                .last_write_err
+                .expect("unflushed_write implies a stored write error");
+            return Err(e.into());
+        }
 
         let mut buf = match inner.state {
             State::Idle(ref mut buf_cell) => buf_cell.take().unwrap(),
@@ -474,7 +540,7 @@ impl File {
     /// # }
     /// ```
     pub async fn try_clone(&self) -> io::Result<File> {
-        self.inner.lock().await.complete_inflight().await;
+        self.inner.lock().await.complete_inflight(&self.std).await;
         let std = self.std.clone();
         let std_file = asyncify(move || std.try_clone()).await?;
         let mut file = File::from_std(std_file);
@@ -499,7 +565,9 @@ impl File {
     /// # }
     /// ```
     pub async fn into_std(mut self) -> StdFile {
-        self.inner.get_mut().complete_inflight().await;
+        let std = self.std.clone();
+        self.inner.get_mut().complete_inflight(&std).await;
+        drop(std);
         Arc::try_unwrap(self.std).expect("Arc::try_unwrap failed")
     }
 
@@ -611,6 +679,17 @@ impl AsyncRead for File {
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
+        // Unwritten data from a failed write is still buffered. Reading would
+        // either hand those bytes back as file contents or discard them, so
+        // report the error instead and leave the data alone until it is
+        // flushed.
+        if inner.unflushed_write {
+            let e = inner
+                .last_write_err
+                .expect("unflushed_write implies a stored write error");
+            return Poll::Ready(Err(e.into()));
+        }
+
         loop {
             match inner.state {
                 State::Idle(ref mut buf_cell) => {
@@ -653,9 +732,14 @@ impl AsyncRead for File {
                             continue;
                         }
                         Operation::Write(Err(e)) => {
-                            assert!(inner.last_write_err.is_none());
                             inner.last_write_err = Some(e.kind());
+                            // `buf` still holds the bytes that could not be
+                            // written. Falling through to the next iteration
+                            // would hand them to the reader as file contents,
+                            // so stop here and let a flush retry them.
+                            inner.unflushed_write = !buf.is_empty();
                             inner.state = State::Idle(Some(buf));
+                            return Poll::Ready(Err(e));
                         }
                         Operation::Seek(result) => {
                             assert!(buf.is_empty());
@@ -676,6 +760,16 @@ impl AsyncSeek for File {
     fn start_seek(self: Pin<&mut Self>, mut pos: SeekFrom) -> io::Result<()> {
         let me = self.get_mut();
         let inner = me.inner.get_mut();
+
+        // Seeking would `discard_read` the unwritten bytes of a failed write,
+        // or move the cursor out from under them. Refuse until they are
+        // flushed.
+        if inner.unflushed_write {
+            let e = inner
+                .last_write_err
+                .expect("unflushed_write implies a stored write error");
+            return Err(e.into());
+        }
 
         match inner.state {
             State::Busy(_) => Err(io::Error::new(
@@ -709,6 +803,18 @@ impl AsyncSeek for File {
         ready!(crate::trace::trace_leaf());
         let inner = self.inner.get_mut();
 
+        // `Seek::poll` drives this before `start_seek`, so it is the first
+        // place an outside seek reaches. Without this guard the retained bytes
+        // of a failed write would be discarded by `start_seek` below.
+        if inner.unflushed_write {
+            if let State::Idle(_) = inner.state {
+                let e = inner
+                    .last_write_err
+                    .expect("unflushed_write implies a stored write error");
+                return Poll::Ready(Err(e.into()));
+            }
+        }
+
         loop {
             match inner.state {
                 State::Idle(_) => return Poll::Ready(Ok(inner.pos)),
@@ -717,17 +823,27 @@ impl AsyncSeek for File {
                     if res.is_err() {
                         // Restore a valid Idle state before returning the error.
                         inner.state = State::Idle(Some(Buf::with_capacity(0)));
+                        inner.unflushed_write = false;
+                        inner.last_write_err = None;
                     }
                     let (op, buf) = res?;
+                    let retained = !buf.is_empty();
                     inner.state = State::Idle(Some(buf));
 
                     match op {
                         Operation::Read(_) => {}
                         Operation::Write(Err(e)) => {
-                            assert!(inner.last_write_err.is_none());
+                            // The bytes this write could not write are still in
+                            // the buffer just parked in `State::Idle`. Falling
+                            // through would let `start_seek` discard them.
                             inner.last_write_err = Some(e.kind());
+                            inner.unflushed_write = retained;
+                            return Poll::Ready(Err(e));
                         }
-                        Operation::Write(_) => {}
+                        Operation::Write(Ok(())) => {
+                            inner.unflushed_write = false;
+                            inner.last_write_err = None;
+                        }
                         Operation::Seek(res) => {
                             if let Ok(pos) = res {
                                 inner.pos = pos;
@@ -751,6 +867,13 @@ impl AsyncWrite for File {
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
+        // While a failed write's bytes are still buffered, accepting more data
+        // would either overwrite them or reorder them behind the new data.
+        // Report the error and keep it until a flush resolves it.
+        if let Some(e) = inner.take_pending_write_err() {
+            return Poll::Ready(Err(e));
+        }
+
         if let Some(e) = inner.last_write_err.take() {
             return Poll::Ready(Err(e.into()));
         }
@@ -771,9 +894,22 @@ impl AsyncWrite for File {
 
                     let res = spawn_mandatory_blocking(move || {
                         let res = if let Some(seek) = seek {
-                            (&*std).seek(seek).and_then(|_| buf.write_to(&mut &*std))
+                            match (&*std).seek(seek) {
+                                Ok(_) => buf.write_all_to(&mut &*std),
+                                Err(e) => {
+                                    // The rewind that this write had to be
+                                    // paired with failed, so nothing was
+                                    // written and the cursor is not where the
+                                    // data belongs. `poll_flush` retries a
+                                    // bare write with no seek, which would put
+                                    // the bytes at the wrong offset, so drop
+                                    // them rather than misplace them.
+                                    buf.discard_read();
+                                    Err(e)
+                                }
+                            }
                         } else {
-                            buf.write_to(&mut &*std)
+                            buf.write_all_to(&mut &*std)
                         };
 
                         (Operation::Write(res), buf)
@@ -797,6 +933,7 @@ impl AsyncWrite for File {
                         inner.state = State::Idle(Some(Buf::with_capacity(0)));
                     }
                     let (op, buf) = res?;
+                    let buf_is_empty = buf.is_empty();
                     inner.state = State::Idle(Some(buf));
 
                     match op {
@@ -808,8 +945,14 @@ impl AsyncWrite for File {
                         }
                         Operation::Write(res) => {
                             // If the previous write was successful, continue.
-                            // Otherwise, error.
-                            res?;
+                            // Otherwise, error. The buffer just returned to
+                            // `State::Idle` still holds whatever could not be
+                            // written, so flag it for the next flush.
+                            if let Err(e) = res {
+                                inner.unflushed_write = !buf_is_empty;
+                                inner.last_write_err = Some(e.kind());
+                                return Poll::Ready(Err(e));
+                            }
                             continue;
                         }
                         Operation::Seek(_) => {
@@ -831,6 +974,13 @@ impl AsyncWrite for File {
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
+        // While a failed write's bytes are still buffered, accepting more data
+        // would either overwrite them or reorder them behind the new data.
+        // Report the error and keep it until a flush resolves it.
+        if let Some(e) = inner.take_pending_write_err() {
+            return Poll::Ready(Err(e));
+        }
+
         if let Some(e) = inner.last_write_err.take() {
             return Poll::Ready(Err(e.into()));
         }
@@ -851,9 +1001,22 @@ impl AsyncWrite for File {
 
                     let res = spawn_mandatory_blocking(move || {
                         let res = if let Some(seek) = seek {
-                            (&*std).seek(seek).and_then(|_| buf.write_to(&mut &*std))
+                            match (&*std).seek(seek) {
+                                Ok(_) => buf.write_all_to(&mut &*std),
+                                Err(e) => {
+                                    // The rewind that this write had to be
+                                    // paired with failed, so nothing was
+                                    // written and the cursor is not where the
+                                    // data belongs. `poll_flush` retries a
+                                    // bare write with no seek, which would put
+                                    // the bytes at the wrong offset, so drop
+                                    // them rather than misplace them.
+                                    buf.discard_read();
+                                    Err(e)
+                                }
+                            }
                         } else {
-                            buf.write_to(&mut &*std)
+                            buf.write_all_to(&mut &*std)
                         };
 
                         (Operation::Write(res), buf)
@@ -877,6 +1040,7 @@ impl AsyncWrite for File {
                         inner.state = State::Idle(Some(Buf::with_capacity(0)));
                     }
                     let (op, buf) = res?;
+                    let buf_is_empty = buf.is_empty();
                     inner.state = State::Idle(Some(buf));
 
                     match op {
@@ -888,8 +1052,14 @@ impl AsyncWrite for File {
                         }
                         Operation::Write(res) => {
                             // If the previous write was successful, continue.
-                            // Otherwise, error.
-                            res?;
+                            // Otherwise, error. The buffer just returned to
+                            // `State::Idle` still holds whatever could not be
+                            // written, so flag it for the next flush.
+                            if let Err(e) = res {
+                                inner.unflushed_write = !buf_is_empty;
+                                inner.last_write_err = Some(e.kind());
+                                return Poll::Ready(Err(e));
+                            }
                             continue;
                         }
                         Operation::Seek(_) => {
@@ -906,10 +1076,11 @@ impl AsyncWrite for File {
         true
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
         ready!(crate::trace::trace_leaf());
-        let inner = self.inner.get_mut();
-        inner.poll_flush(cx)
+        let me = self.get_mut();
+        let std = &me.std;
+        me.inner.get_mut().poll_flush(cx, std)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
@@ -1118,15 +1289,27 @@ impl Inner {
         })
     }
 
-    async fn complete_inflight(&mut self) {
-        use std::future::poll_fn;
-
-        poll_fn(|cx| self.poll_complete_inflight(cx)).await;
+    /// Returns the stored write error if unwritten data is still buffered.
+    ///
+    /// The error is reported but neither it nor the data is cleared: the bytes
+    /// are still pending and a later `flush` may yet write them.
+    fn take_pending_write_err(&mut self) -> Option<io::Error> {
+        if self.unflushed_write {
+            self.last_write_err.map(Into::into)
+        } else {
+            None
+        }
     }
 
-    fn poll_complete_inflight(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+    async fn complete_inflight(&mut self, std: &Arc<StdFile>) {
+        use std::future::poll_fn;
+
+        poll_fn(|cx| self.poll_complete_inflight(cx, std)).await;
+    }
+
+    fn poll_complete_inflight(&mut self, cx: &mut Context<'_>, std: &Arc<StdFile>) -> Poll<()> {
         ready!(crate::trace::trace_leaf());
-        match self.poll_flush(cx) {
+        match self.poll_flush(cx, std) {
             Poll::Ready(Err(e)) => {
                 self.last_write_err = Some(e.kind());
                 Poll::Ready(())
@@ -1136,9 +1319,44 @@ impl Inner {
         }
     }
 
-    fn poll_flush(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        if let Some(e) = self.last_write_err.take() {
-            return Poll::Ready(Err(e.into()));
+    fn poll_flush(
+        &mut self,
+        cx: &mut Context<'_>,
+        std: &Arc<StdFile>,
+    ) -> Poll<Result<(), io::Error>> {
+        // A stored error whose data is *not* still buffered is reported once
+        // and cleared, as before. When `unflushed_write` is set the data is
+        // still here, so the error is kept until the retry below resolves it.
+        if !self.unflushed_write {
+            if let Some(e) = self.last_write_err.take() {
+                return Poll::Ready(Err(e.into()));
+            }
+        }
+
+        // If a previous write failed, its unwritten bytes are still in the
+        // buffer. Retry them now; this is the only place that happens.
+        if self.unflushed_write {
+            if let State::Idle(ref mut buf_cell) = self.state {
+                let mut buf = buf_cell.take().unwrap();
+                let std = std.clone();
+
+                let res = spawn_mandatory_blocking(move || {
+                    let res = buf.write_all_to(&mut &*std);
+                    (Operation::Write(res), buf)
+                })
+                .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "background task failed"));
+
+                if res.is_err() {
+                    // Restore a valid Idle state before returning the error.
+                    // The retained data cannot be recovered, so stop claiming
+                    // that it is still pending.
+                    self.state = State::Idle(Some(Buf::with_capacity(0)));
+                    self.unflushed_write = false;
+                    self.last_write_err = None;
+                }
+
+                self.state = State::Busy(res?);
+            }
         }
 
         let (op, buf) = match self.state {
@@ -1148,17 +1366,30 @@ impl Inner {
                 if res.is_err() {
                     // Restore a valid Idle state before returning the error.
                     self.state = State::Idle(Some(Buf::with_capacity(0)));
+                    self.unflushed_write = false;
+                    self.last_write_err = None;
                 }
                 res?
             }
         };
 
-        // The buffer is not used here
         self.state = State::Idle(Some(buf));
 
         match op {
             Operation::Read(_) => Poll::Ready(Ok(())),
-            Operation::Write(res) => Poll::Ready(res),
+            Operation::Write(Ok(())) => {
+                // Everything reached the file.
+                self.unflushed_write = false;
+                self.last_write_err = None;
+                Poll::Ready(Ok(()))
+            }
+            Operation::Write(Err(e)) => {
+                // The bytes that could not be written are still in the buffer
+                // that was just returned to `State::Idle`.
+                self.unflushed_write = true;
+                self.last_write_err = Some(e.kind());
+                Poll::Ready(Err(e))
+            }
             Operation::Seek(_) => Poll::Ready(Ok(())),
         }
     }

--- a/tokio/src/fs/file/tests.rs
+++ b/tokio/src/fs/file/tests.rs
@@ -614,13 +614,6 @@ fn write_read_write_err() {
         .once()
         .in_sequence(&mut seq)
         .returning(|_| Err(io::ErrorKind::Other.into()));
-    file.expect_inner_read()
-        .once()
-        .in_sequence(&mut seq)
-        .returning(|buf| {
-            buf[0..HELLO.len()].copy_from_slice(HELLO);
-            Ok(HELLO.len())
-        });
 
     let mut file = File::from_std(file);
 
@@ -629,13 +622,15 @@ fn write_read_write_err() {
 
     pool::run_one();
 
+    // The bytes the failed write could not write are still buffered. Issuing
+    // a read here would either hand them back as file contents or discard
+    // them, so the read reports the pending write error instead and no read
+    // reaches the file.
     let mut buf = [0; 1024];
     let mut t = task::spawn(file.read(&mut buf));
+    assert_ready_err!(t.poll());
 
-    assert_pending!(t.poll());
-
-    pool::run_one();
-
+    // The error is still pending, because the data still is.
     let mut t = task::spawn(file.write(FOO));
     assert_ready_err!(t.poll());
 }
@@ -644,17 +639,11 @@ fn write_read_write_err() {
 fn write_read_flush_err() {
     let mut file = MockFile::default();
     let mut seq = Sequence::new();
+    // Two writes: the original, and the retry that `flush` issues.
     file.expect_inner_write()
-        .once()
+        .times(2)
         .in_sequence(&mut seq)
         .returning(|_| Err(io::ErrorKind::Other.into()));
-    file.expect_inner_read()
-        .once()
-        .in_sequence(&mut seq)
-        .returning(|buf| {
-            buf[0..HELLO.len()].copy_from_slice(HELLO);
-            Ok(HELLO.len())
-        });
 
     let mut file = File::from_std(file);
 
@@ -663,14 +652,19 @@ fn write_read_flush_err() {
 
     pool::run_one();
 
+    // As in `write_read_write_err`, the read reports the pending write error
+    // rather than touching the retained bytes.
     let mut buf = [0; 1024];
     let mut t = task::spawn(file.read(&mut buf));
+    assert_ready_err!(t.poll());
 
+    // `flush` is the one operation that retries the write, so it dispatches a
+    // second write to the file and reports its failure.
+    let mut t = task::spawn(file.flush());
     assert_pending!(t.poll());
 
     pool::run_one();
 
-    let mut t = task::spawn(file.flush());
     assert_ready_err!(t.poll());
 }
 
@@ -682,11 +676,6 @@ fn write_seek_write_err() {
         .once()
         .in_sequence(&mut seq)
         .returning(|_| Err(io::ErrorKind::Other.into()));
-    file.expect_inner_seek()
-        .once()
-        .with(eq(SeekFrom::Start(0)))
-        .in_sequence(&mut seq)
-        .returning(|_| Ok(0));
 
     let mut file = File::from_std(file);
 
@@ -695,12 +684,13 @@ fn write_seek_write_err() {
 
     pool::run_one();
 
+    // Seeking would discard the bytes the failed write left behind, and move
+    // the cursor out from under them. It reports the pending error instead and
+    // never reaches the file.
     {
         let mut t = task::spawn(file.seek(SeekFrom::Start(0)));
-        assert_pending!(t.poll());
+        assert_ready_err!(t.poll());
     }
-
-    pool::run_one();
 
     let mut t = task::spawn(file.write(FOO));
     assert_ready_err!(t.poll());
@@ -710,15 +700,11 @@ fn write_seek_write_err() {
 fn write_seek_flush_err() {
     let mut file = MockFile::default();
     let mut seq = Sequence::new();
+    // The original write, and the retry that `flush` issues.
     file.expect_inner_write()
-        .once()
+        .times(2)
         .in_sequence(&mut seq)
         .returning(|_| Err(io::ErrorKind::Other.into()));
-    file.expect_inner_seek()
-        .once()
-        .with(eq(SeekFrom::Start(0)))
-        .in_sequence(&mut seq)
-        .returning(|_| Ok(0));
 
     let mut file = File::from_std(file);
 
@@ -727,14 +713,17 @@ fn write_seek_flush_err() {
 
     pool::run_one();
 
+    // As above: the seek reports the pending error and leaves the data alone.
     {
         let mut t = task::spawn(file.seek(SeekFrom::Start(0)));
-        assert_pending!(t.poll());
+        assert_ready_err!(t.poll());
     }
 
-    pool::run_one();
-
+    // `flush` is the only operation that retries, so it dispatches a second
+    // write and reports its failure.
     let mut t = task::spawn(file.flush());
+    assert_pending!(t.poll());
+    pool::run_one();
     assert_ready_err!(t.poll());
 }
 
@@ -974,5 +963,174 @@ fn busy_file_seek_error() {
     pool::run_one();
 
     let mut t = task::spawn(file.seek(SeekFrom::Start(0)));
+    assert_ready_err!(t.poll());
+}
+
+#[test]
+fn write_err_retains_data_for_next_flush() {
+    let mut file = MockFile::default();
+    let mut seq = Sequence::new();
+    // First write fails outright.
+    file.expect_inner_write()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(|_| Err(io::ErrorKind::Other.into()));
+    // `flush` retries it, and this time the whole payload lands.
+    file.expect_inner_write()
+        .once()
+        .in_sequence(&mut seq)
+        .withf(|buf| buf == HELLO)
+        .returning(|buf| Ok(buf.len()));
+
+    let mut file = File::from_std(file);
+
+    let mut t = task::spawn(file.write(HELLO));
+    assert_ready_ok!(t.poll());
+
+    pool::run_one();
+
+    // The failure is reported, with the data still buffered. The write task
+    // has already run, so this resolves immediately.
+    let mut t = task::spawn(file.flush());
+    assert_ready_err!(t.poll());
+
+    // Retrying the flush writes the retained bytes instead of silently
+    // dropping them. Before this behaviour existed, the buffer had already
+    // been cleared and this flush returned `Ok(())` having written nothing.
+    let mut t = task::spawn(file.flush());
+    assert_pending!(t.poll());
+    pool::run_one();
+    assert_ready_ok!(t.poll());
+}
+
+#[test]
+fn write_err_flush_twice_reports_err_twice() {
+    let mut file = MockFile::default();
+    let mut seq = Sequence::new();
+    file.expect_inner_write()
+        .times(3)
+        .in_sequence(&mut seq)
+        .returning(|_| Err(io::ErrorKind::Other.into()));
+
+    let mut file = File::from_std(file);
+
+    let mut t = task::spawn(file.write(HELLO));
+    assert_ready_ok!(t.poll());
+    pool::run_one();
+
+    // `BufWriter<std::fs::File>` reports the error on every flush while the
+    // data is still unwritten. Tokio used to report it once and then return
+    // `Ok(())`, having thrown the data away.
+    let mut t = task::spawn(file.flush());
+    assert_ready_err!(t.poll());
+
+    // Each later flush retries the retained bytes and reports the failure
+    // again, rather than claiming success.
+    for _ in 0..2 {
+        let mut t = task::spawn(file.flush());
+        assert_pending!(t.poll());
+        pool::run_one();
+        assert_ready_err!(t.poll());
+    }
+}
+
+#[test]
+fn write_partial_then_err_retries_only_remainder() {
+    let mut file = MockFile::default();
+    let mut seq = Sequence::new();
+    // Write half the payload, then fail.
+    file.expect_inner_write()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(|_| Ok(HELLO.len() / 2));
+    file.expect_inner_write()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(|_| Err(io::ErrorKind::Other.into()));
+    // The retry must resume from where the partial write stopped, not from
+    // the start, and must not resend the bytes that already landed.
+    file.expect_inner_write()
+        .once()
+        .in_sequence(&mut seq)
+        .withf(|buf| buf == &HELLO[HELLO.len() / 2..])
+        .returning(|buf| Ok(buf.len()));
+
+    let mut file = File::from_std(file);
+
+    let mut t = task::spawn(file.write(HELLO));
+    assert_ready_ok!(t.poll());
+    pool::run_one();
+
+    let mut t = task::spawn(file.flush());
+    assert_ready_err!(t.poll());
+
+    let mut t = task::spawn(file.flush());
+    assert_pending!(t.poll());
+    pool::run_one();
+    assert_ready_ok!(t.poll());
+}
+
+#[test]
+fn write_err_then_seek_retains_data_for_flush() {
+    let mut file = MockFile::default();
+    let mut seq = Sequence::new();
+    file.expect_inner_write()
+        .once()
+        .in_sequence(&mut seq)
+        .returning(|_| Err(io::ErrorKind::Other.into()));
+    // The retry that `flush` dispatches after the seek was refused.
+    file.expect_inner_write()
+        .once()
+        .in_sequence(&mut seq)
+        .withf(|buf| buf == HELLO)
+        .returning(|buf| Ok(buf.len()));
+
+    let mut file = File::from_std(file);
+
+    let mut t = task::spawn(file.write(HELLO));
+    assert_ready_ok!(t.poll());
+
+    pool::run_one();
+
+    // `Seek::poll` drives `poll_complete` before `start_seek`, so this is the
+    // first place an outside seek reaches. It must not consume the retained
+    // bytes: `start_seek` would `discard_read` them and rewind the cursor by
+    // their length.
+    {
+        let mut t = task::spawn(file.seek(SeekFrom::Start(0)));
+        assert_ready_err!(t.poll());
+    }
+
+    // The data survived the seek, so flushing still writes it.
+    let mut t = task::spawn(file.flush());
+    assert_pending!(t.poll());
+    pool::run_one();
+    assert_ready_ok!(t.poll());
+}
+
+#[test]
+fn write_err_observed_by_seek_is_not_readable_as_file_contents() {
+    let mut file = MockFile::default();
+    // No `expect_inner_read`: no read may reach the file, because the only
+    // buffered bytes are the ones the failed write could not write. Handing
+    // them back would report data as file contents that the file never held.
+    file.expect_inner_write()
+        .once()
+        .returning(|_| Err(io::ErrorKind::Other.into()));
+
+    let mut file = File::from_std(file);
+
+    let mut t = task::spawn(file.write(HELLO));
+    assert_ready_ok!(t.poll());
+
+    pool::run_one();
+
+    {
+        let mut t = task::spawn(file.seek(SeekFrom::Start(0)));
+        assert_ready_err!(t.poll());
+    }
+
+    let mut buf = [0; 1024];
+    let mut t = task::spawn(file.read(&mut buf));
     assert_ready_err!(t.poll());
 }

--- a/tokio/src/io/blocking.rs
+++ b/tokio/src/io/blocking.rs
@@ -312,6 +312,36 @@ cfg_io_uring! {
 
 cfg_fs! {
     impl Buf {
+        /// Writes the entire buffer to `wr`, advancing the cursor past the
+        /// bytes that are written.
+        ///
+        /// On success the buffer is left empty. If a write fails, the bytes
+        /// that were not written are left in the buffer so that the caller can
+        /// retry them, with the cursor positioned at the first byte still to
+        /// be written.
+        ///
+        /// This differs from [`Buf::write_to`], which clears the buffer even
+        /// when the write fails. That behavior is relied upon by `Blocking<T>`,
+        /// so the two cannot be merged.
+        pub(crate) fn write_all_to<T: Write>(&mut self, wr: &mut T) -> io::Result<()> {
+            while !self.is_empty() {
+                // `Write::write_all` cannot be used here: it does not report
+                // how many bytes it wrote before failing.
+                let res = uninterruptibly!(wr.write(self.bytes()));
+
+                match res {
+                    Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
+                    Ok(n) => self.pos += n,
+                    Err(e) => return Err(e),
+                }
+            }
+
+            self.buf.clear();
+            self.pos = 0;
+
+            Ok(())
+        }
+
         pub(crate) fn discard_read(&mut self) -> i64 {
             let ret = -(self.bytes().len() as i64);
             self.pos = 0;


### PR DESCRIPTION
## Motivation

`tokio::fs::File` loses buffered data when a write fails. `Buf::write_to` (blocking.rs:270) clears the buffer whether or not `write_all` succeeded, so by the time the error surfaces the bytes are already gone. The error is then reported once and forgotten, and the next `flush()` returns `Ok(())` having written nothing.

On a full disk this shows up as silent data loss: `write_all(payload)` followed by two `flush()` calls returns an error and then `Ok(())`, and none of the payload reaches the file. `BufWriter<std::fs::File>` under the same conditions returns the error from both flushes and keeps the data, which is the behaviour #6325 asks for and the one agreed on in #6330.

Two smaller consequences fall out of the same cause. `sync_all` and `sync_data` report success for data that never reached the file, because `complete_inflight` swallows the write error and they only report std's own result. And a read after a failed write can hand back the unwritten bytes as file contents.

## Solution

Add `Buf::write_all_to`, an fs-only variant that writes in a loop, advances the cursor past the bytes that were written, and leaves the rest in the buffer on error. `Buf::write_to` is untouched, because `io::blocking::Blocking` uses it for stdout, stderr and stdin and asserts the buffer is empty on the next write. Retaining there would turn a stdout write error into a panic.

`Inner::poll_flush` takes an `Arc<StdFile>` argument so it can respawn the write when data is left over. Passing it as an argument rather than storing it in `State` is what keeps `into_std`'s `Arc::try_unwrap` working, which is where the earlier attempt in #6330 got stuck.

The retained bytes live in the `Buf` that `State::Idle` already holds, and until now a non-empty idle buffer could only mean unconsumed read-ahead. So `Inner` gains an `unflushed_write` flag to tell the two apart, derived from `!buf.is_empty()` so it cannot be set over an empty buffer. Without it `poll_write` would `discard_read` the retained bytes and seek backwards over them, and `poll_read` would hand them to the reader.

Every consumer of `Operation::Write(Err)` sets the flag, including `AsyncSeek::poll_complete`. That one matters more than it looks: `Seek::poll` drives `poll_complete` before `start_seek`, so an ordinary `write` then `seek` reaches it first, and `start_seek` would otherwise discard the buffer.

One case cannot be retried. If the rewind seek that a write is paired with fails, nothing was written and the cursor is not where the data belongs, so the buffer is dropped rather than retained. Keeping it would let the retry, which issues a bare write with no seek, land the bytes at the wrong offset.

Reads, writes and seeks report the pending error and leave the data alone. `flush` retries it, and so do `set_len`, `sync_all`, `sync_data`, `try_clone` and `into_std`, which flush first.

That last part goes beyond what #6330 discussed. It is what keeps the retained bytes intact rather than a preference: without it `poll_read` hands them back as file contents and the seek path discards them, both covered by the tests below. Letting reads and seeks keep working would mean holding the unwritten bytes outside the `Buf` that `State::Idle` shares with read-ahead, which is a different design rather than a variant of this one.

## Tests

Five new tests in `tokio/src/fs/file/tests.rs`, all of which fail on master: retained data is written by a later flush; two flushes both report the error, matching `BufWriter`; a partial write followed by an error resumes from the cursor instead of resending; the same through `seek`, which reaches `poll_complete` before `start_seek`; and a read after that point does not return the unwritten bytes as file contents. The last one uses a mock with no `expect_inner_read` at all, so any read reaching the file fails the test.

Updated `write_read_write_err`, `write_read_flush_err`, `write_seek_write_err` and `write_seek_flush_err`.

Ran the full workspace suite with `full,test-util`, `cargo clippy -p tokio --features full --all-targets`, `rustfmt --check`, and `cargo +1.71 check -p tokio --features full`. The original bug was also reproduced against a real full filesystem before and after the change.

Fixes: #6325