### PR TITLE
sync: clarify panic behavior of `broadcast::channel()`

### DIFF
--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -532,7 +532,7 @@ const MAX_RECEIVERS: usize = usize::MAX >> 2;
 ///
 /// # Panics
 ///
-/// This will panic if `capacity` is equal to `0`.
+/// This will panic if `capacity` is equal to `0` or exceeds `usize::MAX / 2`.
 ///
 /// This pre-allocates space for `capacity` messages. Allocation failure may result in a panic or
 /// [an allocation error](std::alloc::handle_alloc_error).


### PR DESCRIPTION
## Motivation

The `# Panics` section of `broadcast::channel` documents only the `capacity == 0`
panic, but `new_with_receiver_count` (line 578) also asserts
`capacity <= usize::MAX >> 1`.

## Solution

Add "or exceeds `usize::MAX / 2`" to the existing panic documentation.

## Testing

`cargo doc -p tokio --features full --no-deps`: clean.