### PR TITLE
rt: fix current_thread task dump panicking when a traced task wakes a task

### DIFF
--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -580,37 +580,41 @@ impl Handle {
     ))]
     pub(crate) fn dump(&self) -> crate::runtime::Dump {
         use crate::runtime::dump;
-        use task::trace::trace_current_thread;
+        use task::trace::drain_current_thread;
+        use task::trace::trace_owned;
 
         let mut traces = vec![];
 
         // todo: how to make this work outside of a runtime context?
         context::with_scheduler(|maybe_context| {
-            // drain the local queue
             let context = if let Some(context) = maybe_context {
                 context.expect_current_thread()
             } else {
                 return;
             };
-            let mut maybe_core = context.core.borrow_mut();
-            let core = if let Some(core) = maybe_core.as_mut() {
-                core
-            } else {
-                return;
-            };
-            let local = &mut core.tasks;
 
             if self.shared.inject.is_closed() {
                 return;
             }
 
-            traces = trace_current_thread(&self.shared.owned, local, &self.shared.inject)
+            // Drain the local and injection queues. The core borrow is released
+            // before any task is polled by `trace_owned`: a task polled during
+            // tracing may wake another task, and `Schedule::schedule` would then
+            // re-borrow the core and panic with "RefCell already borrowed".
+            let dequeued = {
+                let mut maybe_core = context.core.borrow_mut();
+                let core = if let Some(core) = maybe_core.as_mut() {
+                    core
+                } else {
+                    return;
+                };
+                drain_current_thread(&mut core.tasks, &self.shared.inject)
+            };
+
+            traces = trace_owned(&self.shared.owned, dequeued)
                 .into_iter()
                 .map(|(id, trace)| dump::Task::new(id, trace))
                 .collect();
-
-            // Avoid double borrow panic
-            drop(maybe_core);
 
             // Taking a taskdump could wakes every task, but we probably don't want
             // the `yield_now` vector to be that large under normal circumstances.

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -363,12 +363,17 @@ impl<T: Future> Future for Root<T> {
     }
 }
 
-/// Trace and poll all tasks of the `current_thread` runtime.
-pub(in crate::runtime) fn trace_current_thread(
-    owned: &OwnedTasks<Arc<current_thread::Handle>>,
+/// Drain the local and injection queues of the `current_thread` runtime
+/// without polling any tasks.
+///
+/// The scheduler core borrow must be released before any task is polled by
+/// [`trace_owned`]: a task polled during tracing may wake another task, and
+/// `Schedule::schedule` would then re-borrow the core and panic with "RefCell
+/// already borrowed".
+pub(in crate::runtime) fn drain_current_thread(
     local: &mut VecDeque<Notified<Arc<current_thread::Handle>>>,
     injection: &Inject<Arc<current_thread::Handle>>,
-) -> Vec<(Id, Trace)> {
+) -> Vec<Notified<Arc<current_thread::Handle>>> {
     // clear the local and injection queues
 
     let mut dequeued = Vec::new();
@@ -381,8 +386,7 @@ pub(in crate::runtime) fn trace_current_thread(
         dequeued.push(task);
     }
 
-    // precondition: We have drained the tasks from the injection queue.
-    trace_owned(owned, dequeued)
+    dequeued
 }
 
 cfg_rt_multi_thread! {
@@ -430,7 +434,7 @@ cfg_rt_multi_thread! {
 ///
 /// This helper presumes exclusive access to each task. The tasks must not exist
 /// in any other queue.
-fn trace_owned<S: Schedule>(owned: &OwnedTasks<S>, dequeued: Vec<Notified<S>>) -> Vec<(Id, Trace)> {
+pub(in crate::runtime) fn trace_owned<S: Schedule>(owned: &OwnedTasks<S>, dequeued: Vec<Notified<S>>) -> Vec<(Id, Trace)> {
     let mut tasks = dequeued;
     // Notify and trace all un-notified tasks. The dequeued tasks are already
     // notified and so do not need to be re-notified.

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -277,3 +277,24 @@ async fn trace_with_callback_and_backtrace() {
         );
     }
 }
+
+/// Regression test for <https://github.com/tokio-rs/tokio/issues/8391>.
+///
+/// Taking a task dump on a `current_thread` runtime used to panic with
+/// "RefCell already borrowed" if any traced task woke a waker while it was
+/// being re-polled by the tracer. Waking during a poll is legal, so the dump
+/// must release the scheduler-core borrow before polling any task.
+#[tokio::test(flavor = "current_thread")]
+async fn dump_does_not_panic_when_traced_task_wakes_self() {
+    let task = tokio::spawn(std::future::poll_fn(|cx| {
+        if tokio::runtime::Handle::is_tracing() {
+            cx.waker().wake_by_ref();
+        }
+        std::task::Poll::<()>::Pending
+    }));
+
+    tokio::task::yield_now().await;
+    let _dump = tokio::runtime::Handle::current().dump().await;
+
+    task.abort();
+}


### PR DESCRIPTION
## Motivation

Fixes #8391. Taking a task dump on a `current_thread` runtime panicked with `RefCell already borrowed` if any traced task woke a waker while being re-polled by the tracer. Waking during a poll is legal, so any application that calls `Handle::dump()` on a `current_thread` runtime could hit this. This was found in production: a `SIGUSR2`-triggered task dump crashed a server (restatedev/restate#5235).

## Root cause

`current_thread::Handle::dump()` held a mutable borrow of the scheduler core across the whole tracing pass, and `Schedule::schedule` for `current_thread::Handle` takes the same borrow when a woken task is scheduled on its own runtime. A task that woke another task (or itself) during tracing therefore hit a double borrow and panicked. The multi_thread scheduler is unaffected because it moves the core out of the `RefCell` before running, so a wake during tracing falls back to the inject queue.

## Solution

Split draining from tracing so the core borrow is released before any task is polled. The borrow is only needed to drain the local and injection queues, which must still happen first to satisfy `trace_owned`'s exclusive-access precondition. Wakes that arrive during tracing then take the normal path and land in the local queue, and the woken tasks are polled after the dump instead of panicking.

- `task::trace`: add `drain_current_thread` (drains without polling); make `trace_owned` reachable from the scheduler.
- `current_thread::Handle::dump`: drain inside a scoped borrow, release it, then `trace_owned`.

## Tests

Added `dump_does_not_panic_when_traced_task_wakes_self` to `tokio/tests/task_trace_self.rs` (gated on Linux + taskdump, matching the existing tests).

Signed-off-by: waterWang <waterWang@users.noreply.github.com>