### PR TITLE
docs(net): document dual-stack last-error behavior of TcpStream::connect

### DIFF
--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -86,6 +86,16 @@ impl TcpStream {
         /// result in a successful connection, the error returned from the last
         /// connection attempt (the last address) is returned.
         ///
+        /// Note that on dual-stack hosts the address list may contain both IPv4
+        /// and IPv6 addresses. If all attempts fail, only the last error is
+        /// returned. For example, on an IPv4-only host where DNS returns
+        /// `[IPv4, IPv6]`, a real IPv4 failure (e.g. connection refused) can be
+        /// hidden by a subsequent IPv6 `EADDRNOTAVAIL` (`AddrNotAvailable`,
+        /// raw OS error 99 on Linux / 10049 on Windows) when the host has no
+        /// IPv6 connectivity. If you need per-address errors, resolve the
+        /// addresses with [`ToSocketAddrs`] yourself and try each address in a
+        /// loop. This matches `std::net::TcpStream::connect`.
+        ///
         /// To configure the socket before connecting, you can use the [`TcpSocket`]
         /// type.
         ///


### PR DESCRIPTION
Follow-up to #7708 as requested by @ADD-SP.

## Motivation
#7708 reports `TcpStream::connect` hides a real IPv4 failure behind IPv6 `EADDRNOTAVAIL` on IPv4-only hosts. Code fix was declined to keep `std::net::TcpStream::connect` parity. The agreed action is to document the case so users aren't surprised.

## Solution
Docs-only in `tokio/src/net/tcp/stream.rs`: note that only the last error is returned when `[IPv4, IPv6]` both fail, give the `EADDRNOTAVAIL` 99 / 10049 example, point to manual `ToSocketAddrs` loop workaround, note `std` parity. No behavior change.

## Test plan
- `cargo check -p tokio --features full` clean
- `cargo test --test tcp_connect` 8 passed
- `cargo fmt --check` clean