### PR TITLE
tokio-util: return the earliest key from `DelayQueue::peek`

### DIFF
--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -1261,23 +1261,24 @@ impl<T> wheel::Stack for Stack<T> {
     }
 
     fn peek_earliest(&self, store: &Self::Store) -> Option<Self::Owned> {
-        let mut curr = self.head;
-        let mut earliest: Option<(Key, u64)> = None;
+        let head = self.head?;
+        let mut earliest = (head, store[head].when);
+        let mut curr = store[head].next;
 
         while let Some(key) = curr {
             let data = &store[key];
 
-            match earliest {
-                // Keep the first entry seen on a tie so that this agrees with
-                // `pop` when every entry in the slot shares a deadline.
-                Some((_, when)) if data.when >= when => {}
-                _ => earliest = Some((key, data.when)),
+            // The comparison is strict so that the first entry seen wins a tie,
+            // which agrees with `pop` when every entry in the slot shares a
+            // deadline.
+            if data.when < earliest.1 {
+                earliest = (key, data.when);
             }
 
             curr = data.next;
         }
 
-        earliest.map(|(key, _)| key)
+        Some(earliest.0)
     }
 
     #[track_caller]

--- a/tokio-util/src/time/delay_queue.rs
+++ b/tokio-util/src/time/delay_queue.rs
@@ -951,7 +951,7 @@ impl<T> DelayQueue<T> {
     pub fn peek(&self) -> Option<Key> {
         use self::wheel::Stack;
 
-        self.expired.peek().or_else(|| self.wheel.peek())
+        self.expired.peek().or_else(|| self.wheel.peek(&self.slab))
     }
 
     /// Returns the next time to poll as determined by the wheel.
@@ -1258,6 +1258,26 @@ impl<T> wheel::Stack for Stack<T> {
 
     fn peek(&self) -> Option<Self::Owned> {
         self.head
+    }
+
+    fn peek_earliest(&self, store: &Self::Store) -> Option<Self::Owned> {
+        let mut curr = self.head;
+        let mut earliest: Option<(Key, u64)> = None;
+
+        while let Some(key) = curr {
+            let data = &store[key];
+
+            match earliest {
+                // Keep the first entry seen on a tie so that this agrees with
+                // `pop` when every entry in the slot shares a deadline.
+                Some((_, when)) if data.when >= when => {}
+                _ => earliest = Some((key, data.when)),
+            }
+
+            curr = data.next;
+        }
+
+        earliest.map(|(key, _)| key)
     }
 
     #[track_caller]

--- a/tokio-util/src/time/wheel/level.rs
+++ b/tokio-util/src/time/wheel/level.rs
@@ -148,8 +148,8 @@ impl<T: Stack> Level<T> {
         ret
     }
 
-    pub(crate) fn peek_entry_slot(&self, slot: usize) -> Option<T::Owned> {
-        self.slot[slot].peek()
+    pub(crate) fn peek_entry_slot(&self, slot: usize, store: &T::Store) -> Option<T::Owned> {
+        self.slot[slot].peek_earliest(store)
     }
 }
 

--- a/tokio-util/src/time/wheel/mod.rs
+++ b/tokio-util/src/time/wheel/mod.rs
@@ -140,9 +140,9 @@ where
     }
 
     /// Next key that will expire
-    pub(crate) fn peek(&self) -> Option<T::Owned> {
+    pub(crate) fn peek(&self, store: &T::Store) -> Option<T::Owned> {
         self.next_expiration()
-            .and_then(|expiration| self.peek_entry(&expiration))
+            .and_then(|expiration| self.peek_entry(&expiration, store))
     }
 
     /// Advances the timer up to the instant represented by `now`.
@@ -250,8 +250,8 @@ where
         self.levels[expiration.level].pop_entry_slot(expiration.slot, store)
     }
 
-    fn peek_entry(&self, expiration: &Expiration) -> Option<T::Owned> {
-        self.levels[expiration.level].peek_entry_slot(expiration.slot)
+    fn peek_entry(&self, expiration: &Expiration, store: &T::Store) -> Option<T::Owned> {
+        self.levels[expiration.level].peek_entry_slot(expiration.slot, store)
     }
 
     fn level_for(&self, when: u64) -> usize {

--- a/tokio-util/src/time/wheel/stack.rs
+++ b/tokio-util/src/time/wheel/stack.rs
@@ -25,6 +25,13 @@ pub(crate) trait Stack: Default {
     /// Peek into the stack.
     fn peek(&self) -> Option<Self::Owned>;
 
+    /// Peek at the item in the stack with the earliest deadline.
+    ///
+    /// Unlike `peek`, this does not have to agree with `pop`: a slot in a level
+    /// above zero spans a range of deadlines, so its entries are only ordered
+    /// once they cascade down.
+    fn peek_earliest(&self, store: &Self::Store) -> Option<Self::Owned>;
+
     fn remove(&mut self, item: &Self::Borrowed, store: &mut Self::Store);
 
     fn when(item: &Self::Borrowed, store: &Self::Store) -> u64;

--- a/tokio-util/tests/time_delay_queue.rs
+++ b/tokio-util/tests/time_delay_queue.rs
@@ -903,6 +903,41 @@ async fn peek() {
 }
 
 #[tokio::test(start_paused = true)]
+async fn peek_entries_sharing_a_wheel_slot() {
+    // Only the lowest level of the timer wheel has one deadline per slot. A
+    // level-one slot spans 64ms, so entries with different deadlines share it
+    // and are only ordered once the slot cascades down.
+    let mut queue = task::spawn(DelayQueue::new());
+
+    let now = Instant::now();
+
+    // 64ms..=127ms all fall in the same level-one slot. Entries are pushed onto
+    // the front of a slot, so inserting the later deadline second puts it at the
+    // head.
+    let early = queue.insert_at("early", now + ms(100));
+    let late = queue.insert_at("late", now + ms(120));
+
+    assert_eq!(queue.peek(), Some(early));
+
+    sleep(ms(105)).await;
+
+    assert_eq!(queue.peek(), Some(early));
+
+    let entry = assert_ready_some!(poll!(queue));
+    assert_eq!(entry.key(), early);
+    assert_eq!(entry.get_ref(), &"early");
+
+    assert_eq!(queue.peek(), Some(late));
+
+    sleep(ms(20)).await;
+
+    let entry = assert_ready_some!(poll!(queue));
+    assert_eq!(entry.key(), late);
+
+    assert!(queue.peek().is_none());
+}
+
+#[tokio::test(start_paused = true)]
 async fn wake_after_remove_last() {
     let mut queue = task::spawn(DelayQueue::new());
     let key = queue.insert("foo", ms(1000));


### PR DESCRIPTION
## Motivation

`DelayQueue::peek` says it gives "the `Key` that `poll_expired` will pull out of the queue next". It doesn't, once two entries land in the same wheel slot above level zero.

```rust
let k0 = q.insert(0, Duration::from_millis(100));
let k1 = q.insert(1, Duration::from_millis(120));
q.peek()          // -> k1
poll_expired(..)  // -> k0
```

Level zero has one deadline per slot, so its head is trivially the earliest. A level-one slot spans 64ms, so it holds entries with different deadlines and `Stack::peek` returns whichever was inserted last. `poll_expired` goes through `poll_expiration`, which cascades the slot down and then pops the genuinely earliest.

Sweeping every pair of deadlines in 1..=90ms, on `master`:

```
PAIRS 1..=90ms:               351/4005 peek() != earliest key; first failing pair = (64, 65)
CONTROL both <64ms (level 0): 0/1953 disagree
E2E peek vs first poll_expired (60..=130 x ..=190):  2199/6745 disagree
E2E triples:                                       123372/154876 disagree
```

Same harness with this change: 0/4005, 0/1953, 0/6745, and 3078/154876 for triples.

Those 3078 are all cases where two entries share the earliest deadline, and the entry `poll_expired` returns has that same deadline — the cascade reverses order within a slot, so the tie flips. I measured that explicitly: 3078 ties, 0 where the popped entry was not one of the minimums. I did not try to match the tie order.

## Solution

`Stack::peek` takes no store, so it structurally cannot compare deadlines. This adds `peek_earliest`, which walks the slot, and routes `Wheel::peek` through it. `peek` is untouched for the already-expired queue, which is documented to come out in `pop` order. `peek` becomes O(entries in the earliest slot) rather than O(1).

- **The naive alternative passes the whole suite.** Using `peek_earliest` for the expired queue as well passes all 36 delay-queue tests, and I could not construct an input that separates it from this version. I kept them separate only because the docs make an explicit promise about the expired queue that I did not want to change on an assumption I could not test. Happy to collapse them if you would rather have one method.
- **My first version of the new test was vacuous.** Entries are pushed onto the front of a slot, so inserting the later deadline *first* leaves the earlier one at the head and the assertion passes on unpatched `master`. The committed test inserts the later deadline second; with the source reverted to `master` it fails at the first `assert_eq!`.

The existing `peek` test uses `now`, `now + 5ms`, `now + 10ms`, and the doc example uses 5s/10s/15s — every entry in its own slot in both, so neither can see this.

Prior art: no issue or PR mentions it. #5569 added `peek`; there you asked for a test that the earliest key comes back regardless of insertion order, and the answer was that it is impossible *for the expired stack*. That caveat is the one in the docs today; this is the other half, still in the wheel. Of the 126 open PRs, three touch `tokio-util/src/time/` (#8157, #7810, #6789) and none touch `peek`.

`cargo test -p tokio-util --all-features` is green, `cargo fmt --check` clean. `cargo clippy -p tokio-util --tests --no-deps --all-features` reports one `manual_filter` warning at `wheel/mod.rs:151` — identical on unmodified `master` with my clippy (1.97, CI pins 1.88), so I left it.

AI disclosure: prepared with AI assistance (Claude Opus 5, `claude-opus-5`). The numbers above are from the commands as shown.
