### PR TITLE
fs: reject zero max buffer size

### DIFF
--- a/tokio/src/fs/file.rs
+++ b/tokio/src/fs/file.rs
@@ -571,6 +571,10 @@ impl File {
     /// Although Tokio uses a sensible default value for this buffer size, this function would be
     /// useful for changing that default depending on the situation.
     ///
+    /// # Panics
+    ///
+    /// This function panics if `max_buf_size` is 0.
+    ///
     /// # Examples
     ///
     /// ```no_run
@@ -590,7 +594,9 @@ impl File {
     /// # Ok(())
     /// # }
     /// ```
+    #[track_caller]
     pub fn set_max_buf_size(&mut self, max_buf_size: usize) {
+        assert!(max_buf_size > 0, "`max_buf_size` must be greater than 0");
         self.max_buf_size = max_buf_size;
     }
 

--- a/tokio/tests/fs_file.rs
+++ b/tokio/tests/fs_file.rs
@@ -238,6 +238,14 @@ async fn set_max_buf_size_write() {
 }
 
 #[tokio::test]
+#[should_panic(expected = "`max_buf_size` must be greater than 0")]
+async fn set_max_buf_size_panics_on_zero() {
+    let tempfile = tempfile();
+    let mut file = File::open(tempfile.path()).await.unwrap();
+    file.set_max_buf_size(0);
+}
+
+#[tokio::test]
 #[cfg_attr(miri, ignore)]
 #[cfg(unix)]
 async fn file_debug_fmt() {


### PR DESCRIPTION
## Motivation

`File::set_max_buf_size(0)` currently accepts zero. That can make file operations use a zero-length buffer, even though a positive buffer size is required.

## Changes

- reject zero with an assertion
- document the panic
- add a regression test

This matches the existing validation in Tokio’s in-memory I/O types.