### PR TITLE
io: panic when in-memory pipe is created with zero capacity

### DIFF
--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -104,6 +104,7 @@ pub struct SimplexStream {
 /// # Panics
 ///
 /// This function panics if `max_buf_size` is 0.
+#[track_caller]
 #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
 pub fn duplex(max_buf_size: usize) -> (DuplexStream, DuplexStream) {
     let one = Arc::new(Mutex::new(SimplexStream::new_unsplit(max_buf_size)));
@@ -215,6 +216,7 @@ impl Drop for DuplexStream {
 /// # Panics
 ///
 /// This function panics if `max_buf_size` is 0.
+#[track_caller]
 #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
 pub fn simplex(max_buf_size: usize) -> (ReadHalf<SimplexStream>, WriteHalf<SimplexStream>) {
     split(SimplexStream::new_unsplit(max_buf_size))
@@ -229,9 +231,8 @@ impl SimplexStream {
     ///
     /// # Panics
     ///
-    /// This function panics if `max_buf_size` is 0. A zero-capacity buffer
-    /// cannot make progress: every write would wait for free space that a read
-    /// can never create, so any write would deadlock.
+    /// This function panics if `max_buf_size` is 0.
+    #[track_caller]
     #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
     pub fn new_unsplit(max_buf_size: usize) -> SimplexStream {
         assert!(max_buf_size > 0, "`max_buf_size` must be greater than 0");

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -100,6 +100,10 @@ pub struct SimplexStream {
 ///
 /// The `max_buf_size` argument is the maximum amount of bytes that can be
 /// written to a side before the write returns `Poll::Pending`.
+///
+/// # Panics
+///
+/// This function panics if `max_buf_size` is 0.
 #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
 pub fn duplex(max_buf_size: usize) -> (DuplexStream, DuplexStream) {
     let one = Arc::new(Mutex::new(SimplexStream::new_unsplit(max_buf_size)));
@@ -207,6 +211,10 @@ impl Drop for DuplexStream {
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Panics
+///
+/// This function panics if `max_buf_size` is 0.
 #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
 pub fn simplex(max_buf_size: usize) -> (ReadHalf<SimplexStream>, WriteHalf<SimplexStream>) {
     split(SimplexStream::new_unsplit(max_buf_size))
@@ -218,8 +226,15 @@ impl SimplexStream {
     ///
     /// The `max_buf_size` argument is the maximum amount of bytes that can be
     /// written to a buffer before it returns `Poll::Pending`.
+    ///
+    /// # Panics
+    ///
+    /// This function panics if `max_buf_size` is 0. A zero-capacity buffer
+    /// cannot make progress: every write would wait for free space that a read
+    /// can never create, so any write would deadlock.
     #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
     pub fn new_unsplit(max_buf_size: usize) -> SimplexStream {
+        assert!(max_buf_size > 0, "`max_buf_size` must be greater than 0");
         SimplexStream {
             buffer: BytesMut::new(),
             is_closed: false,

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -3,7 +3,25 @@
 
 use futures::FutureExt;
 use std::io::IoSlice;
-use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{duplex, simplex, AsyncReadExt, AsyncWriteExt, SimplexStream};
+
+#[test]
+#[should_panic = "must be greater than 0"]
+fn duplex_zero_capacity_panics() {
+    let _ = duplex(0);
+}
+
+#[test]
+#[should_panic = "must be greater than 0"]
+fn simplex_zero_capacity_panics() {
+    let _ = simplex(0);
+}
+
+#[test]
+#[should_panic = "must be greater than 0"]
+fn new_unsplit_zero_capacity_panics() {
+    let _ = SimplexStream::new_unsplit(0);
+}
 
 #[tokio::test]
 async fn ping_pong() {

--- a/tokio/tests/io_mem_stream.rs
+++ b/tokio/tests/io_mem_stream.rs
@@ -3,25 +3,7 @@
 
 use futures::FutureExt;
 use std::io::IoSlice;
-use tokio::io::{duplex, simplex, AsyncReadExt, AsyncWriteExt, SimplexStream};
-
-#[test]
-#[should_panic = "must be greater than 0"]
-fn duplex_zero_capacity_panics() {
-    let _ = duplex(0);
-}
-
-#[test]
-#[should_panic = "must be greater than 0"]
-fn simplex_zero_capacity_panics() {
-    let _ = simplex(0);
-}
-
-#[test]
-#[should_panic = "must be greater than 0"]
-fn new_unsplit_zero_capacity_panics() {
-    let _ = SimplexStream::new_unsplit(0);
-}
+use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt};
 
 #[tokio::test]
 async fn ping_pong() {

--- a/tokio/tests/io_panic.rs
+++ b/tokio/tests/io_panic.rs
@@ -4,7 +4,7 @@
 
 use std::task::{Context, Poll};
 use std::{error::Error, pin::Pin};
-use tokio::io::{self, split, AsyncRead, AsyncWrite, ReadBuf};
+use tokio::io::{self, duplex, simplex, split, AsyncRead, AsyncWrite, ReadBuf, SimplexStream};
 
 mod support {
     pub mod panic;
@@ -123,6 +123,42 @@ fn unsplit_panic_caller() -> Result<(), Box<dyn Error>> {
         let (r1, _w1) = split(RW);
         let (_r2, w2) = split(RW);
         r1.unsplit(w2);
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
+
+#[test]
+fn duplex_zero_capacity_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let _ = duplex(0);
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
+
+#[test]
+fn simplex_zero_capacity_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let _ = simplex(0);
+    });
+
+    // The panic location should be in this file
+    assert_eq!(&panic_location_file.unwrap(), file!());
+
+    Ok(())
+}
+
+#[test]
+fn new_unsplit_zero_capacity_panic_caller() -> Result<(), Box<dyn Error>> {
+    let panic_location_file = test_panic(|| {
+        let _ = SimplexStream::new_unsplit(0);
     });
 
     // The panic location should be in this file


### PR DESCRIPTION
## Motivation

Creating an in-memory pipe with a capacity of 0 — `duplex(0)`, `simplex(0)`, or `SimplexStream::new_unsplit(0)` — hangs forever the first time you write. The writer waits for free space in the buffer, the reader waits for data to show up, but with a 0-byte buffer neither can ever happen, so both sides deadlock.

The pipe is created without any error, so the hang shows up later at a random write, which is hard to debug.

## Solution

Panic at construction when `max_buf_size` is 0, the same way `mpsc::channel(0)` already panics with "requires buffer > 0". This turns a silent deadlock into a clear, immediate error.

Added a `# Panics` note to the docs of `duplex`, `simplex`, and `new_unsplit`, and tests that check all three panic on 0.

Closes #8394