### PR TITLE
net: add .into_split() and .reunite() for BufReader<TcpStream> and BufReader<UnixStream>

### DIFF
--- a/tokio/src/io/util/buf_reader.rs
+++ b/tokio/src/io/util/buf_reader.rs
@@ -1,5 +1,9 @@
 use crate::io::util::DEFAULT_BUF_SIZE;
 use crate::io::{AsyncBufRead, AsyncRead, AsyncSeek, AsyncWrite, ReadBuf};
+#[cfg(all(feature = "net", not(loom)))]
+use crate::net::{tcp, TcpStream};
+#[cfg(all(unix, feature = "net", not(loom)))]
+use crate::net::{unix, UnixStream};
 
 use pin_project_lite::pin_project;
 use std::io::{self, IoSlice, SeekFrom};
@@ -94,6 +98,122 @@ impl<R: AsyncRead> BufReader<R> {
         let me = self.project();
         *me.pos = 0;
         *me.cap = 0;
+    }
+}
+
+#[cfg(all(feature = "net", not(loom)))]
+impl BufReader<TcpStream> {
+    /// Splits a `BufReader<TcpStream>` into a read half and a write half, which can be used
+    /// to read and write the stream concurrently.
+    ///
+    /// Unlike [`split`], the owned halves can be moved to separate tasks, however
+    /// this comes at the cost of a heap allocation.
+    ///
+    /// **Note:** Dropping the write half will shut down the write half of the TCP
+    /// stream. This is equivalent to calling [`shutdown()`] on the `TcpStream`.
+    ///
+    /// [`split`]: TcpStream::split()
+    /// [`shutdown()`]: fn@crate::io::AsyncWriteExt::shutdown
+    pub fn into_split(self) -> (BufReader<tcp::OwnedReadHalf>, tcp::OwnedWriteHalf) {
+        let (rx, tx) = self.inner.into_split();
+        let rx = BufReader {
+            inner: rx,
+            buf: self.buf,
+            pos: self.pos,
+            cap: self.cap,
+            seek_state: self.seek_state,
+        };
+
+        (rx, tx)
+    }
+}
+
+#[cfg(all(feature = "net", not(loom)))]
+impl BufReader<tcp::OwnedReadHalf> {
+    /// Attempts to put the two halves of a `TcpStream` back together and
+    /// recover the original socket. Succeeds only if the two halves
+    /// originated from the same call to `into_split`.
+    pub fn reunite(
+        self,
+        other: tcp::OwnedWriteHalf,
+    ) -> Result<BufReader<TcpStream>, tcp::BufReuniteError> {
+        match self.inner.reunite(other) {
+            Ok(stream) => Ok(BufReader {
+                inner: stream,
+                buf: self.buf,
+                pos: self.pos,
+                cap: self.cap,
+                seek_state: self.seek_state,
+            }),
+            Err(e) => Err(tcp::BufReuniteError(
+                BufReader {
+                    inner: e.0,
+                    buf: self.buf,
+                    pos: self.pos,
+                    cap: self.cap,
+                    seek_state: self.seek_state,
+                },
+                e.1,
+            )),
+        }
+    }
+}
+
+#[cfg(all(unix, feature = "net", not(loom)))]
+impl BufReader<UnixStream> {
+    /// Splits a `UnixStream` into a read half and a write half, which can be used
+    /// to read and write the stream concurrently.
+    ///
+    /// Unlike [`split`], the owned halves can be moved to separate tasks, however
+    /// this comes at the cost of a heap allocation.
+    ///
+    /// **Note:** Dropping the write half will only shut down the write half of the
+    /// stream. This is equivalent to calling [`shutdown()`] on the `UnixStream`.
+    ///
+    /// [`split`]: UnixStream::split()
+    /// [`shutdown()`]: fn@crate::io::AsyncWriteExt::shutdown
+    pub fn into_split(self) -> (BufReader<unix::OwnedReadHalf>, unix::OwnedWriteHalf) {
+        let (rx, tx) = self.inner.into_split();
+        let rx = BufReader {
+            inner: rx,
+            buf: self.buf,
+            pos: self.pos,
+            cap: self.cap,
+            seek_state: self.seek_state,
+        };
+
+        (rx, tx)
+    }
+}
+
+#[cfg(all(unix, feature = "net", not(loom)))]
+impl BufReader<unix::OwnedReadHalf> {
+    /// Attempts to put the two halves of a `UnixStream` back together and
+    /// recover the original socket. Succeeds only if the two halves
+    /// originated from the same call to `into_split`.
+    pub fn reunite(
+        self,
+        other: unix::OwnedWriteHalf,
+    ) -> Result<BufReader<UnixStream>, unix::BufReuniteError> {
+        match self.inner.reunite(other) {
+            Ok(stream) => Ok(BufReader {
+                inner: stream,
+                buf: self.buf,
+                pos: self.pos,
+                cap: self.cap,
+                seek_state: self.seek_state,
+            }),
+            Err(e) => Err(unix::BufReuniteError(
+                BufReader {
+                    inner: e.0,
+                    buf: self.buf,
+                    pos: self.pos,
+                    cap: self.cap,
+                    seek_state: self.seek_state,
+                },
+                e.1,
+            )),
+        }
     }
 }
 

