### PR TITLE
Merge CI fixes from tokio-1.51.x to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1071,7 +1071,10 @@ jobs:
       - name: Install cargo-hack, wasmtime
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-hack,wasmtime
+          # Wasmtime v46.0.1 is the last version to support
+          # `wasm32-wasip1-threads` (which was an experiment that was never
+          # standardized):
+          tool: cargo-hack,wasmtime@46.0.1
 
       - uses: Swatinem/rust-cache@v2
       - name: WASI test tokio full

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1155,7 +1155,7 @@ jobs:
           toolchain: ${{ env.rust_nightly }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+        run: cargo install --locked cargo-fuzz --version 0.13.1
       - name: Check /tokio/
         run: cargo fuzz check --all-features
         working-directory: tokio

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,7 +515,7 @@ jobs:
           package: tokio
           release-type: minor
       - name: Check semver for rest of the workspace
-        if: ${{ !startsWith(github.event.pull_request.base.ref, 'tokio-1.') }}
+        if: ${{ !startsWith(github.event.pull_request.base.ref, 'tokio-1.') && !startsWith(github.ref_name, 'tokio-1.') }}
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           rust-toolchain: ${{ env.rust_stable }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1126,10 +1126,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust 1.98
+      - name: Install Rust ${{ env.rust_stable }}
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: '1.98'
+          toolchain: ${{ env.rust_stable }}
           targets: wasm32-wasip2
 
       - name: Install cargo-nextest, wasmtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1126,10 +1126,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust ${{ env.rust_stable }}
+      - name: Install Rust 1.98
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: ${{ env.rust_stable }}
+          toolchain: '1.98'
           targets: wasm32-wasip2
 
       - name: Install cargo-nextest, wasmtime

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1191,7 +1191,7 @@ jobs:
           toolchain: ${{ env.rust_nightly }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
-        run: cargo install --locked cargo-fuzz --version 0.13.1
+        run: cargo install cargo-fuzz
       - name: Check /tokio/
         run: cargo fuzz check --all-features
         working-directory: tokio

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -26,6 +26,7 @@ async fn c() {
 }
 
 #[test]
+#[ignore]
 fn current_thread() {
     let rt = runtime::Builder::new_current_thread()
         .enable_all()
@@ -63,6 +64,7 @@ fn current_thread() {
 }
 
 #[test]
+#[ignore]
 fn multi_thread() {
     let rt = runtime::Builder::new_multi_thread()
         .enable_all()

--- a/tokio/tests/dump.rs
+++ b/tokio/tests/dump.rs
@@ -26,7 +26,6 @@ async fn c() {
 }
 
 #[test]
-#[ignore]
 fn current_thread() {
     let rt = runtime::Builder::new_current_thread()
         .enable_all()
@@ -64,7 +63,6 @@ fn current_thread() {
 }
 
 #[test]
-#[ignore]
 fn multi_thread() {
     let rt = runtime::Builder::new_multi_thread()
         .enable_all()


### PR DESCRIPTION
This brings #8390 forward to master, and also merges any other changes on LTS branches into the master history, with some of them reverted again.