### PR TITLE
ci: skip workspace semver on release pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
           package: tokio
           release-type: minor
       - name: Check semver for rest of the workspace
-        if: ${{ !startsWith(github.event.pull_request.base.ref, 'tokio-1.') }}
+        if: ${{ !startsWith(github.event.pull_request.base.ref, 'tokio-1.') && !startsWith(github.ref_name, 'tokio-1.') }}
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           rust-toolchain: ${{ env.rust_stable }}


### PR DESCRIPTION
## Motivation

On `push` events, `github.event.pull_request.base.ref` is unset. The existing guard therefore runs the workspace-wide semver check on `tokio-1.*.x` release-branch pushes, where only the `tokio` crate check is applicable. This causes false-positive failures described in [#8389](https://github.com/tokio-rs/tokio/issues/8389).

## Change

The condition now also checks `github.ref_name`, so the workspace check is skipped on LTS branch pushes while pull-request behavior remains unchanged. This PR is based on `tokio-1.47.x` as requested by the maintainers; it can be carried forward to newer LTS branches with the usual merge-forward workflow.

## Validation

- `git diff --check`
- Ruby Psych YAML parsing of `.github/workflows/ci.yml`
- Truth-table checks for push and pull-request events on `master` and `tokio-1.*.x`
- GitHub-Verified SSH-signed commit authored by `fly1d <309400591+fly1d@users.noreply.github.com>`

OpenAI Codex assisted with the implementation and validation.