--- a/tokio/src/net/tcp/mod.rs
+++ b/tokio/src/net/tcp/mod.rs
@@ -10,6 +10,8 @@ mod split;
 pub use split::{ReadHalf, WriteHalf};
 
 mod split_owned;
+#[cfg(feature = "io-util")]
+pub use split_owned::BufReuniteError;
 pub use split_owned::{OwnedReadHalf, OwnedWriteHalf, ReuniteError};
 
 pub(crate) mod stream;

--- a/tokio/src/net/tcp/split_owned.rs
+++ b/tokio/src/net/tcp/split_owned.rs
@@ -8,6 +8,8 @@
 //! split has no associated overhead and enforces all invariants at the type
 //! level.
 
+#[cfg(feature = "io-util")]
+use crate::io::BufReader;
 use crate::io::{AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
 use crate::net::TcpStream;
 
@@ -97,6 +99,25 @@ impl fmt::Display for ReuniteError {
 }
 
 impl Error for ReuniteError {}
+
+/// Error indicating that two halves were not from the same socket, and thus could
+/// not be reunited.
+#[cfg(feature = "io-util")]
+#[derive(Debug)]
+pub struct BufReuniteError(pub BufReader<OwnedReadHalf>, pub OwnedWriteHalf);
+
+#[cfg(feature = "io-util")]
+impl fmt::Display for BufReuniteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "tried to reunite halves that are not from the same socket"
+        )
+    }
+}
+
+#[cfg(feature = "io-util")]
+impl Error for BufReuniteError {}
 
 impl OwnedReadHalf {
     /// Attempts to put the two halves of a `TcpStream` back together and

--- a/tokio/src/net/unix/mod.rs
+++ b/tokio/src/net/unix/mod.rs
@@ -13,6 +13,8 @@ mod split;
 pub use split::{ReadHalf, WriteHalf};
 
 mod split_owned;
+#[cfg(feature = "io-util")]
+pub use split_owned::BufReuniteError;
 pub use split_owned::{OwnedReadHalf, OwnedWriteHalf, ReuniteError};
 
 mod socketaddr;

--- a/tokio/src/net/unix/split_owned.rs
+++ b/tokio/src/net/unix/split_owned.rs
@@ -8,6 +8,8 @@
 //! split has no associated overhead and enforces all invariants at the type
 //! level.
 
+#[cfg(feature = "io-util")]
+use crate::io::BufReader;
 use crate::io::{AsyncRead, AsyncWrite, Interest, ReadBuf, Ready};
 use crate::net::UnixStream;
 
@@ -97,6 +99,25 @@ impl fmt::Display for ReuniteError {
 }
 
 impl Error for ReuniteError {}
+
+/// Error indicating that two halves were not from the same socket, and thus could
+/// not be reunited.
+#[cfg(feature = "io-util")]
+#[derive(Debug)]
+pub struct BufReuniteError(pub BufReader<OwnedReadHalf>, pub OwnedWriteHalf);
+
+#[cfg(feature = "io-util")]
+impl fmt::Display for BufReuniteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "tried to reunite halves that are not from the same socket"
+        )
+    }
+}
+
+#[cfg(feature = "io-util")]
+impl Error for BufReuniteError {}
 
 impl OwnedReadHalf {
     /// Attempts to put the two halves of a `UnixStream` back together and


### PR DESCRIPTION
## Motivation

It is very common to wrap a TCP stream in BufReader, and then want to split it.

It is not currently possible to split anything wrapped in a BufReader without losing the contents of BufReader's buffer.

## Solution

- Modified BufReader to add `.into_split()` methods for `BufReader<TcpStream>` and `BufReader<UnixStream>`.

- Modified BufReader to add `.reunite()` methods for `BufReader<tcp::OwnedReadHalf>` and `BufReader<unix::OwnedReadHalf>`.

- Added `BufReuniteError` variants to `tokio::net::tcp` and `tokio::net::unix` (with `BufReader<OwnedReadHalf>` instead of `OwnedReadHalf`).

---

I ran most of the commands in the contributor's guide, and ran a couple of tests of my own to confirm that both the TCP and Unix halves of this PR work as expected.

Please let me know if any modifications are required.

It may be worth considering adding similar `.into_split()` and `.reunite()` methods for other types when wrapped within BufReader, but I considered that to be beyond the scope of my efforts.