### PR TITLE
runtime: fix misleading signal driver panic message

### DIFF
--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -100,7 +100,7 @@ impl Handle {
         pub(crate) fn signal(&self) -> &crate::runtime::signal::Handle {
             self.signal
                 .as_ref()
-                .expect("there is no signal driver running, must be called from the context of Tokio runtime")
+                .expect("A Tokio 1.x context was found, but IO is disabled. Call `enable_io` on the runtime builder to enable IO.")
         }
     }
 


### PR DESCRIPTION
## Motivation

The `signal()` accessor in `runtime/driver.rs` panics with "there is no signal
driver running, must be called from the context of Tokio runtime" when the
actual cause is IO disabled. This is misleading: the caller IS in a runtime,
just one built without `enable_io()`. The sibling `io()` and `time()` accessors
already use the correct message.

## Solution

Use the same message as `io()`: "A Tokio 1.x context was found, but IO is
disabled. Call `enable_io` on the runtime builder to enable IO."

## Testing

WSL2, `#[should_panic(expected = "IO is disabled")]` test on a runtime built
without `enable_io()` calling `signal(SignalKind::hangup())`: passes with fix,
panics with wrong message at HEAD.