### PR TITLE
net: start accepted sockets as readable and writable

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -106,5 +106,10 @@ name = "remote_spawn"
 path = "remote_spawn.rs"
 harness = false
 
+[[bench]]
+name = "net_accept"
+path = "net_accept.rs"
+harness = false
+
 [lints]
 workspace = true

--- a/benches/net_accept.rs
+++ b/benches/net_accept.rs
@@ -1,0 +1,330 @@
+//! Benchmark the path from `accept` to the first read and write on the
+//! accepted socket. The peer's request is already queued when the socket is
+//! accepted, as it is for a client racing a busy server, so the first read
+//! never needs to wait; this measures whether the runtime makes it wait for
+//! the I/O driver anyway. These benches are a form of regression testing and
+//! not a general purpose benchmark.
+//!
+//! Idle shapes, time per connection:
+//! - `block_on`: accept + read + write inside `block_on`, one connection per
+//!   iteration.
+//! - `serial_task`: one spawned task accepts and serves a batch of connections
+//!   in order, never yielding except on I/O.
+//! - `task_per_conn`: an accept loop spawns one task per connection (the usual
+//!   server shape).
+//!
+//! `live/*`: a current-thread server runs on its own thread for the whole
+//! bench and also drains `busy` other connections that a writer thread keeps
+//! readable; the timed quantity is a blocking client's connect + request +
+//! 2-byte reply. `inline_first_read` reads the request in the accept loop,
+//! `task_per_conn` in a spawned task, `cap8` sets `max_io_events_per_tick(8)`.
+
+use std::io::Write;
+use std::net::{SocketAddr, TcpStream as StdStream};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::runtime::{self, Runtime};
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+
+const REQUEST: &[u8] = &[1; 64];
+const BATCH: u64 = 64;
+
+/// A client that has connected and sent its request before the server accepts.
+fn client(addr: SocketAddr) -> StdStream {
+    let mut c = StdStream::connect(addr).unwrap();
+    c.set_nodelay(true).unwrap();
+    c.write_all(REQUEST).unwrap();
+    c
+}
+
+async fn serve(mut s: TcpStream) {
+    let mut buf = [0u8; REQUEST.len()];
+    s.read_exact(&mut buf).await.unwrap();
+    s.write_all(b"ok").await.unwrap();
+}
+
+fn rt_current_thread() -> Runtime {
+    runtime::Builder::new_current_thread()
+        .enable_io()
+        .build()
+        .unwrap()
+}
+
+fn rt_multi_thread(workers: usize) -> Runtime {
+    runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_io()
+        .build()
+        .unwrap()
+}
+
+fn block_on(c: &mut Criterion, name: &str, rt: Runtime) {
+    let listener = rt.block_on(TcpListener::bind("127.0.0.1:0")).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    c.bench_function(name, |b| {
+        b.iter_batched(
+            || client(addr),
+            |_client| {
+                rt.block_on(async {
+                    let (s, _) = listener.accept().await.unwrap();
+                    serve(s).await;
+                })
+            },
+            BatchSize::PerIteration,
+        )
+    });
+}
+
+/// Runs `iters` connections in batches of `BATCH`: the clients for a batch are
+/// connected and have written before the timed section, which runs `server`
+/// for that batch as one spawned task.
+fn spawned<F, Fut>(c: &mut Criterion, name: &str, rt: Runtime, server: F)
+where
+    F: Fn(Arc<TcpListener>, u64) -> Fut + Copy + Send + 'static,
+    Fut: std::future::Future<Output = ()> + Send + 'static,
+{
+    let listener = Arc::new(rt.block_on(TcpListener::bind("127.0.0.1:0")).unwrap());
+    let addr = listener.local_addr().unwrap();
+
+    c.bench_function(name, |b| {
+        b.iter_custom(|iters| {
+            let mut total = Duration::ZERO;
+            let mut left = iters;
+            while left > 0 {
+                let n = left.min(BATCH);
+                left -= n;
+                let clients: Vec<StdStream> = (0..n).map(|_| client(addr)).collect();
+                let l = listener.clone();
+                let start = Instant::now();
+                rt.block_on(async move { tokio::spawn(server(l, n)).await.unwrap() });
+                total += start.elapsed();
+                drop(clients);
+            }
+            total
+        })
+    });
+}
+
+async fn serial_task(listener: Arc<TcpListener>, n: u64) {
+    for _ in 0..n {
+        let (s, _) = listener.accept().await.unwrap();
+        serve(s).await;
+    }
+}
+
+async fn task_per_conn(listener: Arc<TcpListener>, n: u64) {
+    let mut handlers = Vec::with_capacity(n as usize);
+    for _ in 0..n {
+        let (s, _) = listener.accept().await.unwrap();
+        handlers.push(tokio::spawn(serve(s)));
+    }
+    for h in handlers {
+        h.await.unwrap();
+    }
+}
+
+fn block_on_current_thread(c: &mut Criterion) {
+    block_on(c, "block_on/current_thread", rt_current_thread());
+}
+
+fn block_on_multi_thread_1(c: &mut Criterion) {
+    block_on(c, "block_on/multi_thread_1", rt_multi_thread(1));
+}
+
+fn serial_task_multi_thread_1(c: &mut Criterion) {
+    spawned(
+        c,
+        "serial_task/multi_thread_1",
+        rt_multi_thread(1),
+        serial_task,
+    );
+}
+
+fn serial_task_multi_thread_4(c: &mut Criterion) {
+    spawned(
+        c,
+        "serial_task/multi_thread_4",
+        rt_multi_thread(4),
+        serial_task,
+    );
+}
+
+fn task_per_conn_multi_thread_1(c: &mut Criterion) {
+    spawned(
+        c,
+        "task_per_conn/multi_thread_1",
+        rt_multi_thread(1),
+        task_per_conn,
+    );
+}
+
+fn task_per_conn_multi_thread_4(c: &mut Criterion) {
+    spawned(
+        c,
+        "task_per_conn/multi_thread_4",
+        rt_multi_thread(4),
+        task_per_conn,
+    );
+}
+
+criterion_group!(
+    net_accept,
+    block_on_current_thread,
+    block_on_multi_thread_1,
+    serial_task_multi_thread_1,
+    serial_task_multi_thread_4,
+    task_per_conn_multi_thread_1,
+    task_per_conn_multi_thread_4
+);
+
+// ---------------------------------------------------------------------------
+// Live server: the runtime runs for the whole bench on its own thread and
+// keeps draining the background connections, so both sides do the same
+// background work; the client measures connect -> request -> reply.
+
+use std::io::Read;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering::Relaxed};
+
+struct Live {
+    addr: SocketAddr,
+    stop: Arc<AtomicBool>,
+    drained: Arc<AtomicU64>,
+    writer: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Drop for Live {
+    fn drop(&mut self) {
+        self.stop.store(true, Relaxed);
+        if let Some(h) = self.writer.take() {
+            let _ = h.join();
+        }
+        // The server thread is left running; it holds no resources the next
+        // bench needs and exits with the process.
+        eprintln!(
+            "  (background bytes drained by the server: {})",
+            self.drained.load(Relaxed)
+        );
+    }
+}
+
+fn live(busy: usize, inline: bool, events_per_tick: Option<usize>) -> Live {
+    let std_l = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let std_bg = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    std_l.set_nonblocking(true).unwrap();
+    std_bg.set_nonblocking(true).unwrap();
+    let (addr, bg_addr) = (std_l.local_addr().unwrap(), std_bg.local_addr().unwrap());
+    let accepted = Arc::new(AtomicU64::new(0));
+    let drained = Arc::new(AtomicU64::new(0));
+    let (accepted2, drained2) = (accepted.clone(), drained.clone());
+
+    std::thread::spawn(move || {
+        let mut b = runtime::Builder::new_current_thread();
+        b.enable_io();
+        if let Some(n) = events_per_tick {
+            b.max_io_events_per_tick(n);
+        }
+        let rt = b.build().unwrap();
+        rt.block_on(async move {
+            let bg = TcpListener::from_std(std_bg).unwrap();
+            tokio::spawn(async move {
+                loop {
+                    let (mut s, _) = bg.accept().await.unwrap();
+                    accepted2.fetch_add(1, Relaxed);
+                    let drained = drained2.clone();
+                    tokio::spawn(async move {
+                        let mut buf = [0u8; 256];
+                        loop {
+                            match s.read(&mut buf).await {
+                                Ok(0) | Err(_) => break,
+                                Ok(n) => {
+                                    drained.fetch_add(n as u64, Relaxed);
+                                }
+                            }
+                        }
+                    });
+                }
+            });
+            let l = TcpListener::from_std(std_l).unwrap();
+            loop {
+                let (s, _) = l.accept().await.unwrap();
+                if inline {
+                    serve(s).await;
+                } else {
+                    tokio::spawn(serve(s));
+                }
+            }
+        });
+    });
+
+    let mut clients = Vec::with_capacity(busy);
+    for _ in 0..busy {
+        let c = StdStream::connect(bg_addr).unwrap();
+        c.set_nonblocking(true).unwrap();
+        c.set_nodelay(true).unwrap();
+        clients.push(c);
+    }
+    while accepted.load(Relaxed) < busy as u64 {
+        std::thread::sleep(Duration::from_millis(1));
+    }
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop2 = stop.clone();
+    let writer = std::thread::spawn(move || {
+        let chunk = [2u8; 32];
+        while !stop2.load(Relaxed) {
+            for c in &mut clients {
+                let _ = c.write(&chunk);
+            }
+            std::thread::sleep(Duration::from_micros(200));
+        }
+    });
+    Live {
+        addr,
+        stop,
+        drained,
+        writer: Some(writer),
+    }
+}
+
+fn live_bench(c: &mut Criterion, name: &str, busy: usize, inline: bool, cap: Option<usize>) {
+    let srv = live(busy, inline, cap);
+    c.bench_function(name, |b| {
+        b.iter(|| {
+            let mut c = StdStream::connect(srv.addr).unwrap();
+            c.set_nodelay(true).unwrap();
+            c.write_all(REQUEST).unwrap();
+            let mut reply = [0u8; 2];
+            c.read_exact(&mut reply).unwrap();
+        })
+    });
+}
+
+fn live_task_per_conn_0(c: &mut Criterion) {
+    live_bench(c, "live/task_per_conn/busy_0", 0, false, None);
+}
+fn live_task_per_conn_1024(c: &mut Criterion) {
+    live_bench(c, "live/task_per_conn/busy_1024", 1024, false, None);
+}
+fn live_inline_0(c: &mut Criterion) {
+    live_bench(c, "live/inline_first_read/busy_0", 0, true, None);
+}
+fn live_inline_1024(c: &mut Criterion) {
+    live_bench(c, "live/inline_first_read/busy_1024", 1024, true, None);
+}
+fn live_task_per_conn_cap8_1024(c: &mut Criterion) {
+    live_bench(c, "live/task_per_conn_cap8/busy_1024", 1024, false, Some(8));
+}
+
+criterion_group!(
+    net_accept_live,
+    live_task_per_conn_0,
+    live_task_per_conn_1024,
+    live_inline_0,
+    live_inline_1024,
+    live_task_per_conn_cap8_1024
+);
+criterion_main!(net_accept, net_accept_live);

--- a/tokio/src/net/tcp/listener.rs
+++ b/tokio/src/net/tcp/listener.rs
@@ -166,7 +166,7 @@ impl TcpListener {
             .async_io(Interest::READABLE, || self.io.accept())
             .await?;
 
-        let stream = TcpStream::new(mio)?;
+        let stream = TcpStream::new_accepted(mio)?;
         Ok((stream, addr))
     }
 
@@ -182,7 +182,7 @@ impl TcpListener {
 
             match self.io.accept() {
                 Ok((io, addr)) => {
-                    let io = TcpStream::new(io)?;
+                    let io = TcpStream::new_accepted(io)?;
                     return Poll::Ready(Ok((io, addr)));
                 }
                 Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {

--- a/tokio/src/net/tcp/stream.rs
+++ b/tokio/src/net/tcp/stream.rs
@@ -165,6 +165,18 @@ impl TcpStream {
         Ok(TcpStream { io })
     }
 
+    /// A stream returned by `accept`: assumed readable and writable, so that
+    /// its first read and write try the socket instead of waiting for the
+    /// driver's first event (see `Registration::assume_ready`).
+    pub(crate) fn new_accepted(connected: mio::net::TcpStream) -> io::Result<TcpStream> {
+        let stream = TcpStream::new(connected)?;
+        stream
+            .io
+            .registration()
+            .assume_ready(Ready::READABLE | Ready::WRITABLE);
+        Ok(stream)
+    }
+
     /// Creates new `TcpStream` from a `std::net::TcpStream`.
     ///
     /// This function is intended to be used to wrap a TCP stream from the

--- a/tokio/src/net/unix/listener.rs
+++ b/tokio/src/net/unix/listener.rs
@@ -214,7 +214,7 @@ impl UnixListener {
             .await?;
 
         let addr = SocketAddr(addr);
-        let stream = UnixStream::new(mio)?;
+        let stream = UnixStream::new_accepted(mio)?;
         Ok((stream, addr))
     }
 
@@ -227,7 +227,7 @@ impl UnixListener {
     pub fn poll_accept(&self, cx: &mut Context<'_>) -> Poll<io::Result<(UnixStream, SocketAddr)>> {
         let (sock, addr) = ready!(self.io.registration().poll_read_io(cx, || self.io.accept()))?;
         let addr = SocketAddr(addr);
-        let sock = UnixStream::new(sock)?;
+        let sock = UnixStream::new_accepted(sock)?;
         Poll::Ready(Ok((sock, addr)))
     }
 }

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -918,6 +918,16 @@ impl UnixStream {
         Ok((a, b))
     }
 
+    /// See `TcpStream::new_accepted`.
+    pub(crate) fn new_accepted(stream: mio::net::UnixStream) -> io::Result<UnixStream> {
+        let stream = UnixStream::new(stream)?;
+        stream
+            .io
+            .registration()
+            .assume_ready(Ready::READABLE | Ready::WRITABLE);
+        Ok(stream)
+    }
+
     pub(crate) fn new(stream: mio::net::UnixStream) -> io::Result<UnixStream> {
         let io = PollEvented::new(stream)?;
         Ok(UnixStream { io })

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -104,6 +104,16 @@ impl Registration {
         self.shared.clear_readiness(event);
     }
 
+    /// Marks the resource ready without waiting for the driver's first event.
+    /// Used for accepted sockets, which are writable and usually already hold
+    /// the peer's first bytes; under load that first event can queue behind
+    /// every established connection's events. A wrong guess costs one
+    /// `WouldBlock`, which clears the readiness again.
+    #[cfg(feature = "net")]
+    pub(crate) fn assume_ready(&self, ready: crate::io::Ready) {
+        self.shared.assume_ready(ready);
+    }
+
     // Uses the poll path, requiring the caller to ensure mutual exclusion for
     // correctness. Only the last task to call this function is notified.
     pub(crate) fn poll_read_ready(&self, cx: &mut Context<'_>) -> Poll<io::Result<ReadyEvent>> {

--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -184,6 +184,17 @@ impl Default for ScheduledIo {
 }
 
 impl ScheduledIo {
+    /// Marks the resource ready in the given directions without an event from
+    /// the driver. Readiness may have false positives; an operation that finds
+    /// the resource not ready clears it as usual. Leaves the tick alone and
+    /// does nothing after shutdown.
+    pub(super) fn assume_ready(&self, ready: Ready) {
+        let _ = self.readiness.fetch_update(AcqRel, Acquire, |curr| {
+            (SHUTDOWN.unpack(curr) == 0)
+                .then(|| READINESS.pack(READINESS.unpack(curr) | ready.as_usize(), curr))
+        });
+    }
+
     pub(crate) fn token(&self) -> mio::Token {
         mio::Token(super::EXPOSE_IO.expose_provenance(self))
     }

--- a/tokio/src/runtime/io/scheduled_io.rs
+++ b/tokio/src/runtime/io/scheduled_io.rs
@@ -219,7 +219,11 @@ impl ScheduledIo {
                 Tick::Set => tick.wrapping_add(1) % MAX_TICK,
             };
             let ready = Ready::from_usize(READINESS.unpack(curr));
-            Some(TICK.pack(new_tick, f(ready).as_usize()))
+            // Keep the shutdown bit, so that a clear after shutdown (a
+            // `WouldBlock` observed once the driver is gone) does not turn the
+            // next wait into a wait for an event that will never come.
+            let next = TICK.pack(new_tick, f(ready).as_usize());
+            Some(SHUTDOWN.pack(SHUTDOWN.unpack(curr), next))
         });
     }
 

--- a/tokio/tests/tcp_accept_ready.rs
+++ b/tokio/tests/tcp_accept_ready.rs
@@ -1,0 +1,210 @@
+#![warn(rust_2018_idioms)]
+#![cfg(all(feature = "full", not(target_os = "wasi"), not(miri)))]
+
+//! An accepted socket starts out assumed readable and writable, so its first
+//! read and write try the syscall instead of waiting for the driver's first
+//! event.
+
+use futures::FutureExt;
+use std::future::Future;
+use std::io::{IoSlice, Write};
+use std::pin::pin;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncReadExt, AsyncWriteExt, Interest};
+use tokio::net::{TcpListener, TcpStream};
+
+/// Waits until `n` bytes are queued on `s`, using a raw `MSG_PEEK` that does not touch
+/// tokio's readiness, so a test never depends on loopback delivery timing.
+fn wait_until_queued(s: &TcpStream, n: usize) {
+    if n == 0 {
+        return;
+    }
+    let sock = socket2::SockRef::from(s);
+    let mut buf = [std::mem::MaybeUninit::<u8>::uninit(); 64];
+    assert!(n <= buf.len());
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !matches!(sock.peek(&mut buf), Ok(m) if m >= n) {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "peer's bytes never arrived"
+        );
+        std::thread::yield_now();
+    }
+}
+
+async fn accepted_with(data: &[u8]) -> (TcpStream, std::net::TcpStream) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let mut client = std::net::TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    client.write_all(data).unwrap();
+    let (s, _) = listener.accept().await.unwrap();
+    wait_until_queued(&s, data.len());
+    (s, client)
+}
+
+#[tokio::test]
+async fn accepted_stream_reads_without_waiting_for_an_event() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    // The peer connects and sends before we accept, as a client racing an
+    // overloaded server does.
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    client.write_all(b"hello").unwrap();
+
+    let (stream, _) = listener.accept().await.unwrap();
+    wait_until_queued(&stream, 5);
+
+    // `try_read` never waits for the driver; if the socket did not start out
+    // readable it would return `WouldBlock` here despite the queued data.
+    let mut buf = [0u8; 16];
+    let n = stream
+        .try_read(&mut buf)
+        .expect("data was queued before the first read");
+    assert_eq!(&buf[..n], b"hello");
+    // The first write tries the socket too.
+    assert_eq!(stream.try_write(b"world").unwrap(), 5);
+}
+
+#[tokio::test]
+async fn accepted_stream_with_no_data_still_waits() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let mut client = std::net::TcpStream::connect(addr).unwrap();
+    let (stream, _) = listener.accept().await.unwrap();
+
+    // Nothing queued at accept time: the socket is assumed readable (a false
+    // positive) until a read finds nothing, and it is writable.
+    assert!(stream.readable().now_or_never().is_some());
+    let mut buf = [0u8; 16];
+    let err = stream.try_read(&mut buf).unwrap_err();
+    assert_eq!(err.kind(), std::io::ErrorKind::WouldBlock);
+    assert!(stream.readable().now_or_never().is_none());
+    assert_eq!(stream.try_write(b"early").unwrap(), 5);
+    // The normal event path still delivers data that arrives later.
+    client.write_all(b"later").unwrap();
+    stream.readable().await.unwrap();
+    let n = stream.try_read(&mut buf).unwrap();
+    assert_eq!(&buf[..n], b"later");
+}
+
+// The `AsyncRead`/`AsyncWrite` path (`PollEvented`), which HTTP stacks use.
+#[tokio::test]
+async fn first_poll_read_and_write_are_ready() {
+    let (mut s, _c) = accepted_with(b"hello").await;
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+    let mut buf = [0u8; 16];
+    assert!(matches!(
+        pin!(s.read(&mut buf)).poll(&mut cx),
+        Poll::Ready(Ok(5))
+    ));
+    assert!(matches!(
+        pin!(s.write(b"x")).poll(&mut cx),
+        Poll::Ready(Ok(1))
+    ));
+}
+
+// A read that fills the buffer keeps the socket readable, so draining
+// continues without an event.
+#[tokio::test]
+async fn full_first_read_keeps_draining() {
+    let (mut s, _c) = accepted_with(b"helloworld").await;
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+    let mut buf = [0u8; 5];
+    assert!(matches!(
+        pin!(s.read(&mut buf)).poll(&mut cx),
+        Poll::Ready(Ok(5))
+    ));
+    assert!(matches!(
+        pin!(s.read(&mut buf)).poll(&mut cx),
+        Poll::Ready(Ok(5))
+    ));
+}
+
+// After the runtime is gone: later reads still report the driver gone rather
+// than hang.
+#[test]
+fn later_reads_after_runtime_drop_report_shutdown() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let (mut s, _c) = rt.block_on(accepted_with(b"hello"));
+    drop(rt);
+    assert_eq!(s.try_read(&mut [0u8; 5]).unwrap(), 5);
+    // This read finds nothing and clears readiness after shutdown; the
+    // shutdown bit must survive that or the read below would hang.
+    let _ = s.try_read(&mut [0u8; 5]);
+    let rt2 = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt2.block_on(async {
+        let r = tokio::time::timeout(std::time::Duration::from_secs(1), s.read(&mut [0u8; 5]))
+            .await
+            .expect("read hung instead of reporting shutdown");
+        assert!(tokio::runtime::is_rt_shutdown_err(&r.unwrap_err()));
+    });
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn unix_accepted_stream_reads_without_an_event() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("sock");
+    let listener = tokio::net::UnixListener::bind(&path).unwrap();
+    let mut client = std::os::unix::net::UnixStream::connect(&path).unwrap();
+    client.write_all(b"hello").unwrap();
+    let (s, _) = listener.accept().await.unwrap();
+    // Same-host UDS write is synchronous into the peer's buffer; peek to be sure.
+    let sock = socket2::SockRef::from(&s);
+    let mut peek = [std::mem::MaybeUninit::<u8>::uninit(); 8];
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    while !matches!(sock.peek(&mut peek), Ok(m) if m >= 5) {
+        assert!(std::time::Instant::now() < deadline);
+        std::thread::yield_now();
+    }
+    let mut buf = [0u8; 16];
+    assert_eq!(s.try_read(&mut buf).unwrap(), 5);
+}
+
+// `peek` goes through `async_io`.
+#[tokio::test]
+async fn peek_first_poll_ready() {
+    let (s, _c) = accepted_with(b"hello").await;
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+    let mut buf = [0u8; 16];
+    let r = pin!(s.peek(&mut buf)).poll(&mut cx);
+    assert!(matches!(r, Poll::Ready(Ok(5))), "{r:?}");
+}
+
+// `write_vectored` goes through `poll_write_io` / `poll_io`.
+#[tokio::test]
+async fn write_vectored_first_poll_ready() {
+    let (mut s, _c) = accepted_with(b"").await;
+    let mut cx = Context::from_waker(futures::task::noop_waker_ref());
+    let bufs = [IoSlice::new(b"ab"), IoSlice::new(b"cd")];
+    let r = pin!(s.write_vectored(&bufs)).poll(&mut cx);
+    assert!(matches!(r, Poll::Ready(Ok(4))), "{r:?}");
+}
+
+// An `async_io` whose closure finds the assumed readiness wrong clears it,
+// waits for the driver, and calls the closure again once data arrives.
+#[tokio::test]
+async fn async_io_wouldblock_falls_back_to_wait() {
+    let (s, mut c) = accepted_with(b"").await;
+    let calls = std::cell::Cell::new(0);
+    let fut = s.async_io(Interest::READABLE, || {
+        calls.set(calls.get() + 1);
+        let mut b = [std::mem::MaybeUninit::<u8>::uninit(); 8];
+        socket2::SockRef::from(&s).recv(&mut b)
+    });
+    let mut fut = pin!(fut);
+    assert!(fut.as_mut().now_or_never().is_none());
+    c.write_all(b"xyz").unwrap();
+    let n = tokio::time::timeout(std::time::Duration::from_secs(5), fut)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(n, 3);
+    assert!(calls.get() >= 2, "calls={}", calls.get());
+}

