### PR TITLE
rt: add `Builder::max_io_events_per_busy_tick`

### DIFF
--- a/tokio/src/process/unix/orphan.rs
+++ b/tokio/src/process/unix/orphan.rs
@@ -295,7 +295,7 @@ pub(crate) mod test {
     #[cfg_attr(miri, ignore)] // No `sigaction` on Miri
     #[test]
     fn does_not_register_signal_if_queue_empty() {
-        let (io_driver, io_handle) = IoDriver::new(1024).unwrap();
+        let (io_driver, io_handle) = IoDriver::new(1024, None).unwrap();
         let signal_driver = SignalDriver::new(io_driver, &io_handle).unwrap();
         let handle = signal_driver.handle();
 

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -62,6 +62,7 @@ pub struct Builder {
     /// Whether or not to enable the I/O driver
     enable_io: bool,
     nevents: usize,
+    nevents_busy: Option<usize>,
 
     /// Whether or not to enable the time driver
     enable_time: bool,
@@ -308,6 +309,7 @@ impl Builder {
             // I/O defaults to "off"
             enable_io: false,
             nevents: 1024,
+            nevents_busy: None,
 
             // Time defaults to "off"
             enable_time: false,
@@ -1196,6 +1198,10 @@ impl Builder {
             enable_time: self.enable_time,
             start_paused: self.start_paused,
             nevents: self.nevents,
+            // Only the multi-thread runtime has local queues to overflow.
+            nevents_busy: self
+                .nevents_busy
+                .filter(|_| !matches!(self.kind, Kind::CurrentThread)),
             timer_flavor: self.timer_flavor,
         }
     }
@@ -1865,6 +1871,52 @@ cfg_io_driver! {
         /// ```
         pub fn max_io_events_per_tick(&mut self, capacity: usize) -> &mut Self {
             self.nevents = capacity;
+            self
+        }
+
+        /// Sets the max number of I/O events a worker processes when it polls
+        /// the driver while it still has tasks to run.
+        ///
+        /// A busy worker polls the driver every [`event_interval`] tasks, and
+        /// every task that poll wakes goes to its local queue. A large batch
+        /// overflows that queue, and under sustained overload the overflow
+        /// grows until requests time out. A small busy batch leaves the rest
+        /// in the kernel. An idle worker still takes up to
+        /// [`max_io_events_per_tick`] events.
+        ///
+        /// The runtime treats any poll that does not wait as busy. That
+        /// includes a park with a timer that has already expired, because the
+        /// worker runs that timer's task next.
+        ///
+        /// The local queue holds 256 tasks, so set `max_io_events_per_tick`
+        /// to at most 256 as well, with room for the tasks those tasks wake.
+        ///
+        /// The default is `max_io_events_per_tick`. Only the multi-thread
+        /// runtime uses this option.
+        ///
+        /// [`event_interval`]: Builder::event_interval
+        /// [`max_io_events_per_tick`]: Builder::max_io_events_per_tick
+        ///
+        /// # Panics
+        ///
+        /// Panics if `capacity` is zero.
+        ///
+        /// # Examples
+        ///
+        /// ```
+        /// use tokio::runtime;
+        ///
+        /// let rt = runtime::Builder::new_multi_thread()
+        ///     .enable_io()
+        ///     .max_io_events_per_tick(128)
+        ///     .max_io_events_per_busy_tick(8)
+        ///     .build()
+        ///     .unwrap();
+        /// ```
+        #[track_caller]
+        pub fn max_io_events_per_busy_tick(&mut self, capacity: usize) -> &mut Self {
+            assert!(capacity > 0, "max_io_events_per_busy_tick must be non-zero");
+            self.nevents_busy = Some(capacity);
             self
         }
     }

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1852,8 +1852,7 @@ cfg_io_driver! {
             self
         }
 
-        /// Enables the I/O driver and configures the max number of events to be
-        /// processed per tick.
+        /// Sets the max number of I/O events processed per tick.
         ///
         /// To take a smaller batch on polls that do not wait, see
         /// [`max_io_events_per_busy_tick`].

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1904,7 +1904,7 @@ impl Builder {
     /// ```
     /// use tokio::runtime;
     ///
-    /// let rt = runtime::Builder::new_multi_thread()
+    /// let rt = runtime::Builder::new_current_thread()
     ///     .enable_io()
     ///     .max_io_events_per_tick(128)
     ///     .max_io_events_per_busy_tick(8)

--- a/tokio/src/runtime/builder.rs
+++ b/tokio/src/runtime/builder.rs
@@ -1198,10 +1198,7 @@ impl Builder {
             enable_time: self.enable_time,
             start_paused: self.start_paused,
             nevents: self.nevents,
-            // Only the multi-thread runtime has local queues to overflow.
-            nevents_busy: self
-                .nevents_busy
-                .filter(|_| !matches!(self.kind, Kind::CurrentThread)),
+            nevents_busy: self.nevents_busy,
             timer_flavor: self.timer_flavor,
         }
     }
@@ -1858,6 +1855,11 @@ cfg_io_driver! {
         /// Enables the I/O driver and configures the max number of events to be
         /// processed per tick.
         ///
+        /// To take a smaller batch on polls that do not wait, see
+        /// [`max_io_events_per_busy_tick`].
+        ///
+        /// [`max_io_events_per_busy_tick`]: Builder::max_io_events_per_busy_tick
+        ///
         /// # Examples
         ///
         /// ```
@@ -1888,11 +1890,11 @@ cfg_io_driver! {
         /// includes a park with a timer that has already expired, because the
         /// worker runs that timer's task next.
         ///
-        /// The local queue holds 256 tasks, so set `max_io_events_per_tick`
-        /// to at most 256 as well, with room for the tasks those tasks wake.
+        /// A multi-thread worker's local queue holds 256 tasks, so set
+        /// `max_io_events_per_tick` to at most 256 as well, with room for the
+        /// tasks those tasks wake.
         ///
-        /// The default is `max_io_events_per_tick`. Only the multi-thread
-        /// runtime uses this option.
+        /// The default is to use the same value as [`max_io_events_per_tick`].
         ///
         /// [`event_interval`]: Builder::event_interval
         /// [`max_io_events_per_tick`]: Builder::max_io_events_per_tick

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -40,12 +40,14 @@ pub(crate) struct Cfg {
     pub(crate) enable_pause_time: bool,
     pub(crate) start_paused: bool,
     pub(crate) nevents: usize,
+    pub(crate) nevents_busy: Option<usize>,
     pub(crate) timer_flavor: crate::runtime::TimerFlavor,
 }
 
 impl Driver {
     pub(crate) fn new(cfg: Cfg) -> io::Result<(Self, Handle)> {
-        let (io_stack, io_handle, signal_handle) = create_io_stack(cfg.enable_io, cfg.nevents)?;
+        let (io_stack, io_handle, signal_handle) =
+            create_io_stack(cfg.enable_io, cfg.nevents, cfg.nevents_busy)?;
 
         let clock = create_clock(cfg.enable_pause_time, cfg.start_paused);
 
@@ -146,12 +148,13 @@ cfg_io_driver! {
         Disabled(UnparkThread),
     }
 
-    fn create_io_stack(enabled: bool, nevents: usize) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
+    fn create_io_stack(enabled: bool, nevents: usize, nevents_busy: Option<usize>) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
         #[cfg(loom)]
         assert!(!enabled);
 
         let ret = if enabled {
-            let (io_driver, io_handle) = crate::runtime::io::Driver::new(nevents)?;
+            let (mut io_driver, io_handle) = crate::runtime::io::Driver::new(nevents)?;
+            io_driver.set_max_events_busy(nevents_busy);
 
             let (signal_driver, signal_handle) = create_signal_driver(io_driver, &io_handle)?;
             let process_driver = create_process_driver(signal_driver);
@@ -212,7 +215,7 @@ cfg_not_io_driver! {
     #[derive(Debug)]
     pub(crate) struct IoStack(ParkThread);
 
-    fn create_io_stack(_enabled: bool, _nevents: usize) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
+    fn create_io_stack(_enabled: bool, _nevents: usize, _nevents_busy: Option<usize>) -> io::Result<(IoStack, IoHandle, SignalHandle)> {
         let park_thread = ParkThread::new();
         let unpark_thread = park_thread.unpark();
         Ok((IoStack(park_thread), unpark_thread, Default::default()))

--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -153,8 +153,7 @@ cfg_io_driver! {
         assert!(!enabled);
 
         let ret = if enabled {
-            let (mut io_driver, io_handle) = crate::runtime::io::Driver::new(nevents)?;
-            io_driver.set_max_events_busy(nevents_busy);
+            let (io_driver, io_handle) = crate::runtime::io::Driver::new(nevents, nevents_busy)?;
 
             let (signal_driver, signal_handle) = create_signal_driver(io_driver, &io_handle)?;
             let process_driver = create_process_driver(signal_driver);

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -29,6 +29,11 @@ pub(crate) struct Driver {
     /// Reuse the `mio::Events` value across calls to poll.
     events: mio::Events,
 
+    /// Smaller buffer for zero-timeout polls. A worker makes one while it
+    /// still has tasks, or when a timer has already expired. Set by
+    /// `Builder::max_io_events_per_busy_tick`.
+    events_busy: Option<mio::Events>,
+
     /// The system event queue.
     poll: mio::Poll,
 }
@@ -123,6 +128,7 @@ impl Driver {
         let driver = Driver {
             signal_ready: false,
             events: mio::Events::with_capacity(nevents),
+            events_busy: None,
             poll,
         };
 
@@ -156,6 +162,12 @@ impl Driver {
         Ok((driver, handle))
     }
 
+    pub(crate) fn set_max_events_busy(&mut self, nevents: Option<usize>) {
+        self.events_busy = nevents
+            .filter(|&n| n < self.events.capacity())
+            .map(mio::Events::with_capacity);
+    }
+
     pub(crate) fn park(&mut self, rt_handle: &driver::Handle) {
         let handle = rt_handle.io();
         self.turn(handle, None);
@@ -181,7 +193,12 @@ impl Driver {
 
         handle.release_pending_registrations();
 
-        let events = &mut self.events;
+        // A poll that does not wait takes the smaller batch. Events it leaves
+        // behind stay queued in the kernel, so the next poll returns them.
+        let events = match (&mut self.events_busy, max_wait) {
+            (Some(busy), Some(wait)) if wait.is_zero() => busy,
+            _ => &mut self.events,
+        };
 
         // Block waiting for an event to happen, peeling out how many events
         // happened.

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -382,5 +382,6 @@ mod tests {
         for (mut rx, _tx, reg) in sources {
             handle.deregister_source(&reg, &mut rx).unwrap();
         }
+        handle.release_pending_registrations();
     }
 }

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -29,9 +29,8 @@ pub(crate) struct Driver {
     /// Reuse the `mio::Events` value across calls to poll.
     events: mio::Events,
 
-    /// Smaller buffer for zero-timeout polls. A worker makes one while it
-    /// still has tasks, or when a timer has already expired. Set by
-    /// `Builder::max_io_events_per_busy_tick`.
+    /// Buffer for polls that do not wait, if
+    /// `Builder::max_io_events_per_busy_tick` is set.
     events_busy: Option<mio::Events>,
 
     /// The system event queue.
@@ -119,7 +118,7 @@ fn _assert_kinds() {
 impl Driver {
     /// Creates a new event loop, returning any error that happened during the
     /// creation.
-    pub(crate) fn new(nevents: usize) -> io::Result<(Driver, Handle)> {
+    pub(crate) fn new(nevents: usize, nevents_busy: Option<usize>) -> io::Result<(Driver, Handle)> {
         let poll = mio::Poll::new()?;
         #[cfg(not(target_os = "wasi"))]
         let waker = mio::Waker::new(poll.registry(), TOKEN_WAKEUP)?;
@@ -128,7 +127,7 @@ impl Driver {
         let driver = Driver {
             signal_ready: false,
             events: mio::Events::with_capacity(nevents),
-            events_busy: None,
+            events_busy: nevents_busy.map(mio::Events::with_capacity),
             poll,
         };
 
@@ -162,12 +161,6 @@ impl Driver {
         Ok((driver, handle))
     }
 
-    pub(crate) fn set_max_events_busy(&mut self, nevents: Option<usize>) {
-        self.events_busy = nevents
-            .filter(|&n| n < self.events.capacity())
-            .map(mio::Events::with_capacity);
-    }
-
     pub(crate) fn park(&mut self, rt_handle: &driver::Handle) {
         let handle = rt_handle.io();
         self.turn(handle, None);
@@ -193,7 +186,7 @@ impl Driver {
 
         handle.release_pending_registrations();
 
-        // A poll that does not wait takes the smaller batch. Events it leaves
+        // A poll that does not wait takes the busy batch. Events it leaves
         // behind stay queued in the kernel, so the next poll returns them.
         let events = match (&mut self.events_busy, max_wait) {
             (Some(busy), Some(wait)) if wait.is_zero() => busy,

--- a/tokio/src/runtime/io/driver.rs
+++ b/tokio/src/runtime/io/driver.rs
@@ -354,3 +354,33 @@ impl Direction {
         }
     }
 }
+
+#[cfg(all(test, unix, feature = "net", not(loom), not(miri)))]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn busy_turn_takes_busy_batch() {
+        let (mut driver, handle) = Driver::new(16, Some(2)).unwrap();
+        let mut sources = Vec::new();
+        for _ in 0..5 {
+            let (mut rx, mut tx) = mio::net::UnixStream::pair().unwrap();
+            tx.write_all(b"x").unwrap();
+            let reg = handle.add_source(&mut rx, Interest::READABLE).unwrap();
+            sources.push((rx, tx, reg));
+        }
+
+        // A poll that does not wait takes the busy batch.
+        driver.turn(&handle, Some(Duration::ZERO));
+        assert_eq!(driver.events_busy.as_ref().unwrap().iter().count(), 2);
+
+        // The rest stays queued for the next poll, which takes the main batch.
+        driver.turn(&handle, Some(Duration::from_millis(100)));
+        assert_eq!(driver.events.iter().count(), 3);
+
+        for (mut rx, _tx, reg) in sources {
+            handle.deregister_source(&reg, &mut rx).unwrap();
+        }
+    }
+}

--- a/tokio/tests/rt_busy_tick.rs
+++ b/tokio/tests/rt_busy_tick.rs
@@ -1,0 +1,66 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))]
+
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
+#[test]
+#[should_panic(expected = "max_io_events_per_busy_tick must be non-zero")]
+fn zero_busy_tick_panics() {
+    tokio::runtime::Builder::new_multi_thread().max_io_events_per_busy_tick(0);
+}
+
+#[test]
+fn busy_workers_still_get_every_event() {
+    // Every worker always has a task, so it polls the driver only at its
+    // maintenance tick, and each poll takes one event. The events each poll
+    // leaves in the kernel must still reach their tasks.
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_io_events_per_busy_tick(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    for _ in 0..8 {
+        rt.spawn(async {
+            loop {
+                tokio::task::yield_now().await;
+            }
+        });
+    }
+    rt.block_on(async {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut s, _) = listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    let mut buf = [0u8; 4];
+                    while s.read_exact(&mut buf).await.is_ok() {
+                        s.write_all(&buf).await.unwrap();
+                    }
+                });
+            }
+        });
+        let clients: Vec<_> = (0..16)
+            .map(|_| {
+                tokio::spawn(async move {
+                    let mut s = TcpStream::connect(addr).await.unwrap();
+                    for _ in 0..16 {
+                        s.write_all(b"ping").await.unwrap();
+                        s.read_exact(&mut [0u8; 4]).await.unwrap();
+                    }
+                })
+            })
+            .collect();
+        let all = async {
+            for c in clients {
+                c.await.unwrap();
+            }
+        };
+        tokio::time::timeout(Duration::from_secs(20), all)
+            .await
+            .expect("echo round trips did not finish");
+    });
+}

--- a/tokio/tests/rt_busy_tick.rs
+++ b/tokio/tests/rt_busy_tick.rs
@@ -11,9 +11,8 @@ fn zero_busy_tick_panics() {
     tokio::runtime::Builder::new_multi_thread().max_io_events_per_busy_tick(0);
 }
 
-// Every worker always has a task, so it polls the driver only at its
-// maintenance tick, and each poll takes one event. The events each poll
-// leaves in the kernel must still reach their tasks.
+// Liveness check: the runtime always has runnable tasks, so its I/O polls do
+// not wait and each takes one event. Echo traffic must still complete.
 fn busy_runtime_gets_every_event(rt: tokio::runtime::Runtime) {
     for _ in 0..8 {
         rt.spawn(async {
@@ -60,8 +59,9 @@ fn busy_runtime_gets_every_event(rt: tokio::runtime::Runtime) {
 
 #[test]
 fn multi_thread_busy_tick() {
+    // One worker, so the spinning tasks keep it from ever parking.
     let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
+        .worker_threads(1)
         .max_io_events_per_busy_tick(1)
         .enable_all()
         .build()

--- a/tokio/tests/rt_busy_tick.rs
+++ b/tokio/tests/rt_busy_tick.rs
@@ -11,17 +11,10 @@ fn zero_busy_tick_panics() {
     tokio::runtime::Builder::new_multi_thread().max_io_events_per_busy_tick(0);
 }
 
-#[test]
-fn busy_workers_still_get_every_event() {
-    // Every worker always has a task, so it polls the driver only at its
-    // maintenance tick, and each poll takes one event. The events each poll
-    // leaves in the kernel must still reach their tasks.
-    let rt = tokio::runtime::Builder::new_multi_thread()
-        .worker_threads(2)
-        .max_io_events_per_busy_tick(1)
-        .enable_all()
-        .build()
-        .unwrap();
+// Every worker always has a task, so it polls the driver only at its
+// maintenance tick, and each poll takes one event. The events each poll
+// leaves in the kernel must still reach their tasks.
+fn busy_runtime_gets_every_event(rt: tokio::runtime::Runtime) {
     for _ in 0..8 {
         rt.spawn(async {
             loop {
@@ -63,4 +56,25 @@ fn busy_workers_still_get_every_event() {
             .await
             .expect("echo round trips did not finish");
     });
+}
+
+#[test]
+fn multi_thread_busy_tick() {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(2)
+        .max_io_events_per_busy_tick(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    busy_runtime_gets_every_event(rt);
+}
+
+#[test]
+fn current_thread_busy_tick() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .max_io_events_per_busy_tick(1)
+        .enable_all()
+        .build()
+        .unwrap();
+    busy_runtime_gets_every_event(rt);
 }


### PR DESCRIPTION
## Motivation

A multi-thread worker that still has tasks polls the I/O driver every `event_interval` (61) tasks.
That poll takes up to `max_io_events_per_tick` events, 1024 by default.
Every task those events wake goes into the worker's local queue, which holds 256.
The rest overflows to the global queue, and only idle workers drain that queue in bulk.
Under sustained overload, the backlog grows until requests time out.

Setting `max_io_events_per_tick(8)` stops the overflow.
But a blocking park then also takes only 8 events, which adds latency when many connections become ready at once.

## Solution

Add `Builder::max_io_events_per_busy_tick(n)`.
It caps the events taken by a poll that does not wait.

```rust
Builder::new_multi_thread()
    .max_io_events_per_tick(128)     // blocking parks
    .max_io_events_per_busy_tick(8)  // polls that do not wait
```

The I/O driver keeps a second, smaller `mio::Events` buffer.
`turn()` uses it when `max_wait` is `Some(0)`.
The scheduler and the process, signal, and time drivers don't change.

- A worker polls without waiting at its maintenance tick, and when it has deferred tasks.
- The time driver does the same when a timer has already expired. The worker runs that timer's task next.
- A blocking park still takes up to `max_io_events_per_tick`.
- Events that a small poll leaves behind stay queued in the kernel, and the next poll returns them. `max_io_events_per_tick` already relies on this.
- When the option is unset, every poll uses `max_io_events_per_tick`, as before.
- Zero panics.
- Both runtime flavors use the option. The current-thread runtime also polls without waiting every `event_interval` ticks.

The docs say to keep `max_io_events_per_tick` at 256 or less too.
A blocking park puts every woken task in the local queue, so a busy cap of 8 with the default 1024 still overflows.

The option is stable here, like `event_interval` and `max_io_events_per_tick`.
I'm happy to put it behind `tokio_unstable` instead, if you prefer.

## Results

An HTTP/2 streaming server with a fake backend, on 16 workers, with 2 rounds per configuration.
Its capacity is about 650 streams/s.
The connection storm adds 10,000 new connections per second on top of 600 streams/s of steady load.

| Config | Failed streams at 1100/s | p50 time to first response at 1100/s | Local-queue overflows per 40 s | Time to first response in the storm |
|---|---|---|---|---|
| Default (1024) | 5,113 / 5,164 | 11.2 s | about 8,000 | 25.6 ms |
| `max_io_events_per_tick(8)` | 0 | 0.81 s | 0 | 105 ms |
| tick 128, busy tick 8 | 0 | 0.74 s | 0 to 2 | 27.8 ms |
| tick 64, busy tick 8 | 0 | 0.72 s | 0 | 30 to 83 ms |

At 900 streams/s, no configuration had failures.
The default's p50 was 5.3 s, and each capped configuration's was about 0.46 s.

With a tick of 128 and a busy tick of 8, the server holds the overload, and the storm costs about 2 ms.
An earlier run found that a tick of 255 falls behind at 1100 streams/s.

## Testing

- New `tests/rt_busy_tick.rs` covers the zero panic, and echo traffic through always-busy workers with a busy tick of 1.
- I traced a sample binary with `strace`.
  - With `max_io_events_per_tick(128)` and `max_io_events_per_busy_tick(8)`, every non-blocking `epoll_wait` passed `maxevents=8`, and every blocking one passed 128.
  - With the option unset, every call passed 128. On a current-thread runtime, non-blocking calls passed 8 as well.
