### PR TITLE
Remove leftover debug loop counter in `try_read_buf` test

### DIFF
--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -372,12 +372,7 @@ async fn try_read_buf() {
 
     #[cfg(not(target_os = "wasi"))] // WASI does not yet support `POLLHUP` or `POLLRDHUP`
     {
-        let mut count = 0;
         loop {
-            count += 1;
-            if count > 100 {
-                panic!("loop 4")
-            }
             let ready = server.ready(Interest::READABLE).await.unwrap();
 
             if ready.is_read_closed() {


### PR DESCRIPTION
#7933 added a loop counter that panics if the loop runs more than 100 times, likely left over from debugging WASI test hangs.

In FreeBSD CI runners, the test thread can yield and loop 100 times before the kernel finishes closing the socket and delivers the kqueue EOF event, causing the test to fail with `panic!("loop 4")`.

Remove the debug counter and panic so it matches the `try_read_write` test.