### PR TITLE
runtime: stabilize worker_index

### DIFF
--- a/tokio/src/runtime/context.rs
+++ b/tokio/src/runtime/context.rs
@@ -165,7 +165,6 @@ cfg_rt! {
         CONTEXT.try_with(|ctx| ctx.current_task_id.get()).unwrap_or_default()
     }
 
-    #[cfg(tokio_unstable)]
     pub(crate) fn worker_index() -> Option<usize> {
         with_scheduler(|ctx| ctx.and_then(|c| c.worker_index()))
     }

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -563,43 +563,44 @@ cfg_rt! {
     cfg_unstable! {
         pub use self::builder::UnhandledPanic;
         pub use crate::util::rand::RngSeed;
+    }
 
-        /// Returns the index of the current worker thread, if called from a
-        /// runtime worker thread.
-        ///
-        /// The returned value is a 0-based index matching the worker indices
-        /// used by [`RuntimeMetrics`] methods such as
-        /// [`worker_total_busy_duration`](RuntimeMetrics::worker_total_busy_duration).
-        ///
-        /// Returns `None` when called from outside a runtime worker thread
-        /// (for example, from a blocking thread or a non-Tokio thread). On the
-        /// multi-thread runtime, the thread that calls [`Runtime::block_on`] is
-        /// not a worker thread, so this also returns `None` there.
-        ///
-        /// For the current-thread runtime and [`LocalRuntime`], this always
-        /// returns `Some(0)` (including inside `block_on`, since the calling
-        /// thread *is* the worker thread).
-        ///
-        /// Note that the result may change across `.await` points, as the
-        /// task may be moved to a different worker thread by the scheduler.
-        ///
-        /// # Examples
-        ///
-        /// ```
-        /// # #[cfg(not(target_family = "wasm"))]
-        /// # {
-        /// #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
-        /// async fn main() {
-        ///     let index = tokio::spawn(async {
-        ///         tokio::runtime::worker_index()
-        ///     }).await.unwrap();
-        ///     println!("Task ran on worker {:?}", index);
-        /// }
-        /// # }
-        /// ```
-        pub fn worker_index() -> Option<usize> {
-            context::worker_index()
-        }
+    /// Returns the index of the current worker thread, if called from a
+    /// runtime worker thread.
+    ///
+    /// The returned value is a 0-based index matching the worker indices
+    /// used by [`RuntimeMetrics`] methods such as
+    /// [`worker_total_busy_duration`](RuntimeMetrics::worker_total_busy_duration).
+    ///
+    /// Returns `None` when called from outside a runtime worker thread
+    /// (for example, from a blocking thread or a non-Tokio thread). On the
+    /// multi-thread runtime, the thread that calls [`Runtime::block_on`] is
+    /// not a worker thread, so this also returns `None` there.
+    ///
+    /// For the current-thread runtime and [`LocalRuntime`], this returns
+    /// `Some(0)` when called from the thread that currently owns the runtime
+    /// driver. If multiple threads call [`Runtime::block_on`] concurrently,
+    /// calls on threads that do not own the driver return `None`.
+    ///
+    /// Note that the result may change across `.await` points, as the
+    /// task may be moved to a different worker thread by the scheduler.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # #[cfg(not(target_family = "wasm"))]
+    /// # {
+    /// #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
+    /// async fn main() {
+    ///     let index = tokio::spawn(async {
+    ///         tokio::runtime::worker_index()
+    ///     }).await.unwrap();
+    ///     println!("Task ran on worker {:?}", index);
+    /// }
+    /// # }
+    /// ```
+    pub fn worker_index() -> Option<usize> {
+        context::worker_index()
     }
 
     cfg_taskdump! {

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -577,10 +577,11 @@ cfg_rt! {
     /// multi-thread runtime, the thread that calls [`Runtime::block_on`] is
     /// not a worker thread, so this also returns `None` there.
     ///
-    /// For the current-thread runtime and [`LocalRuntime`], this returns
-    /// `Some(0)` when called from the thread that currently owns the runtime
-    /// driver. If multiple threads call [`Runtime::block_on`] concurrently,
-    /// calls on threads that do not own the driver return `None`.
+    /// For the current-thread runtime, this returns `Some(0)` when called from
+    /// the thread that currently owns the runtime driver. If multiple threads
+    /// call [`Runtime::block_on`] concurrently, calls on threads that do not
+    /// own the driver return `None`. A [`LocalRuntime`] can only be driven from
+    /// its owning thread, so calls inside `block_on` always return `Some(0)`.
     ///
     /// Note that the result may change across `.await` points, as the
     /// task may be moved to a different worker thread by the scheduler.

--- a/tokio/src/runtime/scheduler/mod.rs
+++ b/tokio/src/runtime/scheduler/mod.rs
@@ -278,7 +278,6 @@ cfg_rt! {
             match_flavor!(self, Context(context) => context.defer(waker));
         }
 
-        #[cfg(tokio_unstable)]
         pub(crate) fn worker_index(&self) -> Option<usize> {
             match self {
                 Context::CurrentThread(_) => Some(0),

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -1073,7 +1073,6 @@ impl Context {
         })
     }
 
-    #[cfg(tokio_unstable)]
     pub(crate) fn worker_index(&self) -> usize {
         self.worker.index
     }

--- a/tokio/tests/rt_worker_index.rs
+++ b/tokio/tests/rt_worker_index.rs
@@ -19,6 +19,16 @@ fn worker_index_current_thread() {
 }
 
 #[test]
+fn worker_index_handle_block_on_current_thread() {
+    let rt = runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let index = rt.handle().block_on(async { runtime::worker_index() });
+    assert_eq!(index, None);
+}
+
+#[test]
 fn worker_index_current_thread_concurrent_block_on() {
     let rt = Arc::new(
         runtime::Builder::new_current_thread()
@@ -113,4 +123,14 @@ fn worker_index_block_on_multi_thread() {
         index, None,
         "block_on thread is not a worker thread on multi-thread runtime"
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn worker_index_tokio_test_current_thread() {
+    assert_eq!(runtime::worker_index(), Some(0));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn worker_index_tokio_test_multi_thread() {
+    assert_eq!(runtime::worker_index(), None);
 }

--- a/tokio/tests/rt_worker_index.rs
+++ b/tokio/tests/rt_worker_index.rs
@@ -115,14 +115,15 @@ fn worker_index_from_spawn_blocking() {
 }
 
 #[test]
-fn worker_index_block_on_multi_thread() {
-    let rt = Runtime::new().unwrap();
-    // block_on runs on the calling thread, not a worker thread
-    let index = rt.block_on(async { runtime::worker_index() });
-    assert_eq!(
-        index, None,
-        "block_on thread is not a worker thread on multi-thread runtime"
-    );
+fn worker_index_multi_thread() {
+    let rt = runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let index = runtime::worker_index();
+        assert_eq!(index, None);
+    });
 }
 
 #[tokio::test(flavor = "current_thread")]

--- a/tokio/tests/rt_worker_index.rs
+++ b/tokio/tests/rt_worker_index.rs
@@ -1,5 +1,8 @@
 #![warn(rust_2018_idioms)]
-#![cfg(all(feature = "full", tokio_unstable, not(target_os = "wasi"),))]
+#![cfg(all(feature = "full", not(target_os = "wasi"),))]
+
+use std::sync::Arc;
+use std::thread;
 
 use tokio::runtime::{self, Runtime};
 
@@ -16,6 +19,36 @@ fn worker_index_current_thread() {
 }
 
 #[test]
+fn worker_index_current_thread_concurrent_block_on() {
+    let rt = Arc::new(
+        runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap(),
+    );
+    let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+    let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+
+    let owner_rt = rt.clone();
+    let owner = thread::spawn(move || {
+        owner_rt.block_on(async {
+            entered_tx.send(()).unwrap();
+            release_rx.await.unwrap();
+            runtime::worker_index()
+        })
+    });
+
+    entered_rx.recv().unwrap();
+
+    let other_rt = rt.clone();
+    let other = thread::spawn(move || other_rt.block_on(async { runtime::worker_index() }));
+
+    assert_eq!(other.join().unwrap(), None);
+    release_tx.send(()).unwrap();
+    assert_eq!(owner.join().unwrap(), Some(0));
+}
+
+#[test]
 fn worker_index_local_runtime() {
     let rt = runtime::LocalRuntime::new().unwrap();
     rt.block_on(async {
@@ -29,7 +62,7 @@ fn worker_index_outside_runtime() {
     assert_eq!(runtime::worker_index(), None);
 }
 
-#[cfg(target_has_atomic = "64")]
+#[cfg(all(tokio_unstable, target_has_atomic = "64"))]
 #[test]
 fn worker_index_matches_metrics_worker_thread_id() {
     let rt = runtime::Builder::new_multi_thread()


### PR DESCRIPTION
## Motivation

	tokio::runtime::worker_index is currently gated on tokio_unstable, although #8369 requests stabilizing the API. Current-thread runtimes can have concurrent block_on callers, so only the thread that owns the driver has a worker context.

## Solution


Stabilize worker_index, document current-thread driver ownership, and add a regression test covering concurrent block_on calls. The existing behavior remains unchanged for multi-thread runtimes, blocking threads, and non-runtime callers.

Fixes: #8369