### PR TITLE
ci: require a completion marker from the io_uring kernel test guest

### DIFF
--- a/.github/workflows/uring-kernel-version-test.yml
+++ b/.github/workflows/uring-kernel-version-test.yml
@@ -81,6 +81,7 @@ jobs:
           mount -t sysfs sysfs /sys
           mkdir -p /tmp && mount -t tmpfs -o mode=1777 tmpfs /tmp
           for f in /bin/tests/*; do RUST_BACKTRACE=1 "$f" ; done
+          echo "ALL_TESTS_COMPLETED"
           EOF
           chmod +x initramfs/init
 
@@ -94,11 +95,14 @@ jobs:
           set -euo pipefail
 
           set +e
+          # 3 GiB guest (the runner has 16 GB): the initramfs holds ~760 MB of
+          # unstripped test binaries, and `open_many_files` in `fs_uring` had
+          # 200-340 MB of anon RSS when the 1 GiB guest OOM-killed it.
           qemu-system-x86_64 \
             -kernel linux-${{ env.KERNEL_VERSION }}/arch/x86/boot/bzImage \
             -initrd initramfs.cpio.gz \
             -append "console=ttyS0 rootfstype=ramfs panic=1" \
-            -nographic -no-reboot -m 1024 -action panic=exit-failure 2>&1 | tee qemu-output.log
+            -nographic -no-reboot -m 3072 -action panic=exit-failure 2>&1 | tee qemu-output.log
           qemu_status=${PIPESTATUS[0]} tee_status=${PIPESTATUS[1]}
           set -e
 
@@ -115,6 +119,14 @@ jobs:
           if grep -q "test result: FAILED" qemu-output.log; then
             echo "tests reported failures"
             exit 1
-          else
-            echo "all tests passed"
           fi
+
+          # A binary killed before it prints its summary (OOM, panic in init)
+          # never writes `test result: FAILED`, so also require the marker that
+          # init prints after the last binary.
+          if ! grep -q "ALL_TESTS_COMPLETED" qemu-output.log; then
+            echo "tests did not run to completion"
+            exit 1
+          fi
+
+          echo "all tests passed"

--- a/tokio/tests/fs_uring_statx.rs
+++ b/tokio/tests/fs_uring_statx.rs
@@ -158,6 +158,12 @@ async fn stat_permission_denied() {
         return;
     }
 
+    // A 0o244 directory does not stop root, so the EACCES this test expects
+    // never happens when running as root (e.g. in the CI kernel test guest).
+    if unsafe { libc::geteuid() } == 0 {
+        return;
+    }
+
     let dir = tempdir().unwrap();
     let permission_denied_directory_path = dir.path().join("baz");
     create_dir(&permission_denied_directory_path).await.unwrap();

--- a/tokio/tests/fs_uring_statx_fd_leak_test.rs
+++ b/tokio/tests/fs_uring_statx_fd_leak_test.rs
@@ -3,7 +3,11 @@
     feature = "io-uring",
     feature = "rt",
     feature = "fs",
-    target_os = "linux"
+    target_os = "linux",
+    // `tokio::fs::read` only takes the io_uring path on these targets (see the
+    // FIXME in `src/fs/read.rs`); on musl it falls back to `spawn_blocking` and
+    // the poll-count assumptions below do not hold.
+    any(target_env = "gnu", target_os = "android")
 ))]
 
 mod support {


### PR DESCRIPTION
## Motivation

The `Test io_uring on Linux <latest stable>` job greps the QEMU log for `test result: FAILED`, so a test binary that is killed before it prints a summary leaves the job green. On the latest-kernel leg `fs_uring` is OOM-killed in the 1 GiB guest during `open_many_files`, init dies with it, and the ten binaries after it never run (#8433). With enough memory, two tests that had never run on that leg fail, one after the other: `fs_uring_statx::stat_permission_denied`, because the guest runs as root (https://github.com/glaziermag/tokio/actions/runs/34248668864), then `fs_uring_statx_fd_leak_test`, because the guest binaries are musl (https://github.com/glaziermag/tokio/actions/runs/34412513122).

## Solution

The marker alone turns this leg red on master (https://github.com/glaziermag/tokio/actions/runs/34248665407, `tests did not run to completion`); the other three changes make it green again.

- init echoes `ALL_TESTS_COMPLETED` after the last binary and the step fails when the marker is missing, as suggested in #8433. Any early exit of init (OOM, panic, killed binary) now fails the step.
- The guest gets 3 GiB: the initramfs holds ~760 MB of unstripped test binaries, and `open_many_files` had 200–340 MB of anon RSS when the 1 GiB guest killed it. Stripping the binaries instead would shrink the initramfs but lose file:line backtraces.
- `stat_permission_denied` returns early when running as root, the same early return the test already has for `io_uring_supported()`. A `0o244` directory does not stop root, so the `EACCES` the test expects cannot happen there.
- `fs_uring_statx_fd_leak_test` gets the `any(target_env = "gnu", target_os = "android")` cfg of the io_uring branch of `tokio::fs::read` (`src/fs/read.rs`). On musl `read` goes through `spawn_blocking` and is ready on the second poll, so the `assert_pending!` in `PollOpenOnceThenNeverRepoll::poll` panics. The same FIXME cfg gates `fs::try_exists` and the statx op, so on this musl leg neither `read` nor `try_exists` reaches io_uring until it is resolved (MSRV 1.93); this gate should go with it.

Fork runs of the reusable workflow on this commit plus a one-file caller workflow (branch `uring-probe-pr`), both kernel legs, twice: https://github.com/glaziermag/tokio/actions/runs/34416658388 and https://github.com/glaziermag/tokio/actions/runs/34416689494, all green, with 25 test binaries and the marker in the 7.2.4 log. Today's master run (https://github.com/tokio-rs/tokio/actions/runs/34377281108/job/102553852161) shows 15 binaries, `Out of memory: Killed process 176 (fs_uring-1ba693)`, and a green step.

Fixes #8433

I used Claude for the investigation and drafting and reviewed the result myself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
