### PR TITLE
rt: add a dispatch enum for the multi-thread inject queue

### DIFF
--- a/tokio/src/runtime/scheduler/inject.rs
+++ b/tokio/src/runtime/scheduler/inject.rs
@@ -14,6 +14,7 @@ pub(crate) use synced::Synced;
 
 cfg_rt_multi_thread! {
     mod rt_multi_thread;
+    pub(crate) use rt_multi_thread::InjectQueue;
 }
 
 mod metrics;

--- a/tokio/src/runtime/scheduler/inject/rt_multi_thread.rs
+++ b/tokio/src/runtime/scheduler/inject/rt_multi_thread.rs
@@ -4,6 +4,90 @@ use crate::runtime::task;
 
 use std::sync::atomic::Ordering::Release;
 
+/// The multi-thread scheduler's inject queue. Each variant owns its queue and
+/// lock topology.
+pub(crate) enum InjectQueue<T: 'static> {
+    /// A single queue behind a single mutex.
+    Locked(Inject<T>),
+}
+
+impl<T: 'static> InjectQueue<T> {
+    pub(crate) fn new() -> InjectQueue<T> {
+        InjectQueue::Locked(Inject::new())
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        match self {
+            InjectQueue::Locked(q) => q.is_empty(),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            InjectQueue::Locked(q) => q.len(),
+        }
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        match self {
+            InjectQueue::Locked(q) => q.is_closed(),
+        }
+    }
+
+    /// Closes the queue, returns `true` if the queue was open when the
+    /// transition was made.
+    pub(crate) fn close(&self) -> bool {
+        match self {
+            InjectQueue::Locked(q) => q.close(),
+        }
+    }
+
+    /// Pushes a value into the queue.
+    ///
+    /// This does nothing if the queue is closed.
+    pub(crate) fn push(&self, task: task::Notified<T>) {
+        match self {
+            InjectQueue::Locked(q) => q.push(task),
+        }
+    }
+
+    pub(crate) fn pop(&self) -> Option<task::Notified<T>> {
+        match self {
+            InjectQueue::Locked(q) => q.pop(),
+        }
+    }
+
+    /// Pushes several values into the queue.
+    ///
+    /// This does nothing if the queue is closed.
+    pub(crate) fn push_batch<I>(&self, iter: I)
+    where
+        I: Iterator<Item = task::Notified<T>>,
+    {
+        match self {
+            InjectQueue::Locked(q) => q.push_batch(iter),
+        }
+    }
+
+    /// Pops up to `n` values from the queue, passing an iterator over them to
+    /// `f`. Any values `f` does not consume are removed from the queue and
+    /// dropped.
+    pub(crate) fn pop_n<R>(&self, n: usize, f: impl FnOnce(Pop<'_, T>) -> R) -> R {
+        match self {
+            InjectQueue::Locked(q) => q.pop_n(n, f),
+        }
+    }
+
+    /// Pops every task from the queue into `dst`, atomically with respect to
+    /// concurrent pushes.
+    #[cfg(all(tokio_unstable, feature = "taskdump"))]
+    pub(crate) fn drain_into(&self, dst: &mut Vec<task::Notified<T>>) {
+        match self {
+            InjectQueue::Locked(q) => q.drain_into(dst),
+        }
+    }
+}
+
 impl<T: 'static> Inject<T> {
     pub(crate) fn is_empty(&self) -> bool {
         self.shared.is_empty()

--- a/tokio/src/runtime/scheduler/multi_thread/worker.rs
+++ b/tokio/src/runtime/scheduler/multi_thread/worker.rs
@@ -61,7 +61,7 @@ use crate::runtime;
 use crate::runtime::scheduler::multi_thread::{
     idle, park, queue, Counters, Handle, Idle, Overflow, Parker, Stats, TraceStatus, Unparker,
 };
-use crate::runtime::scheduler::{Defer, Inject};
+use crate::runtime::scheduler::{inject::InjectQueue, Defer};
 use crate::runtime::task::OwnedTasks;
 use crate::runtime::{
     blocking, driver, scheduler, task, Config, SchedulerMetrics, TimerFlavor, WorkerMetrics,
@@ -175,7 +175,7 @@ pub(crate) struct Shared {
     /// Global task queue used for:
     ///  1. Submit work to the scheduler while **not** currently on a worker thread.
     ///  2. Submit work to the scheduler when a worker run queue is saturated
-    pub(super) inject: Inject<Arc<Handle>>,
+    pub(super) inject: InjectQueue<Arc<Handle>>,
 
     /// Coordinates idle workers
     idle: Idle,
@@ -323,7 +323,7 @@ pub(super) fn create(
         task_hooks: TaskHooks::from_config(&config),
         shared: Shared {
             remotes: remotes.into_boxed_slice(),
-            inject: Inject::new(),
+            inject: InjectQueue::new(),
             idle,
             owned: OwnedTasks::new(size),
             synced: Mutex::new(Synced {
@@ -1344,7 +1344,7 @@ impl Core {
 
 impl Worker {
     /// Returns a reference to the scheduler's injection queue.
-    fn inject(&self) -> &Inject<Arc<Handle>> {
+    fn inject(&self) -> &InjectQueue<Arc<Handle>> {
         &self.handle.shared.inject
     }
 }

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -386,13 +386,14 @@ pub(in crate::runtime) fn trace_current_thread(
 }
 
 cfg_rt_multi_thread! {
+    use crate::runtime::scheduler::inject::InjectQueue;
     use crate::runtime::scheduler::multi_thread;
 
     /// Trace and poll all tasks of the `multi_thread` runtime.
     pub(in crate::runtime) fn trace_multi_thread(
         owned: &OwnedTasks<Arc<multi_thread::Handle>>,
         local: &mut multi_thread::queue::Local<Arc<multi_thread::Handle>>,
-        injection: &Inject<Arc<multi_thread::Handle>>,
+        injection: &InjectQueue<Arc<multi_thread::Handle>>,
     ) -> Vec<(Id, Trace)> {
         let mut dequeued = Vec::new();
 


### PR DESCRIPTION
`InjectQueue` has a single `Locked` variant wrapping the existing implementation, and each operation dispatches to a variant method that performs the entire operation. This gives an alternative sharded implementation a symmetric slot to fill, following the pattern from #8135.

This is a step towards #7973.
