### PR TITLE
rt: type-erase auto-boxed futures so large tasks share one harness

### DIFF
--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -7,7 +7,7 @@ use crate::runtime::blocking::sharded::ShardedImpl;
 use crate::runtime::blocking::{shutdown, BlockingTask};
 use crate::runtime::builder::ThreadNameFn;
 use crate::runtime::task::{self, JoinHandle};
-use crate::runtime::{Builder, Callback, Handle, BOX_FUTURE_THRESHOLD};
+use crate::runtime::{AutoBox, Builder, Callback, Handle};
 use crate::util::metric_atomics::MetricAtomicUsize;
 use crate::util::trace::{blocking_task, SpawnMeta};
 
@@ -370,7 +370,7 @@ impl Spawner {
         R: Send + 'static,
     {
         let fn_size = std::mem::size_of::<F>();
-        let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
+        let (join_handle, spawn_result) = if AutoBox::<F>::SHOULD_BOX {
             self.spawn_blocking_inner(
                 Box::new(func),
                 Mandatory::NonMandatory,
@@ -409,7 +409,7 @@ impl Spawner {
             R: Send + 'static,
         {
             let fn_size = std::mem::size_of::<F>();
-            let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
+            let (join_handle, spawn_result) = if AutoBox::<F>::SHOULD_BOX {
                 self.spawn_blocking_inner(
                     Box::new(func),
                     Mandatory::Mandatory,

--- a/tokio/src/runtime/blocking/pool.rs
+++ b/tokio/src/runtime/blocking/pool.rs
@@ -371,8 +371,9 @@ impl Spawner {
     {
         let fn_size = std::mem::size_of::<F>();
         let (join_handle, spawn_result) = if AutoBox::<F>::SHOULD_BOX {
+            let func: Box<dyn FnOnce() -> R + Send> = Box::new(func);
             self.spawn_blocking_inner(
-                Box::new(func),
+                func,
                 Mandatory::NonMandatory,
                 SpawnMeta::new_unnamed(fn_size),
                 rt,
@@ -410,8 +411,9 @@ impl Spawner {
         {
             let fn_size = std::mem::size_of::<F>();
             let (join_handle, spawn_result) = if AutoBox::<F>::SHOULD_BOX {
+                let func: Box<dyn FnOnce() -> R + Send> = Box::new(func);
                 self.spawn_blocking_inner(
-                    Box::new(func),
+                    func,
                     Mandatory::Mandatory,
                     SpawnMeta::new_unnamed(fn_size),
                     rt,

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -21,6 +21,7 @@ use crate::util::trace::SpawnMeta;
 
 use std::future::Future;
 use std::marker::PhantomData;
+use std::pin::Pin;
 use std::{error, fmt, mem};
 
 /// Runtime context guard.
@@ -201,7 +202,8 @@ impl Handle {
     {
         let fut_size = mem::size_of::<F>();
         if AutoBox::<F>::SHOULD_BOX {
-            self.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            let future: Pin<Box<dyn Future<Output = F::Output> + Send>> = Box::pin(future);
+            self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
         } else {
             self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
         }
@@ -342,7 +344,8 @@ impl Handle {
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();
         if AutoBox::<F>::SHOULD_BOX {
-            self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            let future: Pin<Box<dyn Future<Output = F::Output> + '_>> = Box::pin(future);
+            self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))
         } else {
             self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))
         }

--- a/tokio/src/runtime/handle.rs
+++ b/tokio/src/runtime/handle.rs
@@ -15,7 +15,7 @@ pub struct Handle {
 }
 
 use crate::runtime::task::JoinHandle;
-use crate::runtime::BOX_FUTURE_THRESHOLD;
+use crate::runtime::AutoBox;
 use crate::util::error::{CONTEXT_MISSING_ERROR, THREAD_LOCAL_DESTROYED_ERROR};
 use crate::util::trace::SpawnMeta;
 
@@ -200,7 +200,7 @@ impl Handle {
         F::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
@@ -341,7 +341,7 @@ impl Handle {
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))

--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -9,6 +9,7 @@ use crate::util::trace::SpawnMeta;
 use std::future::Future;
 use std::marker::PhantomData;
 use std::mem;
+use std::pin::Pin;
 use std::time::Duration;
 
 /// A local Tokio runtime.
@@ -159,7 +160,8 @@ impl LocalRuntime {
         // safety: spawn_local can only be called from `LocalRuntime`, which this is
         unsafe {
             if AutoBox::<F>::SHOULD_BOX {
-                self.handle.spawn_local_named(Box::pin(future), meta)
+                let future: Pin<Box<dyn Future<Output = F::Output>>> = Box::pin(future);
+                self.handle.spawn_local_named(future, meta)
             } else {
                 self.handle.spawn_local_named(future, meta)
             }
@@ -226,7 +228,8 @@ impl LocalRuntime {
         let meta = SpawnMeta::new_unnamed(fut_size);
 
         if AutoBox::<F>::SHOULD_BOX {
-            self.block_on_inner(Box::pin(future), meta)
+            let future: Pin<Box<dyn Future<Output = F::Output> + '_>> = Box::pin(future);
+            self.block_on_inner(future, meta)
         } else {
             self.block_on_inner(future, meta)
         }

--- a/tokio/src/runtime/local_runtime/runtime.rs
+++ b/tokio/src/runtime/local_runtime/runtime.rs
@@ -2,7 +2,7 @@
 
 use crate::runtime::blocking::BlockingPool;
 use crate::runtime::scheduler::CurrentThread;
-use crate::runtime::{context, Builder, EnterGuard, Handle, BOX_FUTURE_THRESHOLD};
+use crate::runtime::{context, AutoBox, Builder, EnterGuard, Handle};
 use crate::task::JoinHandle;
 
 use crate::util::trace::SpawnMeta;
@@ -158,7 +158,7 @@ impl LocalRuntime {
 
         // safety: spawn_local can only be called from `LocalRuntime`, which this is
         unsafe {
-            if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+            if AutoBox::<F>::SHOULD_BOX {
                 self.handle.spawn_local_named(Box::pin(future), meta)
             } else {
                 self.handle.spawn_local_named(future, meta)
@@ -225,7 +225,7 @@ impl LocalRuntime {
         let fut_size = mem::size_of::<F>();
         let meta = SpawnMeta::new_unnamed(fut_size);
 
-        if std::mem::size_of::<F>() > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.block_on_inner(Box::pin(future), meta)
         } else {
             self.block_on_inner(future, meta)

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -636,6 +636,24 @@ cfg_rt! {
         16384
     };
 
+    /// Decides whether a future or closure of type `T` is boxed before it is
+    /// turned into a task, based on [`BOX_FUTURE_THRESHOLD`].
+    ///
+    /// The decision is an associated constant rather than a runtime
+    /// comparison of `std::mem::size_of::<T>()` so that only the taken branch
+    /// is instantiated. With a runtime `if`, both branches are instantiated
+    /// for every `T` (one task harness for `T`, one for `Pin<Box<T>>`),
+    /// doubling the generated code for every spawned future in a crate. A
+    /// branch on a constant that is known once `T` is known is pruned by the
+    /// monomorphization collector, so only the harness that is actually used
+    /// is generated.
+    pub(crate) struct AutoBox<T>(std::marker::PhantomData<T>);
+
+    impl<T> AutoBox<T> {
+        /// `true` if a value of type `T` is larger than [`BOX_FUTURE_THRESHOLD`].
+        pub(crate) const SHOULD_BOX: bool = std::mem::size_of::<T>() > BOX_FUTURE_THRESHOLD;
+    }
+
     mod thread_id;
     pub(crate) use thread_id::ThreadId;
 

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -1,4 +1,4 @@
-use super::BOX_FUTURE_THRESHOLD;
+use super::AutoBox;
 use crate::runtime::blocking::BlockingPool;
 use crate::runtime::scheduler::CurrentThread;
 use crate::runtime::{context, EnterGuard, Handle};
@@ -247,7 +247,7 @@ impl Runtime {
         F::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.handle
                 .spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
@@ -342,7 +342,7 @@ impl Runtime {
     #[track_caller]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))

--- a/tokio/src/runtime/runtime.rs
+++ b/tokio/src/runtime/runtime.rs
@@ -9,6 +9,7 @@ use crate::util::trace::SpawnMeta;
 use std::future::Future;
 use std::io;
 use std::mem;
+use std::pin::Pin;
 use std::time::Duration;
 
 cfg_rt_multi_thread! {
@@ -248,8 +249,9 @@ impl Runtime {
     {
         let fut_size = mem::size_of::<F>();
         if AutoBox::<F>::SHOULD_BOX {
+            let future: Pin<Box<dyn Future<Output = F::Output> + Send>> = Box::pin(future);
             self.handle
-                .spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+                .spawn_named(future, SpawnMeta::new_unnamed(fut_size))
         } else {
             self.handle
                 .spawn_named(future, SpawnMeta::new_unnamed(fut_size))
@@ -343,7 +345,8 @@ impl Runtime {
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         let fut_size = mem::size_of::<F>();
         if AutoBox::<F>::SHOULD_BOX {
-            self.block_on_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            let future: Pin<Box<dyn Future<Output = F::Output> + '_>> = Box::pin(future);
+            self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))
         } else {
             self.block_on_inner(future, SpawnMeta::new_unnamed(fut_size))
         }

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -1,6 +1,6 @@
 #![allow(unreachable_pub)]
 use crate::{
-    runtime::{Handle, BOX_FUTURE_THRESHOLD},
+    runtime::{AutoBox, Handle},
     task::{JoinHandle, LocalSet},
     util::trace::SpawnMeta,
 };
@@ -90,7 +90,7 @@ impl<'a> Builder<'a> {
         Fut::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             super::spawn::spawn_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             super::spawn::spawn_inner(future, SpawnMeta::new(self.name, fut_size))
@@ -111,7 +111,7 @@ impl<'a> Builder<'a> {
         Fut::Output: Send + 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             handle.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             handle.spawn_named(future, SpawnMeta::new(self.name, fut_size))
@@ -142,7 +142,7 @@ impl<'a> Builder<'a> {
         Fut::Output: 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             super::local::spawn_local_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             super::local::spawn_local_inner(future, SpawnMeta::new(self.name, fut_size))
@@ -167,7 +167,7 @@ impl<'a> Builder<'a> {
         Fut::Output: 'static,
     {
         let fut_size = mem::size_of::<Fut>();
-        Ok(if fut_size > BOX_FUTURE_THRESHOLD {
+        Ok(if AutoBox::<Fut>::SHOULD_BOX {
             local_set.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
         } else {
             local_set.spawn_named(future, SpawnMeta::new(self.name, fut_size))
@@ -213,7 +213,7 @@ impl<'a> Builder<'a> {
     {
         use crate::runtime::Mandatory;
         let fn_size = mem::size_of::<Function>();
-        let (join_handle, spawn_result) = if fn_size > BOX_FUTURE_THRESHOLD {
+        let (join_handle, spawn_result) = if AutoBox::<Function>::SHOULD_BOX {
             handle.inner.blocking_spawner().spawn_blocking_inner(
                 Box::new(function),
                 Mandatory::NonMandatory,

--- a/tokio/src/task/builder.rs
+++ b/tokio/src/task/builder.rs
@@ -4,7 +4,7 @@ use crate::{
     task::{JoinHandle, LocalSet},
     util::trace::SpawnMeta,
 };
-use std::{future::Future, io, mem};
+use std::{future::Future, io, mem, pin::Pin};
 
 /// Factory which is used to configure the properties of a new task.
 ///
@@ -91,7 +91,8 @@ impl<'a> Builder<'a> {
     {
         let fut_size = mem::size_of::<Fut>();
         Ok(if AutoBox::<Fut>::SHOULD_BOX {
-            super::spawn::spawn_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            let future: Pin<Box<dyn Future<Output = Fut::Output> + Send>> = Box::pin(future);
+            super::spawn::spawn_inner(future, SpawnMeta::new(self.name, fut_size))
         } else {
             super::spawn::spawn_inner(future, SpawnMeta::new(self.name, fut_size))
         })
@@ -112,7 +113,8 @@ impl<'a> Builder<'a> {
     {
         let fut_size = mem::size_of::<Fut>();
         Ok(if AutoBox::<Fut>::SHOULD_BOX {
-            handle.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            let future: Pin<Box<dyn Future<Output = Fut::Output> + Send>> = Box::pin(future);
+            handle.spawn_named(future, SpawnMeta::new(self.name, fut_size))
         } else {
             handle.spawn_named(future, SpawnMeta::new(self.name, fut_size))
         })
@@ -143,7 +145,8 @@ impl<'a> Builder<'a> {
     {
         let fut_size = mem::size_of::<Fut>();
         Ok(if AutoBox::<Fut>::SHOULD_BOX {
-            super::local::spawn_local_inner(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            let future: Pin<Box<dyn Future<Output = Fut::Output>>> = Box::pin(future);
+            super::local::spawn_local_inner(future, SpawnMeta::new(self.name, fut_size))
         } else {
             super::local::spawn_local_inner(future, SpawnMeta::new(self.name, fut_size))
         })
@@ -168,7 +171,8 @@ impl<'a> Builder<'a> {
     {
         let fut_size = mem::size_of::<Fut>();
         Ok(if AutoBox::<Fut>::SHOULD_BOX {
-            local_set.spawn_named(Box::pin(future), SpawnMeta::new(self.name, fut_size))
+            let future: Pin<Box<dyn Future<Output = Fut::Output>>> = Box::pin(future);
+            local_set.spawn_named(future, SpawnMeta::new(self.name, fut_size))
         } else {
             local_set.spawn_named(future, SpawnMeta::new(self.name, fut_size))
         })
@@ -214,8 +218,9 @@ impl<'a> Builder<'a> {
         use crate::runtime::Mandatory;
         let fn_size = mem::size_of::<Function>();
         let (join_handle, spawn_result) = if AutoBox::<Function>::SHOULD_BOX {
+            let function: Box<dyn FnOnce() -> Output + Send> = Box::new(function);
             handle.inner.blocking_spawner().spawn_blocking_inner(
-                Box::new(function),
+                function,
                 Mandatory::NonMandatory,
                 SpawnMeta::new(self.name, fn_size),
                 handle,

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -398,7 +398,8 @@ cfg_rt! {
     {
         let fut_size = std::mem::size_of::<F>();
         if AutoBox::<F>::SHOULD_BOX {
-            spawn_local_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            let future: Pin<Box<dyn Future<Output = F::Output>>> = Box::pin(future);
+            spawn_local_inner(future, SpawnMeta::new_unnamed(fut_size))
         } else {
             spawn_local_inner(future, SpawnMeta::new_unnamed(fut_size))
         }
@@ -595,7 +596,8 @@ impl LocalSet {
     {
         let fut_size = mem::size_of::<F>();
         if AutoBox::<F>::SHOULD_BOX {
-            self.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            let future: Pin<Box<dyn Future<Output = F::Output>>> = Box::pin(future);
+            self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
         } else {
             self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))
         }

--- a/tokio/src/task/local.rs
+++ b/tokio/src/task/local.rs
@@ -5,7 +5,7 @@ use crate::runtime;
 use crate::runtime::task::{
     self, JoinHandle, LocalOwnedTasks, SpawnLocation, Task, TaskHarnessScheduleHooks,
 };
-use crate::runtime::{context, ThreadId, BOX_FUTURE_THRESHOLD};
+use crate::runtime::{context, AutoBox, ThreadId};
 use crate::sync::AtomicWaker;
 use crate::util::trace::SpawnMeta;
 use crate::util::RcCell;
@@ -397,7 +397,7 @@ cfg_rt! {
         F::Output: 'static,
     {
         let fut_size = std::mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             spawn_local_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             spawn_local_inner(future, SpawnMeta::new_unnamed(fut_size))
@@ -594,7 +594,7 @@ impl LocalSet {
         F::Output: 'static,
     {
         let fut_size = mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             self.spawn_named(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             self.spawn_named(future, SpawnMeta::new_unnamed(fut_size))

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -1,4 +1,4 @@
-use crate::runtime::BOX_FUTURE_THRESHOLD;
+use crate::runtime::AutoBox;
 use crate::task::JoinHandle;
 use crate::util::trace::SpawnMeta;
 
@@ -177,7 +177,7 @@ cfg_rt! {
         F::Output: Send + 'static,
     {
         let fut_size = std::mem::size_of::<F>();
-        if fut_size > BOX_FUTURE_THRESHOLD {
+        if AutoBox::<F>::SHOULD_BOX {
             spawn_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
         } else {
             spawn_inner(future, SpawnMeta::new_unnamed(fut_size))

--- a/tokio/src/task/spawn.rs
+++ b/tokio/src/task/spawn.rs
@@ -3,6 +3,7 @@ use crate::task::JoinHandle;
 use crate::util::trace::SpawnMeta;
 
 use std::future::Future;
+use std::pin::Pin;
 
 cfg_rt! {
     /// Spawns a new asynchronous task, returning a
@@ -178,7 +179,8 @@ cfg_rt! {
     {
         let fut_size = std::mem::size_of::<F>();
         if AutoBox::<F>::SHOULD_BOX {
-            spawn_inner(Box::pin(future), SpawnMeta::new_unnamed(fut_size))
+            let future: Pin<Box<dyn Future<Output = F::Output> + Send>> = Box::pin(future);
+            spawn_inner(future, SpawnMeta::new_unnamed(fut_size))
         } else {
             spawn_inner(future, SpawnMeta::new_unnamed(fut_size))
         }

--- a/tokio/tests/tracing_task.rs
+++ b/tokio/tests/tracing_task.rs
@@ -5,7 +5,7 @@
 #![warn(rust_2018_idioms)]
 #![cfg(all(tokio_unstable, feature = "tracing", target_has_atomic = "64"))]
 
-use std::{mem, time::Duration};
+use std::{future::Future, mem, pin::Pin, time::Duration};
 
 use tokio::task;
 use tracing_mock::{expect, span::NewSpan, subscriber};
@@ -164,11 +164,9 @@ fn task_big_spawn_sizes_recorded() {
             big::<20_000>()
         };
 
-        fn boxed_size<T>(_: &T) -> usize {
-            mem::size_of::<Box<T>>()
-        }
+        // Futures above the threshold are spawned as `Pin<Box<dyn Future + Send>>`.
         let size = mem::size_of_val(&future) as u64;
-        let boxed_size = boxed_size(&future);
+        let boxed_size = mem::size_of::<Pin<Box<dyn Future<Output = ()> + Send>>>();
 
         let task_span = expect::span()
             .named("runtime.spawn")


### PR DESCRIPTION
## Motivation

Split out of #8414 at review's request (https://github.com/tokio-rs/tokio/pull/8414#issuecomment-5568773953). That PR makes the `BOX_FUTURE_THRESHOLD` check a constant so only the taken arm is monomorphized; this one is about what the taken arm boxes *to*.

When a spawned future is larger than `BOX_FUTURE_THRESHOLD`, tokio already `Box::pin`s it. But it boxes to the concrete `Pin<Box<F>>`, which is still a distinct type per future, so the box buys nothing at compile time: a crate that spawns N distinct large futures still instantiates the task harness (`Cell<T, S>::new`, `Harness::poll_inner`/`complete`/`release`, `poll_future`, `RawTask::new`, `OwnedTasks::bind`, the six `catch_unwind` sites and their closures, …) N times per scheduler.

## Change

The boxed arm now boxes to a trait object:

- `Pin<Box<dyn Future<Output = F::Output> + Send>>` for `spawn` / `Handle::spawn` / `Runtime::spawn` / `Builder::spawn*`,
- `Pin<Box<dyn Future<Output = F::Output>>>` for `spawn_local` / `LocalSet` / `LocalRuntime`,
- `Pin<Box<dyn Future<Output = F::Output> + '_>>` for the `block_on`s,
- `Box<dyn FnOnce() -> R + Send>` for `spawn_blocking`.

All large futures with the same `Output` then share one harness instantiation per scheduler.

What does **not** change:

- The allocation. It is the one that was already being made; small futures (the common case) are untouched and stay inline in the task cell.
- The boxing decision, threshold, or anything about cancellation, panics, `JoinHandle`, `Instrumented`, taskdump `Trace::root`, or `LocalSet` ownership — the erasure happens before any of it.
- MSRV. Nothing beyond stable trait objects.

What does change:

- A >threshold future is polled through a vtable instead of a direct call. These are futures of ≥2 KiB (debug) / ≥16 KiB (release) that are already behind a heap pointer, and `#[tokio::main]` / `#[tokio::test]` already erase their body the same way (`Pin<&mut dyn Future>` in tokio-macros), so this is not a new class of indirection in tokio.
- `size.bytes` on the `runtime.spawn` span (`tokio_unstable` + `tracing`) reports the boxed future's size, now a fat pointer (16 bytes on 64-bit) instead of a thin one; `original_size.bytes` is unchanged. `tests/tracing_task.rs::task_big_spawn_sizes_recorded` is updated.

On the "we'd rather not box in release" question (#6057, #6826): this change lives entirely inside the arm that already boxes. If tokio later narrows *when* it boxes, the erasure narrows with it — it never introduces an indirection where the runtime would not already have one.

## Measurement

Same rig as #8414 (`spawnbench`: 300 distinct futures, 150 under / 150 over the debug threshold, `new_multi_thread`, dev profile, rustc 1.97.1, `-Zdump-mono-stats`):

| tokio | mono instantiations | `total_estimate` | `Cell<T,S>::new` | `catch_unwind` | rustc wall |
|---|---|---|---|---|---|
| master | 110,652 | 1,258,468 | 1,200 | 6,000 | 7.31 s |
| + #8414 | 55,833 | 640,682 | 602 | 3,000 | 3.86 s |
| + #8414 + this PR | **28,566 (−49 % vs #8414)** | **333,748 (−48 %)** | 304 | 1,510 | **2.04 s (−47 %)** |

Reading the counts: with #8414, 300 futures × 2 schedulers; with this PR, 150 small futures × 2 schedulers + one erased `dyn Future<Output = ()>` harness per scheduler shared by all 150 large futures. Half the bench futures are over the threshold, so this is the upper end.

On a large internal debug crate (390k lines, ~350 distinct spawned future types, of which 124 (35 %) were over the debug threshold; 16 CGUs, opt-level 0; the crate's rustc action replayed by hand, mono counts deterministic, wall the median of 2–3 runs):

| tokio | mono instantiations | `total_estimate` | `Cell<T,S>::new` | harness family share of `total_estimate` | rustc wall | user CPU |
|---|---|---|---|---|---|---|
| 1.53.1 | 414,028 | 6,727,145 | 1,568 | 24.4 % | 316 s | 478 s |
| + #8414 | 315,288 (−24 %) | 5,589,302 (−17 %) | 784 | 14.8 % | 288 s (−9 %) | 429 s (−10 %) |
| + #8414 + this PR | **287,785 (−8.7 % vs #8414)** | **5,272,838 (−5.7 % vs #8414)** | 564 | 11.4 % | 284 s (within the ±6 s run-to-run noise of #8414) | 416 s (−3 % vs #8414) |

Who this helps: the same crate later moved its own spawns behind a wrapper that boxes every future to `dyn` before handing it to tokio, and on that version this PR is worth only about −1 % of instantiations on top of #8414 — the erasure had already been done by hand. What a user-side wrapper cannot reach is the futures spawned *by dependencies* (HTTP server connection tasks, protocol upgrade tasks, …); in that crate those were the residual, and they are what this PR still collapses. The table above is the effect for a crate that has not done the wrapping itself, which is the typical case.

## Test plan

- `cargo test -p tokio --features full` on this exact revision (rebased on `022c004b`, rustc 1.95): 179 test binaries, **2187 passed, 0 failed**.
- `RUSTFLAGS="--cfg tokio_unstable" cargo test -p tokio --features full,tracing --test tracing_task`: 6 passed (incl. the updated `task_big_spawn_sizes_recorded`).
- `cargo clippy -p tokio --features full -- -D warnings` and `--cfg tokio_unstable --features full,tracing,taskdump`: clean. `cargo fmt --all -- --check`: clean.

## Relationship to #8414

This branch contains #8414's commit as its base (the `AutoBox::<F>::SHOULD_BOX` constant is what makes the boxed arm the only arm compiled for a large `F`); the change under review here is the second commit. I will rebase once #8414 lands.

---

This PR was authored with LLM assistance and measured on a large internal async codebase (numbers above); a maintainer of that codebase reviewed the change and the measurements before publishing.
