### PR TITLE
enable `send_to_recv_closed_returns_err` test for WASI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1182,9 +1182,9 @@ jobs:
       - name: Install cargo-nextest, wasmtime
         uses: taiki-e/install-action@v2
         with:
-          # Wasmtime v47.0.0 or later should work, but we stick with a known,
+          # Wasmtime v48.0.0 or later should work, but we stick with a known,
           # specific version to avoid surprises:
-          tool: cargo-nextest,wasmtime-cli@47.0.2
+          tool: cargo-nextest,wasmtime-cli@48.0.2
 
       - uses: Swatinem/rust-cache@v2
 

--- a/tokio/tests/udp.rs
+++ b/tokio/tests/udp.rs
@@ -56,10 +56,6 @@ async fn send_recv_poll() -> std::io::Result<()> {
 }
 
 #[tokio::test]
-#[cfg_attr(
-    target_os = "wasi",
-    ignore = "temporarily disabled for WASI pending https://github.com/bytecodealliance/wasmtime/pull/13933"
-)]
 async fn send_to_recv_closed_returns_err() -> std::io::Result<()> {
     let sender = UdpSocket::bind("127.0.0.1:0").await?;
     let receiver = UdpSocket::bind("127.0.0.1:0").await?;


### PR DESCRIPTION
This is the last remaining test which was temporarily disabled for WASI due to a Wasmtime bug.  Now that Wasmtime 48 has been released, we can enable it.

Fixes #7936
