### PR TITLE
tests: handle EPERM in io_uring_supported helper

### DIFF
--- a/tokio/tests/support/io_uring.rs
+++ b/tokio/tests/support/io_uring.rs
@@ -20,10 +20,15 @@ use io_uring::IoUring;
 pub fn io_uring_supported() -> bool {
     match IoUring::new(256) {
         Ok(_) => true,
-        // The Kernel does not support io-uring
-        Err(e) if e.raw_os_error() == Some(libc::ENOSYS) => false,
-        Err(_) => unreachable!(
-            "The target should either support io_uring or return ENOSYS if not supported"
+        // ENOSYS: kernel does not support io_uring.
+        // EPERM: io_uring disabled via sysctl kernel.io_uring_disabled (#7691).
+        Err(e)
+            if e.raw_os_error() == Some(libc::ENOSYS) || e.raw_os_error() == Some(libc::EPERM) =>
+        {
+            false
+        }
+        Err(e) => unreachable!(
+            "IoUring::new failed with an unexpected error (expected ENOSYS or EPERM): {e}"
         ),
     }
 }


### PR DESCRIPTION
## Motivation

The shared test helper `io_uring_supported()` in `tokio/tests/support/io_uring.rs`
only handles `ENOSYS` and panics with `unreachable!()` on any other error. Some
kernels and container runtimes disable io_uring via `sysctl kernel.io_uring_disabled`,
which returns `EPERM`. The runtime driver already maps `EPERM` to "unsupported" (#7691),
but the test helper does not.

## Solution

Add `EPERM` to the match arm alongside `ENOSYS`, returning `false` instead of panicking.

## Testing

WSL2 6.6, `kernel.io_uring_disabled=2`:

- HEAD: 3 tests panic at `support/io_uring.rs:25` with "entered unreachable code"
- with fix: all tests pass, uring-specific assertions skipped
- `kernel.io_uring_disabled=0` (normal): 8/8 pass, uring path exercised