### PR TITLE
fix: `cargo check -p --all-features` without `tokio_unstable`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -779,15 +779,16 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: "cargo check"
         run: |
+          # `cargo check -p tokio --all-features` must pass without `tokio_unstable`;
+          # unstable Cargo features must be inert unless `tokio_unstable` is also enabled.
           if [[ "${{ github.event.pull_request.base.ref }}" =~ ^tokio-1\..* ]]; then
             # Only check `tokio` crate as the PR is backporting to an earlier tokio release.
 
-            cargo check -p tokio --features $TOKIO_STABLE_FEATURES
+            cargo check -p tokio --all-features
           else
             # Check all crates in the workspace
 
-            cargo check -p tokio --features $TOKIO_STABLE_FEATURES
-            # Other crates doesn't have unstable features, so we can use --all-features.
+            cargo check -p tokio --all-features
             cargo hack check -p tokio-macros -p tokio-stream -p tokio-util -p tokio-test --all-features
           fi
 

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -84,11 +84,6 @@ cargo check --all-features
 cargo test --all-features
 ```
 
-> [!NOTE]
-> There are some features that are not available in some systems (e.g., `io-uring`
-> which is Linux only). In that case you cannot use the `--all-features` and you
-> should specify only the features that are supported (e.g., `--features=full`).
-
 Ideally, you should use the same version of clippy as the one used in CI
 (defined by `env.rust_clippy` in [ci.yml][ci.yml]), because newer versions
 might have new lints:

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -478,13 +478,8 @@ compile_error! {
 ))]
 compile_error!("Only features sync,macros,io-util,rt,time are supported on wasm.");
 
-#[cfg(all(not(tokio_unstable), feature = "io-uring"))]
-compile_error!("The `io-uring` feature requires `--cfg tokio_unstable`.");
-
-#[cfg(all(not(tokio_unstable), feature = "taskdump"))]
-compile_error!("The `taskdump` feature requires `--cfg tokio_unstable`.");
-
 #[cfg(all(
+    tokio_unstable,
     feature = "taskdump",
     not(doc),
     not(all(
@@ -502,10 +497,8 @@ compile_error!(
 linux, on `aarch64`, `x86`, `x86_64` and `s390x`."
 );
 
-#[cfg(all(not(tokio_unstable), feature = "schedule-latency"))]
-compile_error!("The `schedule-latency` feature requires `--cfg tokio_unstable`.");
-
 #[cfg(all(
+    tokio_unstable,
     feature = "schedule-latency",
     not(all(target_pointer_width = "64", target_has_atomic = "64"))
 ))]

--- a/tokio/src/macros/cfg.rs
+++ b/tokio/src/macros/cfg.rs
@@ -753,8 +753,8 @@ macro_rules! cfg_io_uring {
 macro_rules! cfg_schedule_latency {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "schedule-latency")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "schedule-latency")))]
+            #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
+            #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "schedule-latency"))))]
             $item
         )*
     };
@@ -763,7 +763,7 @@ macro_rules! cfg_schedule_latency {
 macro_rules! cfg_not_schedule_latency {
     ($($item:item)*) => {
         $(
-            #[cfg(not(feature = "schedule-latency"))]
+            #[cfg(not(all(tokio_unstable, feature = "schedule-latency")))]
             $item
         )*
     }

--- a/tokio/src/runtime/config.rs
+++ b/tokio/src/runtime/config.rs
@@ -52,7 +52,10 @@ pub(crate) struct Config {
     pub(crate) track_task_schedule_latency: bool,
 
     /// How to build schedule latency histograms
-    #[cfg_attr(not(feature = "schedule-latency"), allow(dead_code))]
+    #[cfg_attr(
+        not(all(tokio_unstable, feature = "schedule-latency")),
+        allow(dead_code)
+    )]
     pub(crate) metrics_schedule_latency_histogram: Option<crate::runtime::HistogramBuilder>,
 
     #[cfg(tokio_unstable)]

--- a/tokio/src/runtime/metrics/batch.rs
+++ b/tokio/src/runtime/metrics/batch.rs
@@ -55,7 +55,7 @@ pub(crate) struct MetricsBatch {
     /// If `Some`, tracks poll times in nanoseconds
     poll_timer: Option<PollTimer>,
 
-    #[cfg(feature = "schedule-latency")]
+    #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
     schedule_latencies: Option<HistogramBatch>,
 }
 
@@ -100,7 +100,7 @@ impl MetricsBatch {
                         })
                 });
                 // Schedule latencies cannot be tracked if `Instant::now()` is unavailable
-                #[cfg(feature = "schedule-latency")]
+                #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
                 let schedule_latencies = maybe_now.and_then(|_| {
                     worker_metrics
                         .schedule_latency_histogram
@@ -120,7 +120,7 @@ impl MetricsBatch {
                     busy_duration_total: 0,
                     processing_scheduled_tasks_started_at: maybe_now,
                     poll_timer,
-                    #[cfg(feature = "schedule-latency")]
+                    #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
                     schedule_latencies,
                 }
             }
@@ -170,7 +170,7 @@ impl MetricsBatch {
                     poll_timer.poll_counts.submit(dst);
                 }
 
-                #[cfg(feature = "schedule-latency")]
+                #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
                 if let Some(schedule_latencies) = &self.schedule_latencies {
                     let dst = worker.schedule_latency_histogram.as_ref().unwrap();
                     schedule_latencies.submit(dst);
@@ -250,12 +250,12 @@ impl MetricsBatch {
                     now
                 });
 
-                #[cfg(feature = "schedule-latency")]
+                #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
                 {
                     self.record_schedule_latency_at(schedule_latency_context, poll_started_at)
                 }
 
-                #[cfg(not(feature = "schedule-latency"))]
+                #[cfg(not(all(tokio_unstable, feature = "schedule-latency")))]
                 {
                     let _ = (poll_started_at, schedule_latency_context);
                     None
@@ -284,12 +284,12 @@ impl MetricsBatch {
                 &mut self,
                 schedule_latency_context: Option<ScheduleLatencyContext>,
             ) -> Option<Duration> {
-                #[cfg(feature = "schedule-latency")]
+                #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
                 {
                     self.record_schedule_latency_at(schedule_latency_context, None)
                 }
 
-                #[cfg(not(feature = "schedule-latency"))]
+                #[cfg(not(all(tokio_unstable, feature = "schedule-latency")))]
                 {
                     let _ = schedule_latency_context;
                     None

--- a/tokio/src/runtime/metrics/runtime.rs
+++ b/tokio/src/runtime/metrics/runtime.rs
@@ -1027,7 +1027,7 @@ impl RuntimeMetrics {
     }
 
     feature! {
-        #![feature = "schedule-latency"]
+        #![all(tokio_unstable, feature = "schedule-latency")]
         /// Returns `true` if the runtime is tracking the distribution of task
         /// schedule latencies.
         ///

--- a/tokio/src/runtime/metrics/worker.rs
+++ b/tokio/src/runtime/metrics/worker.rs
@@ -66,7 +66,7 @@ pub(crate) struct WorkerMetrics {
     /// If `Some`, tracks the number of polls by duration range.
     pub(super) poll_count_histogram: Option<Histogram>,
 
-    #[cfg(feature = "schedule-latency")]
+    #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
     /// If `Some`, tracks the number of times tasks were scheduled by duration range.
     pub(super) schedule_latency_histogram: Option<Histogram>,
 }
@@ -97,7 +97,7 @@ impl WorkerMetrics {
                     .metrics_poll_count_histogram
                     .as_ref()
                     .map(|histogram_builder| histogram_builder.build());
-                #[cfg(feature = "schedule-latency")]
+                #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
                 {
                     worker_metrics.schedule_latency_histogram = config
                         .metrics_schedule_latency_histogram

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -365,7 +365,7 @@ impl Core {
     }
 }
 
-#[cfg(feature = "taskdump")]
+#[cfg(all(tokio_unstable, feature = "taskdump"))]
 fn wake_deferred_tasks_and_free(context: &Context) {
     let wakers = context.defer.take_deferred();
     for waker in wakers {
@@ -514,7 +514,7 @@ impl Handle {
         me.task_hooks.spawn(&TaskMeta {
             id,
             spawned_at,
-            #[cfg(feature = "schedule-latency")]
+            #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
             schedule_latency: None,
             _phantom: Default::default(),
         });
@@ -554,7 +554,7 @@ impl Handle {
         me.task_hooks.spawn(&TaskMeta {
             id,
             spawned_at,
-            #[cfg(feature = "schedule-latency")]
+            #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
             schedule_latency: None,
             _phantom: Default::default(),
         });

--- a/tokio/src/runtime/scheduler/defer.rs
+++ b/tokio/src/runtime/scheduler/defer.rs
@@ -35,7 +35,7 @@ impl Defer {
         }
     }
 
-    #[cfg(feature = "taskdump")]
+    #[cfg(all(tokio_unstable, feature = "taskdump"))]
     pub(crate) fn take_deferred(&self) -> Vec<Waker> {
         let mut deferred = self.deferred.borrow_mut();
         std::mem::take(&mut *deferred)

--- a/tokio/src/runtime/scheduler/inject.rs
+++ b/tokio/src/runtime/scheduler/inject.rs
@@ -36,7 +36,7 @@ impl<T: 'static> Inject<T> {
     }
 
     // Kind of annoying to have to include the cfg here
-    #[cfg(feature = "taskdump")]
+    #[cfg(all(tokio_unstable, feature = "taskdump"))]
     pub(crate) fn is_closed(&self) -> bool {
         let synced = self.synced.lock();
         self.shared.is_closed(&synced)

--- a/tokio/src/runtime/scheduler/inject/shared.rs
+++ b/tokio/src/runtime/scheduler/inject/shared.rs
@@ -38,10 +38,7 @@ impl<T: 'static> Shared<T> {
     }
 
     // Kind of annoying to have to include the cfg here
-    #[cfg(any(
-        all(tokio_unstable, feature = "taskdump"),
-        feature = "rt-multi-thread"
-    ))]
+    #[cfg(any(all(tokio_unstable, feature = "taskdump"), feature = "rt-multi-thread"))]
     pub(crate) fn is_closed(&self, synced: &Synced) -> bool {
         synced.is_closed
     }

--- a/tokio/src/runtime/scheduler/inject/shared.rs
+++ b/tokio/src/runtime/scheduler/inject/shared.rs
@@ -38,7 +38,10 @@ impl<T: 'static> Shared<T> {
     }
 
     // Kind of annoying to have to include the cfg here
-    #[cfg(any(feature = "taskdump", feature = "rt-multi-thread"))]
+    #[cfg(any(
+        all(tokio_unstable, feature = "taskdump"),
+        feature = "rt-multi-thread"
+    ))]
     pub(crate) fn is_closed(&self, synced: &Synced) -> bool {
         synced.is_closed
     }

--- a/tokio/src/runtime/scheduler/multi_thread/handle.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle.rs
@@ -93,7 +93,7 @@ impl Handle {
         me.task_hooks.spawn(&TaskMeta {
             id,
             spawned_at,
-            #[cfg(feature = "schedule-latency")]
+            #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
             schedule_latency: None,
             _phantom: Default::default(),
         });

--- a/tokio/src/runtime/task/harness.rs
+++ b/tokio/src/runtime/task/harness.rs
@@ -374,7 +374,7 @@ where
                 f(&TaskMeta {
                     id: self.core().task_id,
                     spawned_at: self.core().spawned_at.into(),
-                    #[cfg(feature = "schedule-latency")]
+                    #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
                     schedule_latency: None,
                     _phantom: Default::default(),
                 })

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -454,7 +454,7 @@ impl<S: 'static> Task<S> {
         crate::runtime::TaskMeta {
             id: self.id(),
             spawned_at: self.spawned_at().into(),
-            #[cfg(feature = "schedule-latency")]
+            #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
             schedule_latency: _schedule_latency,
             _phantom: PhantomData,
         }

--- a/tokio/src/runtime/task_hooks.rs
+++ b/tokio/src/runtime/task_hooks.rs
@@ -1,6 +1,6 @@
 use super::Config;
 use std::marker::PhantomData;
-#[cfg(feature = "schedule-latency")]
+#[cfg(all(tokio_unstable, feature = "schedule-latency"))]
 use std::time::Duration;
 
 impl TaskHooks {
@@ -65,7 +65,7 @@ pub struct TaskMeta<'a> {
     #[cfg_attr(not(tokio_unstable), allow(unreachable_pub, dead_code))]
     pub(crate) spawned_at: crate::runtime::task::SpawnLocation,
     /// The latency between scheduling the task and starting its current poll.
-    #[cfg(feature = "schedule-latency")]
+    #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
     pub(crate) schedule_latency: Option<Duration>,
     pub(crate) _phantom: PhantomData<&'a ()>,
 }
@@ -103,8 +103,8 @@ impl<'a> TaskMeta<'a> {
     /// [`enable_metrics_schedule_latency_histogram`]: crate::runtime::Builder::enable_metrics_schedule_latency_histogram
     /// [`on_before_task_poll`]: crate::runtime::Builder::on_before_task_poll
     /// [`on_after_task_poll`]: crate::runtime::Builder::on_after_task_poll
-    #[cfg(feature = "schedule-latency")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "schedule-latency")))]
+    #[cfg(all(tokio_unstable, feature = "schedule-latency"))]
+    #[cfg_attr(docsrs, doc(cfg(all(tokio_unstable, feature = "schedule-latency"))))]
     pub fn schedule_latency(&self) -> Option<Duration> {
         self.schedule_latency
     }

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -1223,7 +1223,7 @@ impl NotifiedProject<'_> {
                     return Poll::Pending;
                 }
                 State::Waiting => {
-                    #[cfg(feature = "taskdump")]
+                    #[cfg(all(tokio_unstable, feature = "taskdump"))]
                     if let Some(_waker) = waker {
                         std::task::ready!(crate::trace::trace_leaf());
                     }
@@ -1316,7 +1316,7 @@ impl NotifiedProject<'_> {
                     drop(old_waker);
                 }
                 State::Done => {
-                    #[cfg(feature = "taskdump")]
+                    #[cfg(all(tokio_unstable, feature = "taskdump"))]
                     if let Some(_waker) = waker {
                         std::task::ready!(crate::trace::trace_leaf());
                     }


### PR DESCRIPTION
This used to be a compilation error. This must not be. `cargo check -p --all-features` should always pass.

Fixes #8399