### PR TITLE
io: retry ErrorKind::Interrupted in read_to_end

### DIFF
--- a/tokio/src/io/util/read_to_end.rs
+++ b/tokio/src/io/util/read_to_end.rs
@@ -45,6 +45,7 @@ pub(super) fn read_to_end_internal<V: VecU8, R: AsyncRead + ?Sized>(
     loop {
         let ret = ready!(poll_read_to_end(buf, reader.as_mut(), cx));
         match ret {
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
             Err(err) => return Poll::Ready(Err(err)),
             Ok(0) => return Poll::Ready(Ok(mem::replace(num_read, 0))),
             Ok(num) => {

--- a/tokio/tests/io_read_to_end.rs
+++ b/tokio/tests/io_read_to_end.rs
@@ -9,6 +9,7 @@
     )
 ))]
 
+use std::io;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
@@ -23,6 +24,20 @@ async fn read_to_end() {
     let n = assert_ok!(rd.read_to_end(&mut buf).await);
     assert_eq!(n, 11);
     assert_eq!(buf[..], b"hello world"[..]);
+}
+
+#[tokio::test]
+async fn read_to_end_retries_interrupted() {
+    let mut mock = Builder::new()
+        .read(b"hello")
+        .read_error(io::Error::from(io::ErrorKind::Interrupted))
+        .read(b" world")
+        .build();
+    let mut buf = Vec::new();
+
+    let n = mock.read_to_end(&mut buf).await.unwrap();
+    assert_eq!(n, 11);
+    assert_eq!(buf, b"hello world");
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/tokio/tests/io_read_to_string.rs
+++ b/tokio/tests/io_read_to_string.rs
@@ -26,6 +26,20 @@ async fn read_to_string() {
 }
 
 #[tokio::test]
+async fn read_to_string_retries_interrupted() {
+    let mut mock = Builder::new()
+        .read(b"hello")
+        .read_error(io::Error::from(io::ErrorKind::Interrupted))
+        .read(b" world")
+        .build();
+    let mut buf = String::new();
+
+    let n = mock.read_to_string(&mut buf).await.unwrap();
+    assert_eq!(n, 11);
+    assert_eq!(buf, "hello world");
+}
+
+#[tokio::test]
 async fn to_string_does_not_truncate_on_utf8_error() {
     let data = vec![0xff, 0xff, 0xff];
 


### PR DESCRIPTION
## Motivation

`AsyncReadExt::read_to_end` currently propagates `ErrorKind::Interrupted` when the underlying `poll_read` returns it.

This differs from `read_exact`, which now retries interrupted reads. Since `read_to_string` uses the same internal helper as `read_to_end`, it has the same behavior.

`Interrupted` is a transient I/O error and should be retried for these composite read helpers.

## Solution

Retry `ErrorKind::Interrupted` in `read_to_end_internal` instead of returning it to the caller. Other I/O errors continue to be propagated unchanged.
