### PR TITLE
stream: implement FusedStream for StreamNotifyClose

### DIFF
--- a/tokio-stream/src/stream_close.rs
+++ b/tokio-stream/src/stream_close.rs
@@ -1,4 +1,5 @@
 use crate::Stream;
+use futures_core::FusedStream;
 use pin_project_lite::pin_project;
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -89,5 +90,14 @@ where
         } else {
             (0, Some(0))
         }
+    }
+}
+
+impl<S> FusedStream for StreamNotifyClose<S>
+where
+    S: Stream,
+{
+    fn is_terminated(&self) -> bool {
+        self.inner.is_none()
     }
 }

--- a/tokio-stream/tests/stream_fused.rs
+++ b/tokio-stream/tests/stream_fused.rs
@@ -1,5 +1,25 @@
 use futures_core::FusedStream;
-use tokio_stream::{StreamExt, StreamNotifyClose};
+use tokio_stream::{Stream, StreamExt, StreamNotifyClose};
+
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+struct EndOnce {
+    ended: bool,
+}
+
+impl Stream for EndOnce {
+    type Item = ();
+
+    fn poll_next(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if self.ended {
+            panic!("stream polled after returning None");
+        }
+
+        self.ended = true;
+        Poll::Ready(None)
+    }
+}
 
 // Helper: a fused base stream built from a vec
 fn fused_iter<T>(items: Vec<T>) -> impl FusedStream<Item = T> {
@@ -212,6 +232,15 @@ async fn stream_notify_close_is_terminated_after_close_notification() {
     let mut stream = StreamNotifyClose::new(tokio_stream::iter(vec![1]));
     assert!(!stream.is_terminated());
     assert_eq!(stream.next().await, Some(Some(1)));
+    assert!(!stream.is_terminated());
+    assert_eq!(stream.next().await, Some(None));
+    assert!(stream.is_terminated());
+    assert_eq!(stream.next().await, None);
+}
+
+#[tokio::test]
+async fn stream_notify_close_does_not_poll_inner_after_close_notification() {
+    let mut stream = StreamNotifyClose::new(EndOnce { ended: false });
     assert!(!stream.is_terminated());
     assert_eq!(stream.next().await, Some(None));
     assert!(stream.is_terminated());

--- a/tokio-stream/tests/stream_fused.rs
+++ b/tokio-stream/tests/stream_fused.rs
@@ -1,5 +1,5 @@
 use futures_core::FusedStream;
-use tokio_stream::StreamExt;
+use tokio_stream::{StreamExt, StreamNotifyClose};
 
 // Helper: a fused base stream built from a vec
 fn fused_iter<T>(items: Vec<T>) -> impl FusedStream<Item = T> {
@@ -205,4 +205,15 @@ async fn merge_terminated_only_after_both_done() {
     assert_eq!(stream.next().await, None);
     assert!(stream.is_terminated());
     assert_eq!(collected.len(), 2);
+}
+
+#[tokio::test]
+async fn stream_notify_close_is_terminated_after_close_notification() {
+    let mut stream = StreamNotifyClose::new(tokio_stream::iter(vec![1]));
+    assert!(!stream.is_terminated());
+    assert_eq!(stream.next().await, Some(Some(1)));
+    assert!(!stream.is_terminated());
+    assert_eq!(stream.next().await, Some(None));
+    assert!(stream.is_terminated());
+    assert_eq!(stream.next().await, None);
 }


### PR DESCRIPTION
## **Why**

`StreamNotifyClose` emits one final `Some(None)` item when its inner stream ends, then stops. It already stores the inner stream as `Option<S>`, so it already has a termination marker.

It did not implement `FusedStream`, which meant it could not be used with APIs that require that trait.

## **What changed**

- implement `FusedStream` for `StreamNotifyClose<S>` when `S: Stream`
- return `true` once the close notification has been emitted
- keep using `inner == None` as the termination state

## **Test**

- cover a normal item
- cover the final close notification
- check the stream is terminated and returns `None` afterward

No extra state is needed.