### PR TITLE
tests: re-enable ignored io shutdown tests in rt_handle_block_on

### DIFF
--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -255,11 +255,7 @@ rt_test! {
             .block_on(net::TcpListener::bind("127.0.0.1:0"))
             .unwrap_err();
 
-        assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(
-            err.get_ref().unwrap().to_string(),
-            "A Tokio 1.x context was found, but it is being shutdown.",
-        );
+        assert!(tokio::runtime::is_rt_shutdown_err(&err));
     }
 
     #[test]
@@ -273,11 +269,7 @@ rt_test! {
 
         let err = Handle::current().block_on(bind_future).unwrap_err();
 
-        assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(
-            err.get_ref().unwrap().to_string(),
-            "A Tokio 1.x context was found, but it is being shutdown.",
-        );
+        assert!(tokio::runtime::is_rt_shutdown_err(&err));
     }
 
     #[test]
@@ -303,11 +295,7 @@ rt_test! {
             .block_on(net::UdpSocket::bind("127.0.0.1:0"))
             .unwrap_err();
 
-        assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(
-            err.get_ref().unwrap().to_string(),
-            "A Tokio 1.x context was found, but it is being shutdown.",
-        );
+        assert!(tokio::runtime::is_rt_shutdown_err(&err));
     }
 
     #[cfg_attr(miri, ignore)] // No UDP sockets in miri.
@@ -322,11 +310,7 @@ rt_test! {
 
         let err = Handle::current().block_on(bind_future).unwrap_err();
 
-        assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(
-            err.get_ref().unwrap().to_string(),
-            "A Tokio 1.x context was found, but it is being shutdown.",
-        );
+        assert!(tokio::runtime::is_rt_shutdown_err(&err));
     }
 
     #[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
@@ -343,11 +327,7 @@ rt_test! {
 
         let err = net::UnixListener::bind(path).unwrap_err();
 
-        assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(
-            err.get_ref().unwrap().to_string(),
-            "A Tokio 1.x context was found, but it is being shutdown.",
-        );
+        assert!(tokio::runtime::is_rt_shutdown_err(&err));
     }
 
     #[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
@@ -367,11 +347,7 @@ rt_test! {
         // this should not timeout but fail immediately since the runtime has been shutdown
         let err = Handle::current().block_on(listener.accept()).unwrap_err();
 
-        assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(
-            err.get_ref().unwrap().to_string(),
-            "A Tokio 1.x context was found, but it is being shutdown.",
-        );
+        assert!(tokio::runtime::is_rt_shutdown_err(&err));
     }
 
     #[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
@@ -393,11 +369,7 @@ rt_test! {
         // this should not timeout but fail immediately since the runtime has been shutdown
         let err = Handle::current().block_on(accept_future).unwrap_err();
 
-        assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(
-            err.get_ref().unwrap().to_string(),
-            "A Tokio 1.x context was found, but it is being shutdown.",
-        );
+        assert!(tokio::runtime::is_rt_shutdown_err(&err));
     }
 
     // ==== nesting ======

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -291,6 +291,7 @@ rt_test! {
             .unwrap();
     }
 
+    #[cfg_attr(miri, ignore)] // No UDP sockets in miri.
     #[test]
     fn udp_stream_bind_after_shutdown() {
         let rt = rt();
@@ -309,6 +310,7 @@ rt_test! {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // No UDP sockets in miri.
     #[test]
     fn udp_stream_bind_before_shutdown() {
         let rt = rt();
@@ -327,6 +329,7 @@ rt_test! {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
     #[cfg(unix)]
     #[test]
     fn unix_listener_bind_after_shutdown() {
@@ -347,6 +350,7 @@ rt_test! {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
     #[cfg(unix)]
     #[test]
     fn unix_listener_shutdown_after_bind() {
@@ -370,6 +374,7 @@ rt_test! {
         );
     }
 
+    #[cfg_attr(miri, ignore)] // No Unix domain sockets in miri.
     #[cfg(unix)]
     #[test]
     fn unix_listener_shutdown_after_accept() {

--- a/tokio/tests/rt_handle_block_on.rs
+++ b/tokio/tests/rt_handle_block_on.rs
@@ -1,12 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![cfg(feature = "full")]
 
-// All io tests that deal with shutdown is currently ignored because there are known bugs in with
-// shutting down the io driver while concurrently registering new resources. See
-// https://github.com/tokio-rs/tokio/pull/3569#pullrequestreview-612703467 for more details.
-//
-// When this has been fixed we want to re-enable these tests.
-
 use std::time::Duration;
 use tokio::runtime::{Handle, Runtime};
 use tokio::sync::mpsc;
@@ -250,8 +244,6 @@ rt_test! {
             .unwrap();
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn tcp_listener_connect_after_shutdown() {
         let rt = rt();
@@ -270,8 +262,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn tcp_listener_connect_before_shutdown() {
         let rt = rt();
@@ -301,8 +291,6 @@ rt_test! {
             .unwrap();
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn udp_stream_bind_after_shutdown() {
         let rt = rt();
@@ -321,8 +309,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[test]
     fn udp_stream_bind_before_shutdown() {
         let rt = rt();
@@ -341,8 +327,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[cfg(unix)]
     #[test]
     fn unix_listener_bind_after_shutdown() {
@@ -363,8 +347,6 @@ rt_test! {
         );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[cfg(unix)]
     #[test]
     fn unix_listener_shutdown_after_bind() {
@@ -382,11 +364,12 @@ rt_test! {
         let err = Handle::current().block_on(listener.accept()).unwrap_err();
 
         assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(err.get_ref().unwrap().to_string(), "reactor gone");
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
     }
 
-    // All io tests are ignored for now. See above why that is.
-    #[ignore]
     #[cfg(unix)]
     #[test]
     fn unix_listener_shutdown_after_accept() {
@@ -406,7 +389,10 @@ rt_test! {
         let err = Handle::current().block_on(accept_future).unwrap_err();
 
         assert_eq!(err.kind(), std::io::ErrorKind::Other);
-        assert_eq!(err.get_ref().unwrap().to_string(), "reactor gone");
+        assert_eq!(
+            err.get_ref().unwrap().to_string(),
+            "A Tokio 1.x context was found, but it is being shutdown.",
+        );
     }
 
     // ==== nesting ======


### PR DESCRIPTION
This re-opens the work from #8398, which I couldn't reopen through the API after pushing (GitHub returns UNPROCESSABLE once a commit lands on a closed PR's branch).

Same change as #8398 — remove the stale `#[ignore]` from the io-shutdown tests in `rt_handle_block_on` — **plus the one fix that was missing**: the only failing check on #8398 was `miri-test`, because the newly enabled UDP and Unix-domain tests can't run under Miri (no `SOCK_DGRAM`/`AF_UNIX` emulation). Those five are now gated with `#[cfg_attr(miri, ignore)]`, matching the existing convention in `tests/udp.rs` and `tests/uds_socket.rs`; the TCP cases run fine under Miri and stay enabled.

The original `#[ignore]` reason (io-driver shutdown unsoundness, #3569) no longer holds after the `RegistrationSet` rewrite in #5833 — which is also why the two `"reactor gone"` assertions became `"A Tokio 1.x context was found, but it is being shutdown."`.

Closes #8398 in spirit; happy to squash or adjust as you prefer, @Darksonn.