### PR TITLE
io: flush the writer when the reader stalls in `copy_buf`

### DIFF
--- a/tokio/src/io/util/copy_buf.rs
+++ b/tokio/src/io/util/copy_buf.rs
@@ -18,6 +18,7 @@ cfg_io_util! {
         reader: &'a mut R,
         writer: &'a mut W,
         amt: u64,
+        need_flush: bool,
     }
 
     /// Asynchronously copies the entire contents of a reader into a writer.
@@ -75,6 +76,7 @@ cfg_io_util! {
             reader,
             writer,
             amt: 0,
+            need_flush: false,
         }.await
     }
 }
@@ -89,7 +91,21 @@ where
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         loop {
             let me = &mut *self;
-            let buffer = ready!(Pin::new(&mut *me.reader).poll_fill_buf(cx))?;
+            let buffer = match Pin::new(&mut *me.reader).poll_fill_buf(cx) {
+                Poll::Ready(Ok(buffer)) => buffer,
+                Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                Poll::Pending => {
+                    // Try flushing when the reader has no progress to avoid deadlock
+                    // when the reader depends on buffered writer.
+                    if me.need_flush {
+                        ready!(Pin::new(&mut *me.writer).poll_flush(cx))?;
+                        me.need_flush = false;
+                    }
+
+                    return Poll::Pending;
+                }
+            };
+
             if buffer.is_empty() {
                 ready!(Pin::new(&mut self.writer).poll_flush(cx))?;
                 return Poll::Ready(Ok(self.amt));
@@ -100,6 +116,7 @@ where
                 return Poll::Ready(Err(std::io::ErrorKind::WriteZero.into()));
             }
             self.amt += i as u64;
+            self.need_flush = true;
             Pin::new(&mut *self.reader).consume(i);
         }
     }

--- a/tokio/tests/io_copy.rs
+++ b/tokio/tests/io_copy.rs
@@ -44,39 +44,39 @@ async fn copy() {
     assert_eq!(wr, b"hello world");
 }
 
+struct BufferedWd {
+    buf: BytesMut,
+    writer: io::DuplexStream,
+}
+
+impl AsyncWrite for BufferedWd {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        self.get_mut().buf.extend_from_slice(buf);
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+
+        while !this.buf.is_empty() {
+            let n = ready!(Pin::new(&mut this.writer).poll_write(cx, &this.buf))?;
+            let _ = this.buf.split_to(n);
+        }
+
+        Pin::new(&mut this.writer).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.writer).poll_shutdown(cx)
+    }
+}
+
 #[tokio::test]
 async fn proxy() {
-    struct BufferedWd {
-        buf: BytesMut,
-        writer: io::DuplexStream,
-    }
-
-    impl AsyncWrite for BufferedWd {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            _cx: &mut Context<'_>,
-            buf: &[u8],
-        ) -> Poll<io::Result<usize>> {
-            self.get_mut().buf.extend_from_slice(buf);
-            Poll::Ready(Ok(buf.len()))
-        }
-
-        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            let this = self.get_mut();
-
-            while !this.buf.is_empty() {
-                let n = ready!(Pin::new(&mut this.writer).poll_write(cx, &this.buf))?;
-                let _ = this.buf.split_to(n);
-            }
-
-            Pin::new(&mut this.writer).poll_flush(cx)
-        }
-
-        fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
-            Pin::new(&mut self.writer).poll_shutdown(cx)
-        }
-    }
-
     let (rd, wd) = io::duplex(1024);
     let mut rd = rd.take(1024);
     let mut wd = BufferedWd {
@@ -89,6 +89,24 @@ async fn proxy() {
     assert_ok!(wd.flush().await);
 
     let n = assert_ok!(io::copy(&mut rd, &mut wd).await);
+
+    assert_eq!(n, 1024);
+}
+
+#[tokio::test]
+async fn proxy_buf() {
+    let (rd, wd) = io::duplex(1024);
+    let mut rd = io::BufReader::new(rd).take(1024);
+    let mut wd = BufferedWd {
+        buf: BytesMut::new(),
+        writer: wd,
+    };
+
+    // write start bytes
+    assert_ok!(wd.write_all(&[0x42; 512]).await);
+    assert_ok!(wd.flush().await);
+
+    let n = assert_ok!(io::copy_buf(&mut rd, &mut wd).await);
 
     assert_eq!(n, 1024);
 }


### PR DESCRIPTION
## Motivation

`CopyBuffer::poll_copy`, used by `copy` and `copy_bidirectional`, flushes the writer whenever the reader makes no progress. That guard came from #4001, whose comment says it exists "to avoid deadlock when the reader depends on buffered writer".

`CopyBuf::poll` never grew the same guard. It flushes only once the reader reports EOF, so `poll_fill_buf` returning `Pending` propagates straight out with the writer left unflushed. Proxying a request/response protocol through a writer that buffers hangs forever, even though the byte-for-byte equivalent `copy` call completes.

`copy_buf` is documented as the `copy` alternative for `AsyncBufRead` readers with no extra buffer allocation, so swapping one for the other to save an allocation silently reintroduces the deadlock #4001 fixed.

## Solution

Track whether anything has been written since the last flush, and flush on a stalled reader, mirroring `CopyBuffer::poll_copy`.

`proxy_buf` is the `copy_buf` analogue of the `proxy` test added alongside #4001. It reuses the same `BufferedWd` writer, which moves to module scope so both tests share it; `proxy` itself is otherwise untouched.

Without this change `proxy_buf` hangs while `proxy` passes in the same test binary.

Verified with `cargo test -p tokio --features full,test-util --tests`: 177 test binaries, 1412 passed, 0 failed.