### PR TITLE
fix(taskdump): restore deferred leaf wakes during capture

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -606,7 +606,7 @@ impl AsyncRead for File {
         cx: &mut Context<'_>,
         dst: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
 
         let me = self.get_mut();
         let inner = me.inner.get_mut();
@@ -706,7 +706,7 @@ impl AsyncSeek for File {
     }
 
     fn poll_complete(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         let inner = self.inner.get_mut();
 
         loop {
@@ -747,7 +747,7 @@ impl AsyncWrite for File {
         cx: &mut Context<'_>,
         src: &[u8],
     ) -> Poll<io::Result<usize>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
@@ -827,7 +827,7 @@ impl AsyncWrite for File {
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         let me = self.get_mut();
         let inner = me.inner.get_mut();
 
@@ -907,13 +907,13 @@ impl AsyncWrite for File {
     }
 
     fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         let inner = self.inner.get_mut();
         inner.poll_flush(cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         self.poll_flush(cx)
     }
 }
@@ -1125,7 +1125,7 @@ impl Inner {
     }
 
     fn poll_complete_inflight(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         match self.poll_flush(cx) {
             Poll::Ready(Err(e)) => {
                 self.last_write_err = Some(e.kind());

--- a/tokio/src/io/util/copy.rs
+++ b/tokio/src/io/util/copy.rs
@@ -82,7 +82,7 @@ impl CopyBuffer {
         R: AsyncRead + ?Sized,
         W: AsyncWrite + ?Sized,
     {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         #[cfg(any(
             feature = "fs",
             feature = "io-std",

--- a/tokio/src/io/util/empty.rs
+++ b/tokio/src/io/util/empty.rs
@@ -71,7 +71,7 @@ impl AsyncRead for Empty {
         cx: &mut Context<'_>,
         _: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
@@ -80,7 +80,7 @@ impl AsyncRead for Empty {
 impl AsyncBufRead for Empty {
     #[inline]
     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<&[u8]>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(&[]))
     }
@@ -96,21 +96,21 @@ impl AsyncWrite for Empty {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<io::Result<usize>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(buf.len()))
     }
 
     #[inline]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
 
     #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
@@ -126,7 +126,7 @@ impl AsyncWrite for Empty {
         cx: &mut Context<'_>,
         bufs: &[io::IoSlice<'_>],
     ) -> Poll<Result<usize, io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         let num_bytes = bufs.iter().map(|b| b.len()).sum();
         Poll::Ready(Ok(num_bytes))
@@ -141,7 +141,7 @@ impl AsyncSeek for Empty {
 
     #[inline]
     fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<u64>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(0))
     }

--- a/tokio/src/io/util/mem.rs
+++ b/tokio/src/io/util/mem.rs
@@ -359,7 +359,7 @@ impl AsyncRead for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<std::io::Result<()>> {
-            ready!(crate::trace::trace_leaf());
+            ready!(crate::trace::trace_leaf(cx));
             let coop = ready!(crate::task::coop::poll_proceed(cx));
 
             let ret = self.poll_read_internal(cx, buf);
@@ -376,7 +376,7 @@ impl AsyncRead for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<std::io::Result<()>> {
-            ready!(crate::trace::trace_leaf());
+            ready!(crate::trace::trace_leaf(cx));
             self.poll_read_internal(cx, buf)
         }
     }
@@ -389,7 +389,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &[u8],
         ) -> Poll<std::io::Result<usize>> {
-            ready!(crate::trace::trace_leaf());
+            ready!(crate::trace::trace_leaf(cx));
             let coop = ready!(crate::task::coop::poll_proceed(cx));
 
             let ret = self.poll_write_internal(cx, buf);
@@ -406,7 +406,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             buf: &[u8],
         ) -> Poll<std::io::Result<usize>> {
-            ready!(crate::trace::trace_leaf());
+            ready!(crate::trace::trace_leaf(cx));
             self.poll_write_internal(cx, buf)
         }
     }
@@ -417,7 +417,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             bufs: &[std::io::IoSlice<'_>],
         ) -> Poll<Result<usize, std::io::Error>> {
-            ready!(crate::trace::trace_leaf());
+            ready!(crate::trace::trace_leaf(cx));
             let coop = ready!(crate::task::coop::poll_proceed(cx));
 
             let ret = self.poll_write_vectored_internal(cx, bufs);
@@ -434,7 +434,7 @@ impl AsyncWrite for SimplexStream {
             cx: &mut task::Context<'_>,
             bufs: &[std::io::IoSlice<'_>],
         ) -> Poll<Result<usize, std::io::Error>> {
-            ready!(crate::trace::trace_leaf());
+            ready!(crate::trace::trace_leaf(cx));
             self.poll_write_vectored_internal(cx, bufs)
         }
     }

--- a/tokio/src/io/util/repeat.rs
+++ b/tokio/src/io/util/repeat.rs
@@ -56,7 +56,7 @@ impl AsyncRead for Repeat {
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         buf.put_bytes(self.byte, buf.remaining());
         Poll::Ready(Ok(()))

--- a/tokio/src/io/util/sink.rs
+++ b/tokio/src/io/util/sink.rs
@@ -57,21 +57,21 @@ impl AsyncWrite for Sink {
         cx: &mut Context<'_>,
         buf: &[u8],
     ) -> Poll<Result<usize, io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(buf.len()))
     }
 
     #[inline]
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }
 
     #[inline]
     fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         ready!(poll_proceed_and_make_progress(cx));
         Poll::Ready(Ok(()))
     }

--- a/tokio/src/lib.rs
+++ b/tokio/src/lib.rs
@@ -620,14 +620,14 @@ mod trace {
     cfg_not_taskdump! {
         #[inline(always)]
         #[allow(dead_code)]
-        pub(crate) fn trace_leaf() -> std::task::Poll<()> {
+        pub(crate) fn trace_leaf(_: &mut std::task::Context<'_>) -> std::task::Poll<()> {
             std::task::Poll::Ready(())
         }
     }
 
     #[cfg_attr(not(feature = "sync"), allow(dead_code))]
     pub(crate) async fn async_trace_leaf() {
-        std::future::poll_fn(|_cx| trace_leaf()).await
+        std::future::poll_fn(trace_leaf).await
     }
 }
 

--- a/tokio/src/process/mod.rs
+++ b/tokio/src/process/mod.rs
@@ -1135,7 +1135,7 @@ where
     type Output = Result<T, E>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 

--- a/tokio/src/runtime/dump.rs
+++ b/tokio/src/runtime/dump.rs
@@ -226,11 +226,13 @@ impl Trace {
     /// Also see [`Handle::dump`] for more documentation about dumps, but unlike [`Handle::dump`], this function
     /// should not be much slower than calling `f` directly.
     ///
-    /// Due to the way tracing is implemented, Tokio leaf futures will usually, instead of doing their
-    /// actual work, return `Poll::Pending` without registering the task's waker with any driver.
-    /// This means forward progress will probably not happen unless you eventually call your future
-    /// outside of `capture`, or explicitly re-schedule the task (e.g. by calling
-    /// [`cx.waker().wake_by_ref()`][std::task::Waker::wake_by_ref]) after `capture` returns.
+    /// Due to the way tracing is implemented, Tokio leaf futures return `Poll::Pending` at captured
+    /// yield points instead of doing their actual work. When running on a Tokio scheduler, each
+    /// captured leaf's waker is deferred until the scheduler regains control, so that the future
+    /// can be polled again.
+    ///
+    /// The future must be polled outside of `capture` to make progress. Capturing on every poll can
+    /// cause a wake-and-capture loop even when the future has no work to do.
     ///
     /// [`Handle::dump`]: crate::runtime::Handle::dump
     ///

--- a/tokio/src/runtime/io/registration.rs
+++ b/tokio/src/runtime/io/registration.rs
@@ -146,7 +146,7 @@ impl Registration {
         cx: &mut Context<'_>,
         direction: Direction,
     ) -> Poll<io::Result<ReadyEvent>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
         let ev = ready!(self.shared.poll_readiness(cx, direction));

--- a/tokio/src/runtime/task/join.rs
+++ b/tokio/src/runtime/task/join.rs
@@ -325,7 +325,7 @@ impl<T> Future for JoinHandle<T> {
     type Output = super::Result<T>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         let mut ret = Poll::Pending;
 
         // Keep track of task budget

--- a/tokio/src/runtime/task/mod.rs
+++ b/tokio/src/runtime/task/mod.rs
@@ -522,15 +522,6 @@ impl<S: Schedule> LocalNotified<S> {
         mem::forget(self);
         raw.poll();
     }
-
-    cfg_taskdump! {
-        /// Returns a `WakerRef` borrowing from this task.
-        ///
-        /// `WakerRef` derefs to `Waker` without bumping the task's refcount.
-        pub(crate) fn waker_ref(&self) -> waker::WakerRef<'_, S> {
-            waker::waker_ref::<S>(self.task.raw.header_ptr_ref())
-        }
-    }
 }
 
 impl<S: Schedule> UnownedTask<S> {

--- a/tokio/src/runtime/task/raw.rs
+++ b/tokio/src/runtime/task/raw.rs
@@ -242,12 +242,6 @@ impl RawTask {
         self.ptr
     }
 
-    cfg_taskdump! {
-        pub(super) fn header_ptr_ref(&self) -> &NonNull<Header> {
-            &self.ptr
-        }
-    }
-
     pub(super) fn trailer_ptr(&self) -> NonNull<Trailer> {
         unsafe { Header::get_trailer(self.ptr) }
     }

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -170,11 +170,16 @@ pub struct TraceMeta {
     pub trace_leaf_addr: *const c_void,
 }
 
-/// Runs `f`. If `f` hits a Tokio yield point `trace_leaf` will be invoked.
+/// Runs `f`. If `f` hits a Tokio yield point, the `trace_leaf` callback will be invoked.
 ///
-/// This allows taking a task dump with caller-provided task dump machinery. If `f` is the poll
-/// function of a future and that future returns `Poll::Pending`, then `trace_leaf` will be
-/// invoked. `trace_leaf` can then take a backtrace to determine exactly where the yield occurred.
+/// This allows taking a task dump with caller-provided task dump machinery. At each Tokio yield
+/// point reached while polling a future, `trace_leaf` can take a backtrace. The leaf future then
+/// returns `Poll::Pending` instead of performing its normal work.
+///
+/// When running on a Tokio scheduler, each captured leaf's waker is deferred until the scheduler
+/// regains control, so that the future can be polled again. The future must be polled outside of
+/// `trace_with` to make progress. Capturing on every poll can cause a wake-and-capture loop even
+/// when the future has no work to do.
 ///
 /// # Example
 ///
@@ -283,12 +288,10 @@ impl Trace {
     }
 }
 
-/// If this is a sub-invocation of [`trace_with`], capture a backtrace.
+/// If this is a sub-invocation of [`trace_with`], invoke its callback, defer a wake,
+/// and return `Poll::Pending`.
 ///
-/// The captured backtrace will be returned by [`trace_with`].
-///
-/// Invoking this function does nothing when it is not a sub-invocation
-/// [`trace_with`].
+/// Otherwise, return `Poll::Ready(())` without waking the future.
 // This function is marked `#[inline(never)]` to ensure that it gets a distinct `Frame` in the
 // backtrace, below which frames should not be included in the backtrace (since they reflect the
 // internal implementation details of this crate).

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -293,7 +293,7 @@ impl Trace {
 // backtrace, below which frames should not be included in the backtrace (since they reflect the
 // internal implementation details of this crate).
 #[inline(never)]
-pub(crate) fn trace_leaf() -> Poll<()> {
+pub(crate) fn trace_leaf(_cx: &mut task::Context<'_>) -> Poll<()> {
     let root_addr = Context::current_frame_addr();
 
     let ret = Context::try_with_current_trace_leaf_fn(|leaf_fn| {

--- a/tokio/src/runtime/task/trace/mod.rs
+++ b/tokio/src/runtime/task/trace/mod.rs
@@ -293,7 +293,7 @@ impl Trace {
 // backtrace, below which frames should not be included in the backtrace (since they reflect the
 // internal implementation details of this crate).
 #[inline(never)]
-pub(crate) fn trace_leaf(_cx: &mut task::Context<'_>) -> Poll<()> {
+pub(crate) fn trace_leaf(cx: &mut task::Context<'_>) -> Poll<()> {
     let root_addr = Context::current_frame_addr();
 
     let ret = Context::try_with_current_trace_leaf_fn(|leaf_fn| {
@@ -302,6 +302,19 @@ pub(crate) fn trace_leaf(_cx: &mut task::Context<'_>) -> Poll<()> {
             trace_leaf_addr: trace_leaf as *const c_void,
         };
         leaf_fn(&meta);
+
+        // Wake the leaf, not just the enclosing Tokio task: sub-executors may
+        // only poll children whose own wakers have fired. As with `yield_now`,
+        // defer the wake until the scheduler regains control.
+        context::with_scheduler(|scheduler| {
+            if let Some(scheduler) = scheduler {
+                match scheduler {
+                    scheduler::Context::CurrentThread(s) => s.defer.defer(cx.waker()),
+                    #[cfg(feature = "rt-multi-thread")]
+                    scheduler::Context::MultiThread(s) => s.defer.defer(cx.waker()),
+                }
+            }
+        });
     });
 
     match ret {
@@ -437,26 +450,6 @@ fn trace_owned<S: Schedule>(owned: &OwnedTasks<S>, dequeued: Vec<Notified<S>>) -
         .map(|task| {
             let local_notified = owned.assert_owner(task);
             let id = local_notified.task.id();
-
-            // Re-enqueue the task's waker on the scheduler's defer queue so
-            // the task is polled again after the dump completes. This is the
-            // same mechanism `yield_now` uses; the defer queue is drained
-            // after `trace_current_thread` / `trace_multi_thread` returns.
-            //
-            // We do this before polling so the borrow of the task ends before
-            // the `LocalNotified` is consumed in `run()`. `defer` clones the
-            // waker into its own queue, so the deferred entry outlives the
-            // `WakerRef` here.
-            let waker_ref = local_notified.waker_ref();
-            context::with_scheduler(|scheduler| {
-                if let Some(scheduler) = scheduler {
-                    match scheduler {
-                        scheduler::Context::CurrentThread(s) => s.defer.defer(&waker_ref),
-                        #[cfg(feature = "rt-multi-thread")]
-                        scheduler::Context::MultiThread(s) => s.defer.defer(&waker_ref),
-                    }
-                }
-            });
 
             let ((), trace) = Trace::capture(|| local_notified.run());
             (id, trace)

--- a/tokio/src/runtime/task/waker.rs
+++ b/tokio/src/runtime/task/waker.rs
@@ -6,7 +6,7 @@ use std::ops;
 use std::ptr::NonNull;
 use std::task::{RawWaker, RawWakerVTable, Waker};
 
-pub(crate) struct WakerRef<'a, S: 'static> {
+pub(super) struct WakerRef<'a, S: 'static> {
     waker: ManuallyDrop<Waker>,
     _p: PhantomData<(&'a Header, S)>,
 }

--- a/tokio/src/sync/batch_semaphore.rs
+++ b/tokio/src/sync/batch_semaphore.rs
@@ -576,7 +576,7 @@ impl Future for Acquire<'_> {
     type Output = Result<(), AcquireError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         let _resource_span = self.node.ctx.resource_span.clone().entered();

--- a/tokio/src/sync/broadcast.rs
+++ b/tokio/src/sync/broadcast.rs
@@ -1644,7 +1644,7 @@ where
     type Output = Result<T, RecvError>;
 
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
 
         let (receiver, waiter) = self.project();
 

--- a/tokio/src/sync/mpsc/chan.rs
+++ b/tokio/src/sync/mpsc/chan.rs
@@ -289,7 +289,7 @@ impl<T, S: Semaphore> Rx<T, S> {
     pub(crate) fn recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         use super::block::Read;
 
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
 
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
@@ -349,7 +349,7 @@ impl<T, S: Semaphore> Rx<T, S> {
     ) -> Poll<usize> {
         use super::block::Read;
 
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
 
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));

--- a/tokio/src/sync/notify.rs
+++ b/tokio/src/sync/notify.rs
@@ -1224,8 +1224,9 @@ impl NotifiedProject<'_> {
                 }
                 State::Waiting => {
                     #[cfg(all(tokio_unstable, feature = "taskdump"))]
-                    if let Some(_waker) = waker {
-                        std::task::ready!(crate::trace::trace_leaf());
+                    if let Some(waker) = waker {
+                        let mut cx = Context::from_waker(waker);
+                        std::task::ready!(crate::trace::trace_leaf(&mut cx));
                     }
 
                     if waiter.notification.load(Acquire).is_some() {
@@ -1317,8 +1318,9 @@ impl NotifiedProject<'_> {
                 }
                 State::Done => {
                     #[cfg(all(tokio_unstable, feature = "taskdump"))]
-                    if let Some(_waker) = waker {
-                        std::task::ready!(crate::trace::trace_leaf());
+                    if let Some(waker) = waker {
+                        let mut cx = Context::from_waker(waker);
+                        std::task::ready!(crate::trace::trace_leaf(&mut cx));
                     }
                     return Poll::Ready(());
                 }

--- a/tokio/src/sync/oneshot.rs
+++ b/tokio/src/sync/oneshot.rs
@@ -818,7 +818,7 @@ impl<T> Sender<T> {
     /// # }
     /// ```
     pub fn poll_closed(&mut self, cx: &mut Context<'_>) -> Poll<()> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
 
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
@@ -1315,7 +1315,7 @@ impl<T> Inner<T> {
     }
 
     fn poll_recv(&self, cx: &mut Context<'_>) -> Poll<Result<T, RecvError>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         // Keep track of task budget
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 

--- a/tokio/src/task/coop/consume_budget.rs
+++ b/tokio/src/task/coop/consume_budget.rs
@@ -26,7 +26,7 @@ pub async fn consume_budget() {
     let mut status = std::task::Poll::Pending;
 
     std::future::poll_fn(move |cx| {
-        std::task::ready!(crate::trace::trace_leaf());
+        std::task::ready!(crate::trace::trace_leaf(cx));
         if status.is_ready() {
             return status;
         }

--- a/tokio/src/task/yield_now.rs
+++ b/tokio/src/task/yield_now.rs
@@ -38,7 +38,7 @@ use std::task::{ready, Poll};
 pub async fn yield_now() {
     let mut yielded = false;
     poll_fn(|cx| {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
 
         if yielded {
             return Poll::Ready(());

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -381,7 +381,7 @@ impl Sleep {
     }
 
     fn poll_elapsed(self: Pin<&mut Self>, cx: &mut task::Context<'_>) -> Poll<Result<(), Error>> {
-        ready!(crate::trace::trace_leaf());
+        ready!(crate::trace::trace_leaf(cx));
         let mut this = self.project();
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -66,10 +66,6 @@ impl<F: Future> Future for PrettyFuture<F> {
             let (res, trace) = tokio::runtime::dump::Trace::capture(|| this.f.as_mut().poll(cx));
             this.logs.lock().unwrap().push(trace);
             *this.t_last = State::Alerted;
-            // `Trace::capture` does not reschedule the task. Wake the task
-            // ourselves so the wrapped future gets polled again and can make
-            // progress now that tracing has captured its state.
-            cx.waker().wake_by_ref();
             return res;
         }
         this.f.poll(cx)
@@ -168,13 +164,14 @@ fn strip_symbol_hash(s: &str) -> &str {
 }
 
 pin_project_lite::pin_project! {
-    /// A future wrapper that uses `trace_with` to capture a backtrace on every
-    /// poll.
+    /// A future wrapper that uses `trace_with` to capture backtraces, skipping
+    /// capture on the poll immediately following a capture-induced wake.
     /// The captured backtraces are stored in `logs`.
     pub struct TaskDump<F: Future> {
         #[pin]
         f: Root<F>,
         logs: Arc<Mutex<Vec<Vec<String>>>>,
+        just_captured: bool,
     }
 }
 
@@ -183,6 +180,7 @@ impl<F: Future> TaskDump<F> {
         TaskDump {
             f: Trace::root(f),
             logs,
+            just_captured: false,
         }
     }
 }
@@ -197,6 +195,12 @@ impl<F: Future> Future for TaskDump<F> {
         if let Poll::Ready(result) = this.f.as_mut().poll(cx) {
             return Poll::Ready(result);
         };
+
+        // Let the capture-induced wake register normal waiters without
+        // immediately capturing again and scheduling yet another wake.
+        if std::mem::take(this.just_captured) {
+            return Poll::Pending;
+        }
 
         // if is pending, trace its location:
         let mut logs = Vec::new();
@@ -213,6 +217,7 @@ impl<F: Future> Future for TaskDump<F> {
 
         // Drain any frames captured by trace_leaf_for_test into our log.
         this.logs.lock().unwrap().extend(logs);
+        *this.just_captured = true;
         Poll::Pending
     }
 }
@@ -276,4 +281,24 @@ async fn trace_with_callback_and_backtrace() {
             "expected frame containing {expected:?}, got {actual:?}\nfull trace:\n{trace:#?}"
         );
     }
+}
+
+#[tokio::test]
+async fn trace_with_wrapper_does_not_recapture_its_wake() {
+    let (sender, receiver) = tokio::sync::oneshot::channel();
+    let logs = Arc::new(Mutex::new(vec![]));
+    let mut task = tokio_test::task::spawn(TaskDump::new(receiver, logs.clone()));
+
+    assert!(task.poll().is_pending());
+    tokio::task::yield_now().await;
+    assert!(task.is_woken());
+
+    assert!(task.poll().is_pending());
+    tokio::task::yield_now().await;
+    assert!(!task.is_woken());
+    assert_eq!(logs.lock().unwrap().len(), 1);
+
+    sender.send(42).unwrap();
+    assert!(task.is_woken());
+    assert_eq!(task.poll(), Poll::Ready(Ok(42)));
 }

--- a/tokio/tests/task_trace_self.rs
+++ b/tokio/tests/task_trace_self.rs
@@ -165,7 +165,7 @@ fn strip_symbol_hash(s: &str) -> &str {
 
 pin_project_lite::pin_project! {
     /// A future wrapper that uses `trace_with` to capture backtraces, skipping
-    /// capture on the poll immediately following a capture-induced wake.
+    /// capture on the poll immediately following each capture.
     /// The captured backtraces are stored in `logs`.
     pub struct TaskDump<F: Future> {
         #[pin]
@@ -196,8 +196,8 @@ impl<F: Future> Future for TaskDump<F> {
             return Poll::Ready(result);
         };
 
-        // Let the capture-induced wake register normal waiters without
-        // immediately capturing again and scheduling yet another wake.
+        // Skip capture on the next poll so capture-induced wakes do not
+        // cause a wake-and-capture loop.
         if std::mem::take(this.just_captured) {
             return Poll::Pending;
         }
@@ -209,7 +209,7 @@ impl<F: Future> Future for TaskDump<F> {
             || this.f.as_mut().poll(cx),
             |meta| trace_leaf_for_test(meta, &mut logs),
         );
-        // trace should always produce poll pending
+        // The futures used in these tests remain pending during capture.
         assert!(
             matches!(trace_poll, Poll::Pending),
             "expected trace to produce Poll::Pending but it was ready"

--- a/tokio/tests/task_trace_wake.rs
+++ b/tokio/tests/task_trace_wake.rs
@@ -14,12 +14,16 @@
 ))]
 
 use std::future::Future;
-use std::task::Poll;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
 
 use futures::future::{join_all, select_all};
 use futures::stream::{self, FuturesUnordered, StreamExt};
+use futures::FutureExt;
 use tokio::runtime::dump::{trace_with, Trace};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, Mutex, Semaphore};
 use tokio::task::{yield_now, JoinSet};
 use tokio_test::task::{self, Spawn};
 
@@ -138,6 +142,100 @@ async fn trace_with_futures_unordered() {
     let mut results = trace_after_wake(future, make_ready).await;
     results.sort_unstable_by_key(|result| *result.as_ref().unwrap());
     assert_eq!(results, vec![Ok(0), Ok(1)]);
+}
+
+#[tokio::test]
+async fn trace_with_futures_unordered_mutex_handoff() {
+    // The reproduction from #8434: count parent wakes, but poll the actor by hand.
+    struct CountingWaker(AtomicUsize);
+
+    impl Wake for CountingWaker {
+        fn wake(self: Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn wake_by_ref(self: &Arc<Self>) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    let mutex = Arc::new(Mutex::new(()));
+    // Keep 4 from the issue's repro; any valid positive count would ensure permits are available.
+    let sem = Arc::new(Semaphore::new(4));
+    // Use futures::channel::oneshot, not tokio::sync::oneshot: Tokio's receiver
+    // would stop at trace_leaf during capture, before A could release the mutex to B.
+    let (tx, rx) = futures::channel::oneshot::channel::<()>();
+    let done_a = Arc::new(AtomicBool::new(false));
+    let done_b = Arc::new(AtomicBool::new(false));
+
+    // A holds the mutex from the start, so poll order does not matter.
+    let guard = mutex.clone().try_lock_owned().expect("fresh mutex");
+    let child_a = {
+        let (sem, done) = (sem.clone(), done_a.clone());
+        async move {
+            rx.await.expect("completion arrives");
+            drop(guard);
+            let _permit = sem.acquire().await.unwrap();
+            done.store(true, Ordering::SeqCst);
+        }
+    };
+    let child_b = {
+        let (mutex, done) = (mutex.clone(), done_b.clone());
+        async move {
+            let _g = mutex.lock().await;
+            done.store(true, Ordering::SeqCst);
+        }
+    };
+    let actor = async move {
+        let mut set = FuturesUnordered::new();
+        set.push(child_a.boxed());
+        set.push(child_b.boxed());
+        while set.next().await.is_some() {}
+    };
+    let mut actor: Pin<Box<dyn Future<Output = ()>>> = Box::pin(actor);
+
+    let wakes = Arc::new(CountingWaker(AtomicUsize::new(0)));
+    let waker = Waker::from(wakes.clone());
+    let mut cx = Context::from_waker(&waker);
+
+    // A waits for the completion; B registers as a mutex waiter.
+    assert!(actor.as_mut().poll(&mut cx).is_pending());
+
+    // Deliver the completion from another thread before the capture poll.
+    std::thread::spawn(move || tx.send(()).unwrap())
+        .join()
+        .unwrap();
+
+    // A releases the mutex to B, then both stop at their Tokio leaves.
+    let mut leaves = 0;
+    assert!(trace_with(|| actor.as_mut().poll(&mut cx), |_| leaves += 1).is_pending());
+    assert_eq!(leaves, 2);
+    assert!(!done_a.load(Ordering::SeqCst));
+    assert!(!done_b.load(Ordering::SeqCst));
+    assert!(mutex.try_lock().is_err());
+    assert_eq!(sem.available_permits(), 4);
+
+    // Even repeated parent polls cannot recover a lost child wake. Yield
+    // between polls so Tokio can drain the deferred-wake queue.
+    for _ in 0..50 {
+        if actor.as_mut().poll(&mut cx).is_ready() {
+            assert!(done_a.load(Ordering::SeqCst));
+            assert!(done_b.load(Ordering::SeqCst));
+            assert!(mutex.try_lock().is_ok());
+            assert_eq!(sem.available_permits(), 4);
+            return;
+        }
+        yield_now().await;
+    }
+
+    panic!(
+        "stranded after 50 polls: done_a={} done_b={} mutex_locked={} sem_permits={} task_wakes={}",
+        done_a.load(Ordering::SeqCst),
+        done_b.load(Ordering::SeqCst),
+        mutex.try_lock().is_err(),
+        sem.available_permits(),
+        wakes.0.load(Ordering::SeqCst),
+    );
 }
 
 #[tokio::test]

--- a/tokio/tests/task_trace_wake.rs
+++ b/tokio/tests/task_trace_wake.rs
@@ -1,0 +1,177 @@
+//! Regression tests for #8434: task-dump capture must not strand
+//! notified children in sub-executors.
+
+#![cfg(all(
+    tokio_unstable,
+    feature = "taskdump",
+    target_os = "linux",
+    any(
+        target_arch = "aarch64",
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "s390x"
+    )
+))]
+
+use std::future::Future;
+use std::task::Poll;
+
+use futures::future::{join_all, select_all};
+use futures::stream::{self, FuturesUnordered, StreamExt};
+use tokio::runtime::dump::{trace_with, Trace};
+use tokio::sync::oneshot;
+use tokio::task::{yield_now, JoinSet};
+use tokio_test::task::{self, Spawn};
+
+fn channels(count: usize) -> (Vec<oneshot::Receiver<usize>>, impl Future<Output = ()>) {
+    let (senders, receivers): (Vec<_>, Vec<_>) = (0..count).map(|_| oneshot::channel()).unzip();
+    let make_ready = async move {
+        for (value, sender) in senders.into_iter().enumerate() {
+            sender.send(value).unwrap();
+        }
+    };
+    (receivers, make_ready)
+}
+
+async fn assert_progress<F: Future>(task: &mut Spawn<F>) -> F::Output {
+    // Yield so Tokio can drain the deferred-wake queue used before #8043.
+    // Poll the parent even without a wake: a parent re-poll alone cannot repair
+    // a lost child notification. Bound the loop so regressions fail, not hang.
+    for _ in 0..10 {
+        yield_now().await;
+        if let Poll::Ready(output) = task.poll() {
+            return output;
+        }
+    }
+    panic!("capture stranded a ready child despite 10 subsequent parent polls");
+}
+
+// Deliver a notification between a normal poll and a capture poll, so tracing
+// consumes a child's ready-queue entry in sub-executors that use one. The child's
+// own waker must fire again before that sub-executor will poll it normally.
+async fn trace_after_wake<F: Future>(future: F, make_ready: impl Future<Output = ()>) -> F::Output {
+    let mut task = task::spawn(future);
+    assert!(task.poll().is_pending(), "future must initially be pending");
+    make_ready.await;
+    assert!(task.is_woken(), "completion must notify the parent");
+
+    let mut leaves = 0;
+    let result = trace_with(|| task.poll(), |_| leaves += 1);
+    assert!(leaves > 0, "capture must reach a Tokio leaf");
+
+    match result {
+        Poll::Ready(output) => output,
+        Poll::Pending => assert_progress(&mut task).await,
+    }
+}
+
+#[tokio::test]
+async fn trace_with_futures_unordered() {
+    let (receivers, make_ready) = channels(2);
+    let future = receivers
+        .into_iter()
+        .collect::<FuturesUnordered<_>>()
+        .collect::<Vec<_>>();
+
+    let mut results = trace_after_wake(future, make_ready).await;
+    results.sort_unstable_by_key(|result| *result.as_ref().unwrap());
+    assert_eq!(results, vec![Ok(0), Ok(1)]);
+}
+
+#[tokio::test]
+async fn trace_capture_futures_unordered() {
+    let (receivers, make_ready) = channels(2);
+    let mut task = task::spawn(
+        receivers
+            .into_iter()
+            .collect::<FuturesUnordered<_>>()
+            .collect::<Vec<_>>(),
+    );
+    assert!(task.poll().is_pending());
+    make_ready.await;
+    assert!(task.is_woken());
+
+    let (result, _trace) = Trace::capture(|| task.poll());
+    let mut results = match result {
+        Poll::Ready(output) => output,
+        Poll::Pending => assert_progress(&mut task).await,
+    };
+    results.sort_unstable_by_key(|result| *result.as_ref().unwrap());
+    assert_eq!(results, vec![Ok(0), Ok(1)]);
+}
+
+#[tokio::test]
+async fn trace_with_join_set() {
+    let mut set = JoinSet::new();
+    let child = set.spawn(async { 42 });
+
+    // On this current-thread runtime, the child cannot finish before the
+    // initial join_next poll. Finish it before the capture poll instead.
+    let make_ready = async move {
+        for _ in 0..10 {
+            yield_now().await;
+            if child.is_finished() {
+                return;
+            }
+        }
+        panic!("JoinSet child did not finish before capture");
+    };
+
+    let result = trace_after_wake(set.join_next(), make_ready).await;
+    assert_eq!(result.unwrap().unwrap(), 42);
+    assert!(set.is_empty());
+}
+
+#[tokio::test]
+async fn trace_with_join_all_large() {
+    // Large join_all inputs use FuturesOrdered, backed by FuturesUnordered.
+    let (receivers, make_ready) = channels(64);
+    let results = trace_after_wake(join_all(receivers), make_ready).await;
+    assert_eq!(results, (0..64).map(Ok).collect::<Vec<_>>());
+}
+
+#[tokio::test]
+async fn trace_with_join_all_small() {
+    // Control: small join_all inputs poll every unfinished child directly.
+    let (receivers, make_ready) = channels(2);
+    let results = trace_after_wake(join_all(receivers), make_ready).await;
+    assert_eq!(results, vec![Ok(0), Ok(1)]);
+}
+
+#[tokio::test]
+async fn trace_with_future_select_all() {
+    // Control: future::select_all polls its children without a ready queue.
+    let (receivers, make_ready) = channels(2);
+    let (result, index, remaining) = trace_after_wake(select_all(receivers), make_ready).await;
+    assert_eq!(result, Ok(index));
+    assert_eq!(remaining.len(), 1);
+    assert_eq!(remaining.into_iter().next().unwrap().await, Ok(1 - index));
+}
+
+#[tokio::test]
+async fn trace_with_stream_select_all() {
+    // Unlike future::select_all, stream::select_all uses FuturesUnordered.
+    let (receivers, make_ready) = channels(2);
+    let future = stream::select_all(receivers.into_iter().map(stream::once)).collect::<Vec<_>>();
+    let mut results = trace_after_wake(future, make_ready).await;
+    results.sort_unstable_by_key(|result| *result.as_ref().unwrap());
+    assert_eq!(results, vec![Ok(0), Ok(1)]);
+}
+
+#[tokio::test]
+async fn futures_unordered_without_capture() {
+    // Control: the same notifications suffice if there is no tracing re-poll.
+    let (receivers, make_ready) = channels(2);
+    let mut task = task::spawn(
+        receivers
+            .into_iter()
+            .collect::<FuturesUnordered<_>>()
+            .collect::<Vec<_>>(),
+    );
+    assert!(task.poll().is_pending());
+    make_ready.await;
+
+    let mut results = assert_progress(&mut task).await;
+    results.sort_unstable_by_key(|result| *result.as_ref().unwrap());
+    assert_eq!(results, vec![Ok(0), Ok(1)]);
+}

--- a/tokio/tests/task_trace_wake.rs
+++ b/tokio/tests/task_trace_wake.rs
@@ -102,12 +102,14 @@ async fn capture_defers_wake_current_thread() {
     assert_capture_defers_wake().await;
 }
 
+#[cfg(feature = "rt-multi-thread")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn capture_defers_wake_multi_thread() {
     // Run on a worker: multi-threaded block_on does not drive the scheduler.
     tokio::spawn(assert_capture_defers_wake()).await.unwrap();
 }
 
+#[cfg(feature = "rt-multi-thread")]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn trace_with_futures_unordered_on_worker() {
     tokio::spawn(async {

--- a/tokio/tests/task_trace_wake.rs
+++ b/tokio/tests/task_trace_wake.rs
@@ -34,7 +34,7 @@ fn channels(count: usize) -> (Vec<oneshot::Receiver<usize>>, impl Future<Output 
 }
 
 async fn assert_progress<F: Future>(task: &mut Spawn<F>) -> F::Output {
-    // Yield so Tokio can drain the deferred-wake queue used before #8043.
+    // Yield so Tokio can drain the deferred-wake queue.
     // Poll the parent even without a wake: a parent re-poll alone cannot repair
     // a lost child notification. Bound the loop so regressions fail, not hang.
     for _ in 0..10 {
@@ -63,6 +63,66 @@ async fn trace_after_wake<F: Future>(future: F, make_ready: impl Future<Output =
         Poll::Ready(output) => output,
         Poll::Pending => assert_progress(&mut task).await,
     }
+}
+
+async fn assert_capture_defers_wake() {
+    let (sender, receiver) = oneshot::channel();
+    let mut task = task::spawn(receiver);
+    assert!(task.poll().is_pending());
+    assert!(!task.is_woken());
+
+    let mut leaves = 0;
+    assert!(trace_with(|| task.poll(), |_| leaves += 1).is_pending());
+    assert_eq!(leaves, 1);
+    assert!(!task.is_woken(), "capture must defer the leaf's wake");
+
+    for _ in 0..10 {
+        yield_now().await;
+        if task.is_woken() {
+            break;
+        }
+    }
+    assert!(task.is_woken(), "capture must eventually wake the leaf");
+
+    // A normal poll registers the waker without scheduling another wake.
+    assert!(task.poll().is_pending());
+    yield_now().await;
+    assert!(
+        !task.is_woken(),
+        "normal polling must let an idle future rest"
+    );
+
+    sender.send(42).unwrap();
+    assert!(task.is_woken());
+    assert_eq!(task.poll(), Poll::Ready(Ok(42)));
+}
+
+#[tokio::test]
+async fn capture_defers_wake_current_thread() {
+    assert_capture_defers_wake().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn capture_defers_wake_multi_thread() {
+    // Run on a worker: multi-threaded block_on does not drive the scheduler.
+    tokio::spawn(assert_capture_defers_wake()).await.unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn trace_with_futures_unordered_on_worker() {
+    tokio::spawn(async {
+        let (receivers, make_ready) = channels(2);
+        let future = receivers
+            .into_iter()
+            .collect::<FuturesUnordered<_>>()
+            .collect::<Vec<_>>();
+
+        let mut results = trace_after_wake(future, make_ready).await;
+        results.sort_unstable_by_key(|result| *result.as_ref().unwrap());
+        assert_eq!(results, vec![Ok(0), Ok(1)]);
+    })
+    .await
+    .unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tokio/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation, which requires special commands beyond `cargo fmt` and `cargo doc`.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Fix https://github.com/tokio-rs/tokio/issues/8434.
## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

- Restores trace_leaf wakes removed by https://github.com/tokio-rs/tokio/pull/8043. 
- Added some regression tests, that fail without the fix. 

AI used for codebase discovery, reverting code selectively and writing the regression tests. I take full responsibility for the code.