### PR TITLE
net: start `UnixStream::pair` and `UnixDatagram::pair` sockets as writable

### DIFF
--- a/tokio/src/net/unix/datagram/socket.rs
+++ b/tokio/src/net/unix/datagram/socket.rs
@@ -434,6 +434,10 @@ impl UnixDatagram {
         let (a, b) = mio::net::UnixDatagram::pair()?;
         let a = UnixDatagram::new(a)?;
         let b = UnixDatagram::new(b)?;
+        // A fresh pair has empty buffers: writable now, readable only once
+        // the peer sends.
+        a.io.registration().assume_ready(Ready::WRITABLE);
+        b.io.registration().assume_ready(Ready::WRITABLE);
 
         Ok((a, b))
     }

--- a/tokio/src/net/unix/stream.rs
+++ b/tokio/src/net/unix/stream.rs
@@ -914,6 +914,10 @@ impl UnixStream {
         let (a, b) = mio::net::UnixStream::pair()?;
         let a = UnixStream::new(a)?;
         let b = UnixStream::new(b)?;
+        // A fresh pair has empty buffers: writable now, readable only once
+        // the peer writes.
+        a.io.registration().assume_ready(Ready::WRITABLE);
+        b.io.registration().assume_ready(Ready::WRITABLE);
 
         Ok((a, b))
     }

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -105,10 +105,11 @@ impl Registration {
     }
 
     /// Marks the resource ready without waiting for the driver's first event.
-    /// Used for accepted sockets, which are writable and usually already hold
-    /// the peer's first bytes; under load that first event can queue behind
-    /// every established connection's events. A wrong guess costs one
-    /// `WouldBlock`, which clears the readiness again.
+    /// Used for sockets whose state is known when they are created: accepted
+    /// sockets are writable and usually already hold the peer's first bytes
+    /// (under load that first event can queue behind every established
+    /// connection's events), and both ends of a fresh `pair()` are writable.
+    /// A wrong guess costs one `WouldBlock`, which clears the readiness again.
     #[cfg(feature = "net")]
     pub(crate) fn assume_ready(&self, ready: crate::io::Ready) {
         self.shared.assume_ready(ready);

--- a/tokio/tests/uds_datagram.rs
+++ b/tokio/tests/uds_datagram.rs
@@ -9,6 +9,7 @@ use tokio::try_join;
 use std::future::poll_fn;
 use std::io;
 use std::sync::Arc;
+use std::task::Poll;
 
 async fn echo_server(socket: UnixDatagram) -> io::Result<()> {
     let mut recv_buf = vec![0u8; 1024];
@@ -421,5 +422,36 @@ async fn poll_ready() -> io::Result<()> {
         }
     }
 
+    Ok(())
+}
+
+// Both ends of a fresh pair are writable without a driver event, but not
+// readable until the peer sends.
+#[tokio::test(flavor = "current_thread")]
+#[cfg_attr(miri, ignore)] // No SOCK_DGRAM for `socketpair` in miri.
+async fn pair_starts_writable() -> io::Result<()> {
+    let (a, b) = UnixDatagram::pair()?;
+
+    // Nothing has polled the driver since `pair()`.
+    assert!(poll_fn(|cx| Poll::Ready(a.poll_send_ready(cx)))
+        .await
+        .is_ready());
+    a.try_send(b"hi")?;
+    b.try_send(b"yo")?;
+
+    let (c, _d) = UnixDatagram::pair()?;
+    assert!(poll_fn(|cx| Poll::Ready(c.poll_recv_ready(cx)))
+        .await
+        .is_pending());
+    assert_eq!(
+        c.try_recv(&mut [0u8; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    // The peer's datagram still arrives through the normal event path.
+    a.readable().await?;
+    let mut buf = [0u8; 8];
+    assert_eq!(a.try_recv(&mut buf)?, 2);
+    assert_eq!(&buf[..2], b"yo");
     Ok(())
 }

--- a/tokio/tests/uds_stream.rs
+++ b/tokio/tests/uds_stream.rs
@@ -490,3 +490,31 @@ async fn abstract_socket_name() {
     // `as_abstract_name` removes leading zero bytes
     assert_eq!(abstract_path_name, b"aaa");
 }
+
+// Both ends of a fresh pair are writable without a driver event, but not
+// readable until the peer writes.
+#[tokio::test(flavor = "current_thread")]
+async fn pair_starts_writable() -> io::Result<()> {
+    let (a, mut b) = UnixStream::pair()?;
+
+    // Nothing has polled the driver since `pair()`.
+    let mut writable = task::spawn(a.writable());
+    assert_ready_ok!(writable.poll());
+    assert_eq!(a.try_write(b"hi")?, 2);
+    let mut write = task::spawn(b.write_all(b"yo"));
+    assert_ready_ok!(write.poll());
+    drop(write);
+
+    let (c, _d) = UnixStream::pair()?;
+    let mut readable = task::spawn(c.readable());
+    assert_pending!(readable.poll());
+    assert_eq!(
+        c.try_read(&mut [0u8; 1]).unwrap_err().kind(),
+        io::ErrorKind::WouldBlock
+    );
+
+    // The peer's bytes still arrive through the normal event path.
+    a.readable().await?;
+    assert_eq!(a.try_read(&mut [0u8; 8])?, 2);
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Follow-up to #8435 (suggested in https://github.com/tokio-rs/tokio/pull/8435#discussion_r3980578864). Both ends of a fresh `socketpair` have empty buffers: they are writable immediately and readable only once the peer writes, but today the first `write`/`send` waits for the I/O driver to deliver the socket's first event.

## Solution

Mark both ends `WRITABLE` (not `READABLE`) via `Registration::assume_ready` in `UnixStream::pair()` and `UnixDatagram::pair()`. As with accepted sockets, readiness may be a false positive; a wrong guess costs one `WouldBlock`, which clears the bit.

Tests: `uds_stream::pair_starts_writable` and `uds_datagram::pair_starts_writable` run on a current-thread runtime with no driver turn since `pair()` and check that `writable()` / `poll_send_ready` are ready and the first write/send succeeds on both ends, that the read side is still not ready, and that the peer's data then arrives through the normal event path. Both fail on master.
