### PR TITLE
fix(sync): prevent overflow in SemaphorePermit::merge

### DIFF
--- a/tokio/src/sync/semaphore.rs
+++ b/tokio/src/sync/semaphore.rs
@@ -1232,7 +1232,10 @@ impl<'a> SemaphorePermit<'a> {
             std::ptr::eq(self.sem, other.sem),
             "merging permits from different semaphore instances"
         );
-        self.permits += other.permits;
+        self.permits = self
+            .permits
+            .checked_add(other.permits)
+            .expect("overflow while merging semaphore permits");
         other.permits = 0;
     }
 
@@ -1339,7 +1342,10 @@ impl OwnedSemaphorePermit {
             Arc::ptr_eq(&self.sem, &other.sem),
             "merging permits from different semaphore instances"
         );
-        self.permits += other.permits;
+        self.permits = self
+            .permits
+            .checked_add(other.permits)
+            .expect("overflow while merging semaphore permits");
         other.permits = 0;
     }
 

--- a/tokio/tests/sync_semaphore.rs
+++ b/tokio/tests/sync_semaphore.rs
@@ -143,6 +143,18 @@ fn merge_unrelated_permits() {
 }
 
 #[test]
+#[cfg(not(target_family = "wasm"))] // No stack unwinding on wasm targets
+#[should_panic]
+fn merge_overflow() {
+    // Two permits each holding up to u32::MAX can sum past the limit when merged,
+    // which must panic instead of silently wrapping and losing permits.
+    let sem = Arc::new(Semaphore::new(u32::MAX as usize * 2));
+    let mut p1 = sem.try_acquire_many(u32::MAX).unwrap();
+    let p2 = sem.try_acquire_many(u32::MAX).unwrap();
+    p1.merge(p2);
+}
+
+#[test]
 fn split() {
     let sem = Semaphore::new(5);
     let mut p1 = sem.try_acquire_many(3).unwrap();


### PR DESCRIPTION
## What

Fixes #8395.

`SemaphorePermit::merge` and `OwnedSemaphorePermit::merge` previously summed the two permit counts with a plain `+=`:

```rust
self.permits += other.permits;
```

`permits` is a `u32`, so when two permits each holding up to `u32::MAX` are merged the sum overflows: it panics in debug builds and silently wraps in release builds, quietly losing permits from the semaphore.

## Fix

Use `checked_add` so the overflow is caught and reported clearly instead of silently wrapping:

```rust
self.permits = self
    .permits
    .checked_add(other.permits)
    .expect("overflow while merging semaphore permits");
```

Applied to both `SemaphorePermit::merge` and `OwnedSemaphorePermit::merge`.

## Test

Added `merge_overflow` in `tokio/tests/sync_semaphore.rs`, a `#[should_panic]` test that merges two `u32::MAX` permits and asserts the overflow is caught.
