### PR TITLE
tests: re-enable ignored io shutdown tests in rt_handle_block_on

### DIFF
--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -1,12 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-// All io tests that deal with shutdown is currently ignored because there are known bugs in with
-// shutting down the io driver while concurrently registering new resources. See
-// https://github.com/tokio-rs/tokio/pull/3569#pullrequestreview-612703467 for more details.
-//
-// When this has been fixed we want to re-enable these tests.
-
 use std::time::Duration;
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::mpsc;
@@ -250,8 +244,6 @@ rt_test! {
             .unwrap();
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn tcp_listener_connect_after_shutdown() {
         let rt = rt();
@@ -270,8 +262,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn tcp_listener_connect_before_shutdown() {
         let rt = rt();
@@ -301,8 +291,6 @@ rt_test! {
             .unwrap();
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn udp_stream_bind_after_shutdown() {
         let rt = rt();
@@ -321,8 +309,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn udp_stream_bind_before_shutdown() {
         let rt = rt();
@@ -341,8 +327,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[cfg(unix)]
     #[test]
     fn unix_listener_bind_after_shutdown() {
@@ -363,8 +347,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[cfg(unix)]
     #[test]
     fn unix_listener_shutdown_after_bind() {
@@ -382,11 +364,12 @@ rt_test! {
         let err = Handle::current().block_on(listener.accept()).unwrap_err();
 
         assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(err.get_ref().unwrap().to_string(), "reactor gone");
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[cfg(unix)]
     #[test]
     fn unix_listener_shutdown_after_accept() {
@@ -406,7 +389,10 @@ rt_test! {
         let err = Handle::current().block_on(accept_future).unwrap_err();
 
         assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(err.get_ref().unwrap().to_string(), "reactor gone");
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
     }
 
     // ==== nesting ======


### PR DESCRIPTION
## Motivation

`tokio/tests/rt_handle_block_on.rs` has carried a block of `#[ignore]`d io
tests since it was introduced in #3569 (March 2021). The file-level comment
explained why:

> All io tests that deal with shutdown is currently ignored because there are
> known bugs in with shutting down the io driver while concurrently registering
> new resources. See #3569 (review) for more details.
>
> When this has been fixed we want to re-enable these tests.

That was ~5 years ago. The underlying bug class has since been fixed, so these
tests can be turned back on.

## Why it is now safe to re-enable

The io driver was rewritten in #5833 ("io: remove slab in favor of Arc and
allocations"). Registrations are now tracked by `RegistrationSet`, whose state
lives behind a mutex-protected `Synced`. `RegistrationSet::allocate` checks
`synced.is_shutdown` under the lock and returns
`RUNTIME_SHUTTING_DOWN_ERROR` instead of racing with driver shutdown:

```rust
pub(super) fn allocate(&self, synced: &mut Synced) -> io::Result<Arc<ScheduledIo>> {
    if synced.is_shutdown {
        return Err(io::Error::new(
            io::ErrorKind::Other,
            crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR,
        ));
    }
    ...
}
```

So registering a resource after — or concurrently with — runtime shutdown now
fails deterministically rather than triggering the original unsoundness.

## Solution

Remove the `#[ignore]` from the 7 shutdown io tests (each expanded across the
`current_thread`, `threaded_1_thread`, and `threaded_4_threads`
configurations by the `rt_test!` macro) and drop the stale explanatory
comments.

Five of the seven tests pass unchanged. The two `unix_listener_shutdown_after_bind`
and `unix_listener_shutdown_after_accept` tests asserted the old `"reactor gone"`
error message; #5833 unified that path onto the single
`RUNTIME_SHUTTING_DOWN_ERROR` string, so their assertions are updated to the
current message. The tests still verify the intended behavior: `accept()` fails
immediately with `ErrorKind::Other` instead of hanging until the timeout.

## Evidence

Determinism — full file, 5 consecutive runs:

```
test result: ok. 63 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```
(identical on all 5 runs; `cargo fmt --check` clean)

The re-enabled tests still exercise real behavior (mutation testing):

- Removing the `is_shutdown` guard in `RegistrationSet::allocate` turns the 15
  bind/connect-after-shutdown assertions RED.
- Replacing the message in `registration::gone()` turns the 6
  `unix_listener_shutdown_after_*` assertions RED.

Both revert to GREEN with the mutations undone.

