### PR TITLE
tests: skip the io_uring fs assertions when fs falls back to spawn_blocking

### DIFF
--- a/tokio/tests/fs_uring_read.rs
+++ b/tokio/tests/fs_uring_read.rs
@@ -21,6 +21,12 @@ use tokio::runtime::{Builder, Runtime};
 use tokio_test::assert_pending;
 use tokio_util::task::TaskTracker;
 
+use crate::support::io_uring::uring_fs_op_in_use;
+
+mod support {
+    pub(crate) mod io_uring;
+}
+
 fn multi_rt(n: usize) -> Box<dyn Fn() -> Runtime> {
     Box::new(move || {
         Builder::new_multi_thread()
@@ -48,6 +54,10 @@ fn rt_combinations() -> Vec<Box<dyn Fn() -> Runtime>> {
 
 #[test]
 fn shutdown_runtime_while_performing_io_uring_ops() {
+    if !uring_fs_op_in_use(io_uring::opcode::Read::CODE) {
+        return;
+    }
+
     fn run(rt: Runtime) {
         let (done_tx, done_rx) = mpsc::channel();
         let (_tmp, path) = create_tmp_files(1);
@@ -133,6 +143,10 @@ async fn read_small_large_files() {
 
 #[tokio::test]
 async fn cancel_op_future() {
+    if !uring_fs_op_in_use(io_uring::opcode::Read::CODE) {
+        return;
+    }
+
     let (_tmp_file, path): (Vec<NamedTempFile>, Vec<PathBuf>) = create_tmp_files(1);
     let path = path[0].clone();
 
@@ -143,7 +157,6 @@ async fn cancel_op_future() {
         tokio::pin!(fut);
 
         poll_fn(move |_| {
-            // If io_uring is enabled (and not falling back to the thread pool),
             // the first poll should return Pending.
             assert_pending!(fut.as_mut().poll(&mut Context::from_waker(Waker::noop())));
             tx.send(true).unwrap();

--- a/tokio/tests/fs_uring_statx.rs
+++ b/tokio/tests/fs_uring_statx.rs
@@ -24,7 +24,7 @@ use tokio::runtime::{Builder, Runtime};
 use tokio_test::assert_pending;
 use tokio_util::task::TaskTracker;
 
-use crate::support::io_uring::io_uring_supported;
+use crate::support::io_uring::{io_uring_supported, uring_fs_op_in_use};
 
 mod support {
     pub(crate) mod io_uring;
@@ -57,7 +57,7 @@ fn rt_combinations() -> Vec<Box<dyn Fn() -> Runtime>> {
 
 #[test]
 fn shutdown_runtime_while_performing_io_uring_ops() {
-    if !io_uring_supported() {
+    if !uring_fs_op_in_use(io_uring::opcode::Statx::CODE) {
         return;
     }
 
@@ -239,7 +239,7 @@ async fn stat_path_name_too_long() {
 
 #[tokio::test]
 async fn cancel_op_future() {
-    if !io_uring_supported() {
+    if !uring_fs_op_in_use(io_uring::opcode::Statx::CODE) {
         return;
     }
 

--- a/tokio/tests/support/io_uring.rs
+++ b/tokio/tests/support/io_uring.rs
@@ -17,6 +17,7 @@ use io_uring::IoUring;
 // to check if the fallback mechanism works, this comes with the limitation that we are not
 // able to run some checks (e.g., asserting a poll returns pending). This utility function
 // is useful when we want to run a test only in Linux targets where io_uring is supported.
+#[allow(dead_code)]
 pub fn io_uring_supported() -> bool {
     match IoUring::new(256) {
         Ok(_) => true,
@@ -31,6 +32,25 @@ pub fn io_uring_supported() -> bool {
             "IoUring::new failed with an unexpected error (expected ENOSYS or EPERM): {e}"
         ),
     }
+}
+
+/// Whether tokio uses io_uring, rather than the `spawn_blocking` fallback, for
+/// the `fs` functions built on `opcode` (`Statx` for `try_exists`, `Read` for
+/// `read`). Mirrors the gate in `tokio/src/fs`: the target must have
+/// `libc::statx` (see the FIXME there about musl) and the kernel must support
+/// the opcode. Tests that assert on the io_uring path (e.g. that the first
+/// poll is `Pending`) return early when this is false, since the blocking
+/// fallback may already be done by the first poll.
+#[allow(dead_code)]
+pub fn uring_fs_op_in_use(opcode: u8) -> bool {
+    if !cfg!(any(target_env = "gnu", target_os = "android")) {
+        return false;
+    }
+    let Ok(ring) = IoUring::new(2) else {
+        return false;
+    };
+    let mut probe = io_uring::Probe::new();
+    ring.submitter().register_probe(&mut probe).is_ok() && probe.is_supported(opcode)
 }
 
 #[allow(dead_code)]


### PR DESCRIPTION
## Motivation

`fs_uring_statx::cancel_op_future` failed on the `x86_64-unknown-linux-musl` io_uring job (seen on #8435, https://github.com/tokio-rs/tokio/actions/runs/34481667680/job/102886329000) with `ready; value = Ok(true)`. The test asserts that the first poll of `try_exists` is `Pending`, which holds for the io_uring path, but on musl the statx-based path is compiled out (see the FIXME in `fs/try_exists.rs`), so `try_exists` falls back to `spawn_blocking` and the blocking task can finish before the `JoinHandle` is first polled. `fs_uring_read` has the same assertion and the same fallback.

## Solution

Add `support::io_uring::uring_fs_op_in_use(opcode)`, mirroring the library's own decision (target gate plus an opcode probe), and have the affected tests return early when the io_uring fs path is not in use — the same way they already return when io_uring itself is unsupported. The `Pending` assertions stay unconditional.