--- a/tokio/tests/tcp_stream.rs
+++ b/tokio/tests/tcp_stream.rs
@@ -55,6 +55,13 @@ async fn try_read_write() {
     let (server, _) = listener.accept().await.unwrap();
     let mut written = DATA.to_vec();
 
+    // An accepted socket starts out assumed readable; a read that finds
+    // nothing clears that.
+    assert_eq!(
+        server.try_read(&mut [0; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+
     // Track the server receiving data
     let mut readable = task::spawn(server.readable());
     assert_pending!(readable.poll());
@@ -231,7 +238,10 @@ macro_rules! assert_not_writable_by_polling {
 async fn poll_read_ready() {
     let (mut client, mut server) = create_pair().await;
 
-    // Initial state - not readable.
+    // Initial state - an accepted socket is assumed readable until a read
+    // finds nothing.
+    assert_readable_by_polling!(server);
+    read_until_pending(&mut server);
     assert_not_readable_by_polling!(server);
 
     // There is data in the buffer - readable.
@@ -316,6 +326,13 @@ async fn try_read_buf() {
         .unwrap();
     let (server, _) = listener.accept().await.unwrap();
     let mut written = DATA.to_vec();
+
+    // An accepted socket starts out assumed readable; a read that finds
+    // nothing clears that.
+    assert_eq!(
+        server.try_read(&mut [0; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
 
     // Track the server receiving data
     let mut readable = task::spawn(server.readable());

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -111,6 +111,13 @@ async fn try_read_write() -> std::io::Result<()> {
     let (server, _) = listener.accept().await?;
     let mut written = msg.to_vec();
 
+    // An accepted socket starts out assumed readable; a read that finds
+    // nothing clears that.
+    assert_eq!(
+        server.try_read(&mut [0; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+
     // Track the server receiving data
     let mut readable = task::spawn(server.readable());
     assert_pending!(readable.poll());
@@ -271,7 +278,10 @@ macro_rules! assert_not_writable_by_polling {
 async fn poll_read_ready() {
     let (mut client, mut server) = create_pair().await;
 
-    // Initial state - not readable.
+    // Initial state - an accepted socket is assumed readable until a read
+    // finds nothing.
+    assert_readable_by_polling!(server);
+    read_until_pending(&mut server);
     assert_not_readable_by_polling!(server);
 
     // There is data in the buffer - readable.
@@ -347,6 +357,13 @@ async fn try_read_buf() -> std::io::Result<()> {
 
     let (server, _) = listener.accept().await?;
     let mut written = msg.to_vec();
+
+    // An accepted socket starts out assumed readable; a read that finds
+    // nothing clears that.
+    assert_eq!(
+        server.try_read(&mut [0; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
 
     // Track the server receiving data
     let mut readable = task::spawn(server.readable());


### PR DESCRIPTION
## Motivation

A stream returned by `TcpListener::accept` starts with no cached readiness, so
its first `poll_read`/`poll_write` waits for the I/O driver to deliver the
socket's first event, and its first `try_read`/`try_write` returns `WouldBlock`.
But an accepted socket is writable immediately, and for request/response
protocols the peer's first bytes are usually already in the buffer: the client
sends its request or TLS/h2 preface right after `connect`, well before a busy
server reaches `accept`.

Idle, that wait costs one trip through the driver. Under load it costs a full
pass of the ready queue, because the new socket's event sits behind every
established connection's events. On a saturated HTTP/2 server we traced accepted
sockets waiting 64–128 ms between `accept4` and the first `recvfrom` attempt,
and that `recvfrom` returned data every time (5,298/5,298 connections).

## Solution

Start every accepted socket as readable and writable. `TcpListener::accept`
/ `poll_accept` and the `UnixListener` equivalents build the stream through
`new_accepted`, which sets `READABLE | WRITABLE` on its `ScheduledIo`
(`Registration::assume_ready`). Readiness is allowed to have false positives,
so nothing else changes: the first read or write tries the syscall; if the
socket turns out not to be ready, the `WouldBlock` clears the bit and the
operation waits for the driver as before. A wrong guess costs one `EAGAIN`.

The first commit is a one-line fix this depends on: `set_readiness` rebuilt
the packed word from tick and readiness only, so a `clear_readiness` after the
driver had shut down dropped the shutdown bit and the next wait hung instead of
returning the shutdown error. That was already reachable for a socket whose
readiness had been set before shutdown; starting accepted sockets as ready
makes it the common case.

## Results

`benches/net_accept.rs` (last commit), x86_64 Linux on a shared machine,
criterion point estimates.

`live/*`: a current-thread server with default settings runs on its own thread
for the whole bench. Besides the listener under test it holds *N* other
connections that a writer thread keeps readable (32 bytes every ~200 µs each)
and drains them in per-connection tasks, so both sides do the same background
work (bytes drained are printed and were within 10% between sides). A blocking
client on the bench thread times connect → 64-byte request → 2-byte reply.
`inline_first_read` reads the request in the accept loop itself;
`task_per_conn` spawns a task per accepted socket; `cap8` is
`task_per_conn` with `max_io_events_per_tick(8)`. Runs listed individually:

| | master | this branch |
|---|---|---|
| `live/task_per_conn/busy_0` | 58, 60 µs | 57, 59 µs |
| `live/inline_first_read/busy_0` | 68, 57 µs | 54, 57 µs |
| `live/task_per_conn/busy_1024` | 0.99, 1.69, 0.82, 1.82 ms | 2.26, 0.94, 1.25, 1.01 ms |
| `live/inline_first_read/busy_1024` | 442, 469, 470 µs | 257, 252, 257 µs |
| `live/task_per_conn_cap8/busy_1024` | 1.96, 2.23 ms | 1.33, 1.44 ms |

With a spawned handler and default settings there is no consistent difference:
by the time the handler task first runs, a driver turn has usually delivered
the socket's event already, so there is nothing to skip (and that row swings
~2× run to run on this machine). The change shows when the first read follows
the accept directly (`inline_first_read`, roughly −45% here), or when a small
events-per-tick cap leaves the new socket's event queued behind others
(`cap8`, lower in every back-to-back run, by about 25–40% depending on the
machine), which is the situation in the motivation.

`block_on`, `serial_task`, `task_per_conn`: accept + read + write on an
otherwise idle runtime, per connection, two runs each, to show the cost when
there is no backlog. `block_on` runs it inside `block_on`; `serial_task` in one
spawned task serving a batch of connections in order; `task_per_conn` spawns a task per
accepted socket (the usual server shape).

| | master | this branch |
|---|---|---|
| `block_on/current_thread` | 19.9, 19.8 µs | 18.1, 20.5 µs |
| `block_on/multi_thread_1` | 34.0, 34.9 µs | 21.4, 22.8 µs |
| `serial_task/multi_thread_1` | 21.7, 18.4 µs | 19.2, 18.1 µs |
| `serial_task/multi_thread_4` | 23.0, 18.7 µs | 22.7, 24.0 µs |
| `task_per_conn/multi_thread_1` | 23.4, 17.3 µs | 20.3, 17.6 µs |
| `task_per_conn/multi_thread_4` | 12.9, 9.8 µs | 10.6, 10.3 µs |

Idle, the only clear change is `block_on` on a multi-thread runtime, where the
first read on master parks the `block_on` thread until the worker holding the
driver wakes it. `serial_task` can get *slower* with several idle workers
(within noise here; about 2× on a VM where a cross-CPU wakeup is expensive):
on master the first-read `Pending` returns that task to the scheduler and
keeps the driver on its thread, while on the branch the loop never yields, so
each new registration wakes a parked worker. `task_per_conn` shows no
difference beyond run-to-run noise.

Under load the saving is queueing delay rather than a wakeup. Setup: an HTTP/2
reverse proxy on a 4-worker runtime limited to 2 CPUs, driven past its capacity
C (≈100 req/s here) with long-lived streaming requests, running with
`max_io_events_per_tick(128)` and the `max_io_events_per_busy_tick(8)` option
from #8410.
We did not measure stock event settings; with larger batches the ready queue
drains in fewer passes and the per-connection wait should be smaller. A
separate client opened 50 new connections/s and timed TCP connect → first
server frame. Two 40 s runs per point:

| offered load | | master | this branch |
|---|---|---|---|
| 0.9 C | p50 / p99 / max | 0.9 / 14 / 51 ms | 0.9 / 8 / 25 ms |
| 1.3 C | p50 / p99 / max | 31 / 78 / 104 ms | 20 / 65 / 80 ms |
| 1.7 C | p50 / p99 / max | 130 / 226 / 278 ms | 59 / 160 / 179 ms |

Request latency on established streams did not regress (time to first byte p50
702 → 617 ms, p99 950 → 919 ms at 1.7 C) and the runtime's queue-overflow
counts were unchanged.

`strace`, client wrote before the accept:

```
master:  accept4 · epoll_ctl(ADD) · epoll_wait · recvfrom = 5 · sendto = 5
branch:  accept4 · epoll_ctl(ADD) ·              recvfrom = 5 · sendto = 5
```

## Details

* Only `accept` presets readiness. A stream from `connect` already waits for
  writability inside `connect`, and the peer's first bytes are at least a round
  trip away at that point; `from_std` / `from_raw_fd` wrap a socket whose state
  tokio cannot know.
* Observable behaviour: `readable()` / `ready()` / `poll_read_ready()` on a
  freshly accepted socket complete immediately once, even if nothing is queued;
  the first `try_read` then returns `WouldBlock` and clears it. The three
  `tcp_stream` / `uds_stream` tests that asserted "not readable right after
  accept" now drain that first. `assume_ready` leaves the tick alone and does
  nothing after shutdown.
* No `cfg`: the same code runs on every target with `net`. mio's edge
  emulation on Windows and on the poll(2) fallback re-arms on `WouldBlock` from
  `do_io`, which an early I/O call goes through like any other. One
  pre-existing edge moves earlier: with a *blocking* listener passed to
  `from_std` on Windows/macOS, the first read blocks where master would block in
  the next `accept()`.
* On an idle multi-worker runtime, a single task that accepts and serves
  connections in a loop without otherwise yielding can get slower (see
  `serial_task/multi_thread_4`): on master the first-read `Pending` returned it
  to the scheduler and kept the driver on its thread; now the loop does not
  yield there, so each new registration wakes a parked worker instead.

Tests: `tokio/tests/tcp_accept_ready.rs` — data queued before accept is read
via `try_read`, `AsyncRead`, `peek` and answered via `write_vectored` without a
driver turn (these fail on master under a current-thread runtime); the false
positive on an empty socket is cleared by the first read; an `async_io` closure
that sees `WouldBlock` falls back to waiting; reads after the runtime is dropped
still report shutdown (fails without the first commit); Unix listener. The
tests wait for the client's bytes with a bounded `MSG_PEEK` loop rather than a
sleep.
