### PR TITLE
codec: document buffer reclamation

### DIFF
--- a/tokio-util/src/codec/decoder.rs
+++ b/tokio-util/src/codec/decoder.rs
@@ -119,6 +119,31 @@ pub trait Decoder {
     /// }
     /// ```
     ///
+    /// `BytesMut::clear` and `BytesMut::truncate` preserve the buffer's
+    /// existing capacity. Other methods that remove data do not necessarily
+    /// release the backing allocation either. If a rare large frame causes the
+    /// buffer to retain too much memory, the decoder can replace it after
+    /// consuming that frame. Any unconsumed bytes must be copied into the
+    /// replacement:
+    ///
+    /// ```
+    /// use bytes::BytesMut;
+    ///
+    /// fn reclaim_buffer(src: &mut BytesMut) {
+    ///     *src = BytesMut::from(&src[..]);
+    /// }
+    ///
+    /// let mut src = BytesMut::with_capacity(1024);
+    /// src.extend_from_slice(b"next frame");
+    /// reclaim_buffer(&mut src);
+    /// assert_eq!(&src[..], b"next frame");
+    /// ```
+    ///
+    /// Replacing the buffer copies the unconsumed bytes and may cause more
+    /// allocations, so it should be done only when retaining the existing
+    /// allocation is undesirable. The old allocation remains alive until all
+    /// other values that share it are dropped.
+    ///
     /// An optimal buffer management strategy minimizes reallocations and
     /// over-allocations.
     fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error>;

--- a/tokio-util/src/codec/encoder.rs
+++ b/tokio-util/src/codec/encoder.rs
@@ -20,6 +20,15 @@ pub trait Encoder<Item> {
     /// The `dst` provided is an internal buffer of the [`FramedWrite`] instance and
     /// will be written out when possible.
     ///
+    /// # Buffer management
+    ///
+    /// The buffer is reused across calls and may retain its allocation after a
+    /// large frame is written. If the encoder replaces `dst` to reclaim that
+    /// allocation, it must preserve any queued data. The [`Decoder::decode`]
+    /// buffer management guidance shows how to replace a buffer while preserving
+    /// its contents.
+    ///
     /// [`FramedWrite`]: crate::codec::FramedWrite
+    /// [`Decoder::decode`]: crate::codec::Decoder::decode
     fn encode(&mut self, item: Item, dst: &mut BytesMut) -> Result<(), Self::Error>;
 }


### PR DESCRIPTION
## Motivation

Codec buffers are reused and can retain a large allocation after a rare large frame. The existing documentation explains buffer growth, but not how to reclaim retained capacity.

Fixes #7344.

## Solution

Document capacity retention for decoder and encoder buffers. Add a doctested example that replaces a buffer while preserving unconsumed bytes. Explain how shared allocations affect reclamation.

## Testing

- `cargo test -p tokio-util --all-features`
- `cargo test -p tokio-util --doc --all-features`
- `RUSTFLAGS="--cfg tokio_unstable -Dwarnings" cargo clippy -p tokio-util --tests --no-deps --all-features`
- `rustfmt --check --edition 2021 $(git ls-files '*.rs')`
- `cargo doc -p tokio -p tokio-util --all-features --no-deps`