### PR TITLE
net: close CreateFileW handle on SetNamedPipeHandleState failure

### DIFF
--- a/tokio/src/net/windows/named_pipe.rs
+++ b/tokio/src/net/windows/named_pipe.rs
@@ -2575,7 +2575,9 @@ impl ClientOptions {
             };
 
             if result == 0 {
-                return Err(io::Error::last_os_error());
+                let err = io::Error::last_os_error();
+                unsafe { windows_sys::CloseHandle(h) };
+                return Err(err);
             }
         }
 


### PR DESCRIPTION
## Motivation

In `ClientOptions::open_with_security_attributes_raw`, the raw handle returned
by `CreateFileW` (line 2555) is only wrapped into an owner at line 2582
(`NamedPipeClient::from_raw_handle`). The early return at line 2578
(`SetNamedPipeHandleState` failure for message-mode on a byte-mode server)
leaves the handle open forever.

## Solution

Capture `last_os_error()`, call `CloseHandle(h)`, then return the error.

## Testing

Windows 11, 16 iterations of `ClientOptions::new().pipe_mode(PipeMode::Message).open()`
on a byte-mode `ServerOptions::new().create()`:

- HEAD: `GetProcessHandleCount` shows 16 leaked handles (before=72, after=88)
- with fix: 0 leaked handles