### PR TITLE
rt: monomorphize the task harness once per spawned future, not twice

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -7,7 +7,7 @@ use crate::runtime::blocking::sharded::ShardedImpl;
 use crate::runtime::blocking::{shutdown, BlockingTask};
 use crate::runtime::builder::ThreadNameFn;
 use crate::runtime::task::{self, JoinHandle};
-use crate::runtime::{Builder, Callback, Handle, BOX_FUTURE_THRESHOLD};
+use crate::runtime::{AutoBox, Builder, Callback, Handle};
 use crate::util::metric_atomics::MetricAtomicUsize;
 use crate::util::trace::{blocking_task, SpawnMeta};
 
@@ -370,7 +370,7 @@ impl Spawner {
         R: Send + 'static,
     {
         let fn_size = std::mem::size_of::<F>();
-        let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
+        let (join_handle, spawn_result) = if AutoBox::<F>::SHOULD_BOX {
             self.spawn_blocking_inner(
                 Box::new(func),
                 Mandatory::NonMandatory,
@@ -409,7 +409,7 @@ impl Spawner {
             R: Send + 'static,
         {
             let fn_size = std::mem::size_of::<F>();
-            let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
+            let (join_handle, spawn_result) = if AutoBox::<F>::SHOULD_BOX {
                 self.spawn_blocking_inner(
                     Box::new(func),
                     Mandatory::Mandatory,

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -15,7 +15,7 @@ pub struct Handle {
 }
 
 use crate::runtime::task::JoinHandle;
-use crate::runtime::BOX_FUTURE_THRESHOLD;
+use crate::runtime::AutoBox;
 use crate::util::error::{CONTEXT_MISSING_ERROR, THREAD_LOCAL_DESTROYED_ERROR};
 use crate::util::trace::SpawnMeta;
 
@@ -200,7 +200,7 @@ impl Handle {
         F::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
@@ -341,7 +341,7 @@ impl Handle {
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))

--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -2,7 +2,7 @@
 
 use crate::runtime::blocking::BlockingPool;
 use crate::runtime::scheduler::CurrentThread;
-use crate::runtime::{context, Builder, EnterGuard, Handle, BOX_FUTURE_THRESHOLD};
+use crate::runtime::{context, AutoBox, Builder, EnterGuard, Handle};
 use crate::task::JoinHandle;
 
 use crate::util::trace::SpawnMeta;
@@ -158,7 +158,7 @@ impl LocalRuntime {
 
         // safety: spawn_local can only be called from `LocalRuntime`, which this is
         unsafe {
-            if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+            if AutoBox::<F>::SHOULD_BOX {
                 self.handle.spawn_local_named(Box::pin(future), meta)
             } else {
                 self.handle.spawn_local_named(future, meta)
@@ -225,7 +225,7 @@ impl LocalRuntime {
         let fut_size = mem::size_of::<F>();
         let meta = SpawnMeta::new_unnamed(fut_size);
 
-        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.block_on_inner(Box::pin(future), meta)
         } else {
             self.block_on_inner(future, meta)

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -636,6 +636,24 @@ cfg_rt! {
         16384
     };
 
+    /// Decides whether a future or closure of type `T` is boxed before it is
+    /// turned into a task, based on [`BOX_FUTURE_THRESHOLD`].
+    ///
+    /// The decision is an associated constant rather than a runtime
+    /// comparison of `std::mem::size_of::<T>()` so that only the taken branch
+    /// is instantiated. With a runtime `if`, both branches are instantiated
+    /// for every `T` (one task harness for `T`, one for `Pin<Box<T>>`),
+    /// doubling the generated code for every spawned future in a crate. A
+    /// branch on a constant that is known once `T` is known is pruned by the
+    /// monomorphization collector, so only the harness that is actually used
+    /// is generated.
+    pub(crate) struct AutoBox<T>(std::marker::PhantomData<T>);
+
+    impl<T> AutoBox<T> {
+        /// `true` if a value of type `T` is larger than [`BOX_FUTURE_THRESHOLD`].
+        pub(crate) const SHOULD_BOX: bool = std::mem::size_of::<T>() > BOX_FUTURE_THRESHOLD;
+    }
+
     mod thread_id;
     pub(crate) use thread_id::ThreadId;
 

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -1,4 +1,4 @@
-use super::BOX_FUTURE_THRESHOLD;
+use super::AutoBox;
 use crate::runtime::blocking::BlockingPool;
 use crate::runtime::scheduler::CurrentThread;
 use crate::runtime::{context, EnterGuard, Handle};
@@ -247,7 +247,7 @@ impl Runtime {
         F::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.handle
                 .spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
@@ -342,7 +342,7 @@ impl Runtime {
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -1,6 +1,6 @@
 #![allow(unreachable_pub)]
 use crate::{
-    runtime::{Handle, BOX_FUTURE_THRESHOLD},
+    runtime::{AutoBox, Handle},
     task::{JoinHandle, LocalSet},
     util::trace::SpawnMeta,
 };
@@ -90,7 +90,7 @@ impl<'a> Builder<'a> {
         Fut::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             super::spawn::spawn_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             super::spawn::spawn_inner(future, SpawnMeta::new(self.name, fut_size))
@@ -111,7 +111,7 @@ impl<'a> Builder<'a> {
         Fut::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             handle.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             handle.spawn_named(future, SpawnMeta::new(self.name, fut_size))
@@ -142,7 +142,7 @@ impl<'a> Builder<'a> {
         Fut::Output: 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             super::local::spawn_local_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             super::local::spawn_local_inner(future, SpawnMeta::new(self.name, fut_size))
@@ -167,7 +167,7 @@ impl<'a> Builder<'a> {
         Fut::Output: 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             local_set.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             local_set.spawn_named(future, SpawnMeta::new(self.name, fut_size))
@@ -213,7 +213,7 @@ impl<'a> Builder<'a> {
     {
         use crate::runtime::Mandatory;
         let fn_size = mem::size_of::<Function>();
-        let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
+        let (join_handle, spawn_result) = if AutoBox::<Function>::SHOULD_BOX {
             handle.inner.blocking_spawner().spawn_blocking_inner(
                 Box::new(function),
                 Mandatory::NonMandatory,

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -5,7 +5,7 @@ use crate::runtime;
 use crate::runtime::task::{
     self, JoinHandle, LocalOwnedTasks, SpawnLocation, Task, TaskHarnessScheduleHooks,
 };
-use crate::runtime::{context, ThreadId, BOX_FUTURE_THRESHOLD};
+use crate::runtime::{context, AutoBox, ThreadId};
 use crate::sync::AtomicWaker;
 use crate::util::trace::SpawnMeta;
 use crate::util::RcCell;
@@ -397,7 +397,7 @@ cfg_rt! {
         F::Output: 'static,
     {
         let fut_size = std::mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             spawn_local_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             spawn_local_inner(future, SpawnMeta::new_unnamed(fut_size))
@@ -594,7 +594,7 @@ impl LocalSet {
         F::Output: 'static,
     {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -1,4 +1,4 @@
-use crate::runtime::BOX_FUTURE_THRESHOLD;
+use crate::runtime::AutoBox;
 use crate::task::JoinHandle;
 use crate::util::trace::SpawnMeta;
 
@@ -177,7 +177,7 @@ cfg_rt! {
         F::Output: Send + 'static,
     {
         let fut_size = std::mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             spawn_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             spawn_inner(future, SpawnMeta::new_unnamed(fut_size))


### PR DESCRIPTION
## Motivation

Every spawn entry point (`tokio::spawn`, `Handle::spawn`, `Runtime::spawn`, `task::Builder::spawn*`, `spawn_local`, `LocalSet::spawn_local`, `LocalRuntime::spawn_local`, `spawn_blocking`, and the three `block_on`s) auto-boxes futures larger than `BOX_FUTURE_THRESHOLD` (#6826, #6692):

```rust
let fut_size = std::mem::size_of::<F>();
if fut_size > BOX_FUTURE_THRESHOLD {
    spawn_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
} else {
    spawn_inner(future, SpawnMeta::new_unnamed(fut_size))
}
```

This is a *runtime* `if` on a value that is a compile-time constant for any given `F`, so **both arms are monomorphized for every future type `F`**. The boxed arm is a concrete `Pin<Box<F>>`, not a trait object, so it dedupes nothing. Net effect: each distinct spawned future instantiates the whole task harness twice — `runtime::task::core::Cell<T, S>::new`, `Harness::poll_inner`/`complete`/`release`, `poll_future`, `RawTask::new`, `OwnedTasks::bind`, the six `catch_unwind` sites and their `do_call`/`do_catch`/`AssertUnwindSafe` closures, `UnsafeCell::with_mut`, … — and then ×2 again when both schedulers are compiled in (`scheduler::Handle` is an enum, so `current_thread::Handle::spawn` and `multi_thread::Handle::bind_new_task` are both instantiated for every `F`).

In a large internal debug crate (390k lines, ~350 distinct spawned future types, rustc 1.97, `-Zdump-mono-stats`), the `tokio::runtime::task::*` + `catch_unwind` family was **26 % of all generic instantiations and 24 % of `total_estimate`**; `Cell<T, S>::new` alone was instantiated 1,568 times ≈ 352 future types × 4 copies (+ `spawn_blocking` closures). Half of those copies are for the arm that is never taken.

## Change

```rust
pub(crate) struct AutoBox<T>(PhantomData<T>);
impl<T> AutoBox<T> {
    pub(crate) const SHOULD_BOX: bool = std::mem::size_of::<T>() > BOX_FUTURE_THRESHOLD;
}
```

and every site becomes `if AutoBox::<F>::SHOULD_BOX { … } else { … }`. The value is bit-for-bit the same comparison as before (same threshold, same `size_of`), so **the runtime boxing decision is unchanged** — the boxed arm still boxes the concrete `Pin<Box<F>>` it boxed before. But the branch condition is now a constant once `F` is substituted, and rustc's monomorphization collector skips the untaken block of a `SwitchInt` on a constant — so only one harness is generated per `F`. (`if const { … }` is not stable and `const {}` blocks need 1.79; an associated const on a generic struct works on the MSRV, 1.71.) On a compiler that does not prune constant branches during collection the change is simply neutral.

No behavior, API, or `tokio_unstable` tracing field changes. Docs-only wording in the `AutoBox` comment is chosen to pass `cargo-spellcheck`.

## Measurement

Standalone crate `spawnbench` (300 distinct `async move {}` closure futures spawned with `tokio::spawn` on a `new_multi_thread` runtime, 150 below and 150 above the debug threshold; `tokio` features `rt, rt-multi-thread, time, macros`; `cargo build` dev profile; rustc 1.97.1; `-Zdump-mono-stats` on the bench crate). "rustc wall" is the bench crate's own `rustc` invocation with tokio already built (best of 3; the runs agreed within 0.1 s).

| tokio | mono instantiations | `total_estimate` | `Cell<T,S>::new` | `spawn_inner` | `catch_unwind` | rustc wall | user CPU |
|---|---|---|---|---|---|---|---|
| master `060cc4e4` (== crates.io 1.53.1) | 110,652 | 1,258,468 | 1,200 | 1,200 | 6,000 | 7.31 s | 5.13 s |
| + this PR | **55,833 (−49.5 %)** | **640,682 (−49.1 %)** | 602 | 600 | 3,000 | **3.86 s (−47 %)** | 2.67 s |

Reading the counts: base = 300 futures × 2 arms × 2 schedulers; this PR = 300 × 1 × 2. The `tokio::runtime::task::*` + `catch_unwind` family goes 73,222 → 36,622 instantiations (`total_estimate` 924,305 → 462,305).

On the large internal crate above (mixed real-world futures, 16 CGUs, opt-level 0, rustc replayed by hand ×3), this PR alone: mono instantiations 414,028 → 315,288 (**−24 %**), `total_estimate` 6.73M → 5.59M (−17 %), `Cell<T,S>::new` 1,568 → 784, rustc wall 316 → 288 s (−9 %), user CPU 478 → 429 s (−10 %).

Micro-probe (`rustc -Zprint-mono-items`, 1.97.1) confirming the mechanism: runtime `if size_of::<F>() > T` → `inner::<F>` **and** `inner::<Pin<Box<F>>>` for every `F`; `if Check::<F>::BOX` → exactly one of them.

## MSRV

`rust-version = "1.71"`. Associated consts on generic impls and `const fn size_of` predate it by years; no `const {}` blocks, no `if const`, no `#[cfg(version)]`. CI's MSRV job is the check.

## Test plan

- `cargo test -p tokio --features full`: 178 test binaries, **2157 passed, 0 failed** (on the earlier revision of this branch, which contained a superset of this change).
- `RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --features full,tracing --test tracing_task`: 6 passed on this exact commit (rebased on `022c004b`, rustc 1.95).
- `cargo check -p tokio` with `--no-default-features`, `--features rt`, `rt,rt-multi-thread`, `rt,fs`, `rt,time,sync,macros`, `full`, and `--cfg tokio_unstable` with `full,tracing` and `full,tracing,taskdump`: clean. `cargo clippy -p tokio --features full -- -D warnings` (with and without `tokio_unstable`): clean. `rustfmt --check` on touched files: clean.
- `spawnbench` runs to completion against both variants; the boxing decision is verified identical by the `size.bytes` tracing test, which is unchanged.

## Not in this PR

- Boxing the >threshold arm to `Pin<Box<dyn Future<Output = F::Output> + Send>>` so that all large futures share one harness per output type. It was the second commit of this PR; per review it is now its own PR with its own justification: #8439.
- The remaining ×2 is the `scheduler::Handle` enum dispatch (both schedulers' `spawn` instantiated per `F` whenever `rt-multi-thread` is enabled). Removing it touches the hot path for every small future and is a separate discussion.

---

This PR was authored with LLM assistance and measured on a large internal async codebase (numbers above); a maintainer of that codebase reviewed the change and the measurements before publishing.
