### PR TITLE
io: retry interrupted errors in read_until

### DIFF
--- a/tokio/src/io/util/read_until.rs
+++ b/tokio/src/io/util/read_until.rs
@@ -53,7 +53,11 @@ pub(super) fn read_until_internal<R: AsyncBufRead + ?Sized>(
 ) -> Poll<io::Result<usize>> {
     loop {
         let (done, used) = {
-            let available = ready!(reader.as_mut().poll_fill_buf(cx))?;
+            let available = match ready!(reader.as_mut().poll_fill_buf(cx)) {
+                Ok(available) => available,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                Err(e) => return Poll::Ready(Err(e)),
+            };
             if let Some(i) = memchr::memchr(delimiter, available) {
                 buf.extend_from_slice(&available[..=i]);
                 (true, i + 1)

--- a/tokio/tests/io_read_until.rs
+++ b/tokio/tests/io_read_until.rs
@@ -32,6 +32,20 @@ async fn read_until() {
 }
 
 #[tokio::test]
+async fn read_until_retries_interrupted() {
+    let mock = Builder::new()
+        .read_error(Error::from(ErrorKind::Interrupted))
+        .read(b"hello world")
+        .build();
+    let mut read = BufReader::new(mock);
+    let mut buf = vec![];
+
+    let n = read.read_until(b' ', &mut buf).await.unwrap();
+    assert_eq!(n, 6);
+    assert_eq!(buf, b"hello ");
+}
+
+#[tokio::test]
 async fn read_until_not_all_ready() {
     let mock = Builder::new()
         .read(b"Hello Wor")


### PR DESCRIPTION
## Motivation

`read_until` documents that it ignores `ErrorKind::Interrupted`, but `read_until_internal` currently returns that error from `poll_fill_buf`.

## Changes

- retry `Interrupted` in `read_until_internal`
- add a regression test

This also fixes the shared behavior used by `read_line`, `lines`, and `split`.