### PR TITLE
Fix spawn_blocking hang when only scheduler workers exist

### DIFF
--- a/tokio/src/runtime/blocking/mod.rs
+++ b/tokio/src/runtime/blocking/mod.rs
@@ -23,6 +23,10 @@ pub(crate) use task::BlockingTask;
 
 use crate::runtime::Builder;
 
-pub(crate) fn create_blocking_pool(builder: &Builder, thread_cap: usize) -> BlockingPool {
-    BlockingPool::new(builder, thread_cap)
+pub(crate) fn create_blocking_pool(
+    builder: &Builder,
+    thread_cap: usize,
+    scheduler_threads: usize,
+) -> BlockingPool {
+    BlockingPool::new(builder, thread_cap, scheduler_threads)
 }

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -93,6 +93,9 @@ struct Inner {
     // Maximum number of threads.
     thread_cap: usize,
 
+    // Number of runtime scheduler workers counted in `num_threads`.
+    scheduler_threads: MetricAtomicUsize,
+
     // Customizable wait timeout.
     keep_alive: Duration,
 
@@ -265,7 +268,11 @@ cfg_fs! {
 // ===== impl BlockingPool =====
 
 impl BlockingPool {
-    pub(crate) fn new(builder: &Builder, thread_cap: usize) -> BlockingPool {
+    pub(crate) fn new(
+        builder: &Builder,
+        thread_cap: usize,
+        scheduler_threads: usize,
+    ) -> BlockingPool {
         let (shutdown_tx, shutdown_rx) = shutdown::channel();
         let keep_alive = builder.keep_alive.unwrap_or(KEEP_ALIVE);
 
@@ -292,6 +299,7 @@ impl BlockingPool {
                     after_start: builder.after_start.clone(),
                     before_stop: builder.before_stop.clone(),
                     thread_cap,
+                    scheduler_threads: MetricAtomicUsize::new(scheduler_threads),
                     keep_alive,
                     metrics: SpawnerMetrics::default(),
                 }),
@@ -444,6 +452,21 @@ impl Spawner {
         (handle, spawned)
     }
 
+    pub(crate) fn inc_scheduler_threads(&self) {
+        self.inner.scheduler_threads.increment();
+    }
+
+    pub(crate) fn dec_scheduler_threads(&self) {
+        self.inner.scheduler_threads.decrement();
+    }
+
+    fn num_blocking_threads(&self) -> usize {
+        self.inner
+            .metrics
+            .num_threads()
+            .saturating_sub(self.inner.scheduler_threads.load(Ordering::Relaxed))
+    }
+
     fn spawn_task(&self, task: Task, rt: &Handle) -> Result<(), SpawnError> {
         // The `on_no_idle` closure runs under the same lock as the queue
         // push, exactly like the pre-refactor code that called
@@ -453,7 +476,7 @@ impl Spawner {
             .spawn_task(task, &self.inner.metrics, |thread_mgmt_state| {
                 // No threads are able to process the task.
 
-                if self.inner.metrics.num_threads() == self.inner.thread_cap {
+                if self.num_blocking_threads() == self.inner.thread_cap {
                     // At max number of threads
                     return Ok(());
                 }
@@ -472,7 +495,8 @@ impl Spawner {
                         }
                         Err(ref e)
                             if is_temporary_os_thread_error(e)
-                                && self.inner.metrics.num_threads() > 0 =>
+                                && self.inner.metrics.num_threads()
+                                    > self.inner.scheduler_threads.load(Ordering::Relaxed) =>
                         {
                             // OS temporarily failed to spawn a new thread.
                             // The task will be picked up eventually by a currently

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -94,7 +94,7 @@ struct Inner {
     thread_cap: usize,
 
     // Number of runtime scheduler workers counted in `num_threads`.
-    scheduler_threads: MetricAtomicUsize,
+    scheduler_threads: usize,
 
     // Customizable wait timeout.
     keep_alive: Duration,
@@ -299,7 +299,7 @@ impl BlockingPool {
                     after_start: builder.after_start.clone(),
                     before_stop: builder.before_stop.clone(),
                     thread_cap,
-                    scheduler_threads: MetricAtomicUsize::new(scheduler_threads),
+                    scheduler_threads,
                     keep_alive,
                     metrics: SpawnerMetrics::default(),
                 }),
@@ -452,21 +452,11 @@ impl Spawner {
         (handle, spawned)
     }
 
-    cfg_rt_multi_thread! {
-        pub(crate) fn inc_scheduler_threads(&self) {
-            self.inner.scheduler_threads.increment();
-        }
-
-        pub(crate) fn dec_scheduler_threads(&self) {
-            self.inner.scheduler_threads.decrement();
-        }
-    }
-
     fn num_blocking_threads(&self) -> usize {
         self.inner
             .metrics
             .num_threads()
-            .saturating_sub(self.inner.scheduler_threads.load(Ordering::Relaxed))
+            .saturating_sub(self.inner.scheduler_threads)
     }
 
     fn spawn_task(&self, task: Task, rt: &Handle) -> Result<(), SpawnError> {
@@ -478,7 +468,7 @@ impl Spawner {
             .spawn_task(task, &self.inner.metrics, |thread_mgmt_state| {
                 // No threads are able to process the task.
 
-                if self.num_blocking_threads() == self.inner.thread_cap {
+                if self.inner.metrics.num_threads() == self.inner.thread_cap {
                     // At max number of threads
                     return Ok(());
                 }
@@ -497,8 +487,7 @@ impl Spawner {
                         }
                         Err(ref e)
                             if is_temporary_os_thread_error(e)
-                                && self.inner.metrics.num_threads()
-                                    > self.inner.scheduler_threads.load(Ordering::Relaxed) =>
+                                && self.num_blocking_threads() > 0 =>
                         {
                             // OS temporarily failed to spawn a new thread.
                             // The task will be picked up eventually by a currently

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -452,12 +452,14 @@ impl Spawner {
         (handle, spawned)
     }
 
-    pub(crate) fn inc_scheduler_threads(&self) {
-        self.inner.scheduler_threads.increment();
-    }
+    cfg_rt_multi_thread! {
+        pub(crate) fn inc_scheduler_threads(&self) {
+            self.inner.scheduler_threads.increment();
+        }
 
-    pub(crate) fn dec_scheduler_threads(&self) {
-        self.inner.scheduler_threads.decrement();
+        pub(crate) fn dec_scheduler_threads(&self) {
+            self.inner.scheduler_threads.decrement();
+        }
     }
 
     fn num_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -452,7 +452,7 @@ impl Spawner {
         (handle, spawned)
     }
 
-    fn num_blocking_threads(&self) -> usize {
+    pub(crate) fn num_blocking_threads(&self) -> usize {
         self.inner
             .metrics
             .num_threads()
@@ -530,10 +530,6 @@ impl Spawner {
 
 cfg_unstable_metrics! {
     impl Spawner {
-        pub(crate) fn num_threads(&self) -> usize {
-            self.inner.metrics.num_threads()
-        }
-
         pub(crate) fn num_idle_threads(&self) -> usize {
             self.inner.metrics.num_idle_threads()
         }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1759,7 +1759,7 @@ impl Builder {
         let (driver, driver_handle) = driver::Driver::new(cfg)?;
 
         // Blocking pool
-        let blocking_pool = blocking::create_blocking_pool(self, self.max_blocking_threads);
+        let blocking_pool = blocking::create_blocking_pool(self, self.max_blocking_threads, 0);
         let blocking_spawner = blocking_pool.spawner().clone();
 
         // Generate a rng seed for this runtime.
@@ -2133,7 +2133,7 @@ cfg_rt_multi_thread! {
 
             // Create the blocking pool
             let blocking_pool =
-                blocking::create_blocking_pool(self, self.max_blocking_threads + worker_threads);
+                blocking::create_blocking_pool(self, self.max_blocking_threads + worker_threads, worker_threads);
             let blocking_spawner = blocking_pool.spawner().clone();
 
             // Generate a rng seed for this runtime.

--- a/tokio/src/runtime/scheduler/current_thread/mod.rs
+++ b/tokio/src/runtime/scheduler/current_thread/mod.rs
@@ -662,7 +662,7 @@ cfg_unstable_metrics! {
         }
 
         pub(crate) fn num_blocking_threads(&self) -> usize {
-            self.blocking_spawner.num_threads()
+            self.blocking_spawner.num_blocking_threads()
         }
 
         pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/handle/metrics.rs
@@ -30,10 +30,7 @@ impl Handle {
         }
 
         pub(crate) fn num_blocking_threads(&self) -> usize {
-            // workers are currently spawned using spawn_blocking
-            self.blocking_spawner
-                .num_threads()
-                .saturating_sub(self.num_workers())
+            self.blocking_spawner.num_blocking_threads()
         }
 
         pub(crate) fn num_idle_blocking_threads(&self) -> usize {

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -505,12 +505,7 @@ fn maybe_move_runtime() -> Result<(bool, bool), &'static str> {
         // Once the blocking task is done executing, we will attempt to
         // steal the core back.
         let worker = cx.worker.clone();
-        let spawner = worker.handle.blocking_spawner.clone();
-        spawner.inc_scheduler_threads();
-        runtime::spawn_blocking(move || {
-            run(worker);
-            spawner.dec_scheduler_threads();
-        });
+        runtime::spawn_blocking(move || run(worker));
         Ok(())
     })?;
     Ok((had_entered, take_core))
@@ -519,12 +514,7 @@ fn maybe_move_runtime() -> Result<(bool, bool), &'static str> {
 impl Launch {
     pub(crate) fn launch(mut self) {
         for worker in self.0.drain(..) {
-            let spawner = worker.handle.blocking_spawner.clone();
-            spawner.inc_scheduler_threads();
-            runtime::spawn_blocking(move || {
-                run(worker);
-                spawner.dec_scheduler_threads();
-            });
+            runtime::spawn_blocking(move || run(worker));
         }
     }
 }

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -505,7 +505,12 @@ fn maybe_move_runtime() -> Result<(bool, bool), &'static str> {
         // Once the blocking task is done executing, we will attempt to
         // steal the core back.
         let worker = cx.worker.clone();
-        runtime::spawn_blocking(move || run(worker));
+        let spawner = worker.handle.blocking_spawner.clone();
+        spawner.inc_scheduler_threads();
+        runtime::spawn_blocking(move || {
+            run(worker);
+            spawner.dec_scheduler_threads();
+        });
         Ok(())
     })?;
     Ok((had_entered, take_core))
@@ -514,7 +519,12 @@ fn maybe_move_runtime() -> Result<(bool, bool), &'static str> {
 impl Launch {
     pub(crate) fn launch(mut self) {
         for worker in self.0.drain(..) {
-            runtime::spawn_blocking(move || run(worker));
+            let spawner = worker.handle.blocking_spawner.clone();
+            spawner.inc_scheduler_threads();
+            runtime::spawn_blocking(move || {
+                run(worker);
+                spawner.dec_scheduler_threads();
+            });
         }
     }
 }

--- a/tokio/tests/rt_blocking_thread_exhaust.rs
+++ b/tokio/tests/rt_blocking_thread_exhaust.rs
@@ -1,0 +1,71 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(target_os = "linux", feature = "full", not(miri)))]
+
+use std::panic::{self, AssertUnwindSafe};
+use std::time::Duration;
+
+use tokio::runtime::Builder;
+use tokio::time::{sleep, timeout};
+
+#[test]
+fn spawn_blocking_with_only_scheduler_workers() {
+    // Regression test for https://github.com/tokio-rs/tokio/issues/8406.
+    //
+    // On a multi-threaded runtime, the only pool threads present before the
+    // first `spawn_blocking` are the scheduler workers themselves. If the OS
+    // then refuses to create a new thread, the pool used to swallow the error
+    // assuming a busy thread would pick up the task, but scheduler workers
+    // never drain the blocking queue, so the task was orphaned forever.
+    //
+    // Pin the per-user process thread limit to the current thread count so
+    // that creating a new pool thread fails; `spawn_blocking` must panic
+    // with "OS can't spawn worker thread" instead of hanging.
+    let rt = Builder::new_multi_thread()
+        .worker_threads(4)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async { sleep(Duration::from_millis(300)).await });
+
+    let threads = std::fs::read_dir("/proc/self/task").unwrap().count() as u64;
+    let lim = libc::rlimit {
+        rlim_cur: threads,
+        rlim_max: threads,
+    };
+    assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NPROC, &lim) }, 0);
+
+    // If the limit could not be made effective (e.g. the host user is
+    // already near its thread cap), skip rather than flake.
+    match std::thread::Builder::new()
+        .name("probe".into())
+        .spawn(|| {})
+    {
+        Ok(h) => {
+            let _ = h.join();
+            eprintln!("skip: setrlimit did not prevent thread creation");
+            return;
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
+        Err(e) => panic!("unexpected thread-spawn error: {e}"),
+    }
+
+    let res = panic::catch_unwind(AssertUnwindSafe(|| {
+        rt.block_on(async {
+            timeout(
+                Duration::from_secs(5),
+                tokio::task::spawn_blocking(|| 42u32),
+            )
+            .await
+        })
+    }));
+
+    // The fixed code panics synchronously when no real pool thread can be
+    // created; the bug let the task hang, which the timeout turns into
+    // `Ok(Err(_))`.
+    match res {
+        Err(_) => {}
+        Ok(Err(_)) => panic!("spawn_blocking timed out"),
+        Ok(Ok(_)) => panic!("spawn_blocking unexpectedly succeeded"),
+    }
+}

--- a/tokio/tests/rt_blocking_thread_exhaust.rs
+++ b/tokio/tests/rt_blocking_thread_exhaust.rs
@@ -1,5 +1,11 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(target_os = "linux", feature = "full", not(miri), panic = "unwind",))]
+#![cfg(all(
+    target_os = "linux",
+    feature = "full",
+    not(miri),
+    not(tokio_no_tuning_tests),
+    panic = "unwind",
+))]
 
 use std::panic::{self, AssertUnwindSafe};
 use std::time::Duration;

--- a/tokio/tests/rt_blocking_thread_exhaust.rs
+++ b/tokio/tests/rt_blocking_thread_exhaust.rs
@@ -1,5 +1,5 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(target_os = "linux", feature = "full", not(miri)))]
+#![cfg(all(target_os = "linux", feature = "full", not(miri), panic = "unwind",))]
 
 use std::panic::{self, AssertUnwindSafe};
 use std::time::Duration;

--- a/tokio/tests/rt_blocking_thread_exhaust.rs
+++ b/tokio/tests/rt_blocking_thread_exhaust.rs
@@ -28,10 +28,10 @@ fn spawn_blocking_with_only_scheduler_workers() {
 
     rt.block_on(async { sleep(Duration::from_millis(300)).await });
 
-    let threads = std::fs::read_dir("/proc/self/task").unwrap().count() as u64;
+    let threads = std::fs::read_dir("/proc/self/task").unwrap().count();
     let lim = libc::rlimit {
-        rlim_cur: threads,
-        rlim_max: threads,
+        rlim_cur: threads as libc::rlim_t,
+        rlim_max: threads as libc::rlim_t,
     };
     assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NPROC, &lim) }, 0);
 

--- a/tokio/tests/rt_blocking_thread_exhaust.rs
+++ b/tokio/tests/rt_blocking_thread_exhaust.rs
@@ -8,10 +8,11 @@
 ))]
 
 use std::panic::{self, AssertUnwindSafe};
+use std::sync::mpsc;
 use std::time::Duration;
 
 use tokio::runtime::Builder;
-use tokio::time::{sleep, timeout};
+use tokio::time::timeout;
 
 #[test]
 fn spawn_blocking_with_only_scheduler_workers() {
@@ -26,13 +27,20 @@ fn spawn_blocking_with_only_scheduler_workers() {
     // Pin the per-user process thread limit to the current thread count so
     // that creating a new pool thread fails; `spawn_blocking` must panic
     // with "OS can't spawn worker thread" instead of hanging.
+
+    let (started_tx, started_rx) = mpsc::sync_channel(4);
     let rt = Builder::new_multi_thread()
         .worker_threads(4)
+        .on_thread_start(move || {
+            started_tx.send(()).unwrap();
+        })
         .enable_all()
         .build()
         .unwrap();
 
-    rt.block_on(async { sleep(Duration::from_millis(300)).await });
+    for _ in 0..4 {
+        started_rx.recv().unwrap();
+    }
 
     let threads = std::fs::read_dir("/proc/self/task").unwrap().count();
     let lim = libc::rlimit {
@@ -41,8 +49,8 @@ fn spawn_blocking_with_only_scheduler_workers() {
     };
     assert_eq!(unsafe { libc::setrlimit(libc::RLIMIT_NPROC, &lim) }, 0);
 
-    // If the limit could not be made effective (e.g. the host user is
-    // already near its thread cap), skip rather than flake.
+    // If the limit is not enforced for this process (e.g. when running as root
+    // or in a container), skip rather than fail.
     match std::thread::Builder::new()
         .name("probe".into())
         .spawn(|| {})
@@ -69,9 +77,19 @@ fn spawn_blocking_with_only_scheduler_workers() {
     // The fixed code panics synchronously when no real pool thread can be
     // created; the bug let the task hang, which the timeout turns into
     // `Ok(Err(_))`.
-    match res {
-        Err(_) => {}
+    let panic_err = match res {
+        Err(panic_err) => panic_err,
         Ok(Err(_)) => panic!("spawn_blocking timed out"),
         Ok(Ok(_)) => panic!("spawn_blocking unexpectedly succeeded"),
-    }
+    };
+
+    let msg = panic_err
+        .downcast_ref::<&str>()
+        .copied()
+        .or_else(|| panic_err.downcast_ref::<String>().map(|s| s.as_str()))
+        .unwrap_or("");
+    assert!(
+        msg.contains("OS can't spawn worker thread"),
+        "unexpected panic: {msg}"
+    );
 }


### PR DESCRIPTION
## Motivation

   On a multi-threaded runtime, `spawn_blocking` can hang indefinitely when the OS refuses to create the first blocking-pool thread.

   Tokio currently counts scheduler workers as blocking-pool threads, but scheduler workers do not process the blocking-task queue. As a result, Tokio can incorrectly assume that an existing thread will execute the queued task.

   ## Solution

   Track scheduler workers separately from actual blocking-pool workers.

   Only ignore a temporary thread-creation failure when a real blocking-pool worker exists. Scheduler-worker accounting is updated for both normal scheduler workers and `block_in_place` replacement workers.

   ## Testing

   - `cargo fmt --all`
   - `cargo check -p tokio --features full`
   - `cargo test -p tokio --features full`
   - `git diff --check`

   The issue can be reproduced on Linux using `RLIMIT_NPROC`, but I did not add a regression test yet. Guidance on the preferred way to test this behavior in Tokio would be appreciated.
   
   fixes #8406