### PR TITLE
emscripten: make the inline blocking shim consume coop budget; gate emscripten tests on used features

### DIFF
--- a/tokio/src/blocking.rs
+++ b/tokio/src/blocking.rs
@@ -16,8 +16,15 @@ cfg_rt! {
     // runs the closure inline and hands back an already-completed future. The
     // public `task::spawn_blocking` is not routed through here and keeps its
     // native semantics. Pthread builds (`+atomics`) use the native pool.
+    //
+    // The completed future is wrapped in `Coop` so that polling it consumes
+    // task budget exactly like the native `task::JoinHandle::poll` does. The
+    // `fs` and `io-std` consumers rely on that budget for their yield points:
+    // without it a loop of always-ready file reads never returns `Pending`
+    // and starves every other task on the single-threaded runtime.
     #[cfg(all(target_os = "emscripten", not(target_feature = "atomics")))]
-    pub(crate) type JoinHandle<T> = std::future::Ready<Result<T, crate::task::JoinError>>;
+    pub(crate) type JoinHandle<T> =
+        crate::task::coop::Coop<std::future::Ready<Result<T, crate::task::JoinError>>>;
 
     #[cfg(all(target_os = "emscripten", not(target_feature = "atomics")))]
     pub(crate) fn spawn_blocking<F, R>(f: F) -> JoinHandle<R>
@@ -25,7 +32,7 @@ cfg_rt! {
         F: FnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
-        std::future::ready(Ok(f()))
+        crate::task::coop::cooperative(std::future::ready(Ok(f())))
     }
 
     #[cfg(all(target_os = "emscripten", not(target_feature = "atomics"), feature = "fs"))]

--- a/tokio/src/task/coop/mod.rs
+++ b/tokio/src/task/coop/mod.rs
@@ -434,6 +434,7 @@ cfg_coop! {
     pin_project! {
         /// Future wrapper to ensure cooperative scheduling created by [`cooperative`].
         #[must_use = "futures do nothing unless polled"]
+        #[derive(Debug)]
         pub struct Coop<F: Future> {
             #[pin]
             pub(crate) fut: F,

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -111,10 +111,6 @@ async fn rewind_seek_position() {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "emscripten",
-    ignore = "inline-fs shim does not insert cooperative yield points"
-)]
 async fn coop() {
     let mut tempfile = tempfile();
     tempfile.write_all(HELLO).unwrap();

--- a/tokio/tests/io_emscripten.rs
+++ b/tokio/tests/io_emscripten.rs
@@ -9,7 +9,13 @@
 //! the runner's stdin is `/dev/null`. The contract worth pinning is "a stdin
 //! read returns rather than deadlocking", not a specific errno.
 
-#![cfg(all(target_os = "emscripten", feature = "io-std"))]
+#![cfg(all(
+    target_os = "emscripten",
+    feature = "io-std",
+    feature = "io-util",
+    feature = "rt",
+    feature = "macros"
+))]
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 

--- a/tokio/tests/task_emscripten.rs
+++ b/tokio/tests/task_emscripten.rs
@@ -1,4 +1,9 @@
-#![cfg(all(target_os = "emscripten", not(target_feature = "atomics")))]
+#![cfg(all(
+    target_os = "emscripten",
+    not(target_feature = "atomics"),
+    feature = "rt",
+    feature = "macros"
+))]
 
 /// There is no threadpool on a single-threaded JS worker: the public
 /// `spawn_blocking` is unsupported on non-pthread emscripten, as on the other

--- a/tokio/tests/time_timeout.rs
+++ b/tokio/tests/time_timeout.rs
@@ -5,7 +5,8 @@
         target_os = "emscripten",
         feature = "rt",
         feature = "macros",
-        feature = "test-util"
+        feature = "test-util",
+        feature = "io-util"
     )
 ))]
 


### PR DESCRIPTION
Repo: tokio-rs/tokio · base: 060cc4e46aedc40b0a44dcbc31deb0df39abdb4e ("wasm: support the wasm32-unknown-emscripten target (#8281)") · branch: charles-fix-tokio

## Title

emscripten: keep cooperative yielding in the inline blocking shim

## Body

On non-pthread `wasm32-unknown-emscripten`, `crate::blocking::spawn_blocking` runs the closure
inline and returns `std::future::Ready`, and the internal `JoinHandle` alias is that `Ready`.
The native `task::JoinHandle::poll` calls `coop::poll_proceed` before reading the output;
`Ready::poll` does not, and none of the consumers (`fs::File`, `fs::ReadDir`,
`io::blocking::Blocking` behind stdin/stdout/stderr) check the budget themselves. A task
looping over always-ready file operations therefore never returns `Pending` and never lets any
other task or timer run on the single-threaded runtime. The existing `fs_file::coop` test shows
it: on 060cc4e (with the `#[ignore]` lifted) the test's first `task.poll()` never returns — the
run had to be killed after 30 s.

The shim now wraps the completed future in the existing public `coop::Coop` via
`coop::cooperative(...)`, so polling it consumes one unit of budget and yields when the budget
is exhausted, exactly like the native handle; `Coop` gains `#[derive(Debug)]` because the
consumer `State` enums derive `Debug` through the alias. The `#[cfg_attr(emscripten, ignore)]`
on `fs_file::coop` is removed and the test passes on the target (node runner, emsdk 6.0.9).

Separately, three emscripten test gates listed fewer features than the file uses:
`task_emscripten.rs` (needs `rt`, `macros`), `io_emscripten.rs` (needs `io-util`, `rt`,
`macros`) and `time_timeout.rs` (needs `io-util`). With a narrower feature set those crates
failed to compile instead of being skipped; the gates now name every feature they need.
Note that `--no-default-features --features sync --tests` still does not compile on any target
because the pre-existing `sync_*` tests use `tokio::test` while gating only on `sync`; that is
outside this change.

## Severity

- Coop starvation: medium on this target (fairness/latency; a file-I/O loop can monopolise the
  runtime). Not a regression versus the pre-#8281 tree, where `fs` on emscripten did not build.
- Test gating: low; test-crate hygiene only. CI runs one feature set and does not observe it.
- Stdin test "hangs when interactive" (claim fable-4): **not reproduced**. With stdin attached
  to a pty that never receives input, the 060cc4e test returns immediately. No change made.

## Verification

- `cargo test --target wasm32-unknown-emscripten ... --test fs_file -- coop --include-ignored`
  on 060cc4e: never finishes (killed at 30 s). With the fix: `test coop ... ok`.
- Full CI emscripten command `--features "rt,time,sync,macros,fs,io-util,io-std,test-util" --tests`
  with `-Dwarnings`: 752 passed, 0 failed, 9 ignored.
- `cargo check --target wasm32-unknown-emscripten --no-default-features --features rt --test task_emscripten`
  (and `io-std`/`io_emscripten`, `rt,macros`/`time_timeout`): error on 060cc4e, clean with the fix.
- Native: `cargo test --features full --test fs_file --test io_read --test task_blocking` ok; `cargo fmt --check` clean.
- Upstream `tokio/src/blocking.rs`, `tests/io_emscripten.rs`, `tests/task_emscripten.rs` on
  `master` were byte-identical to this case head at the time of writing.