### PR TITLE
io: retry interrupted writes in `write_all` and `write_all_buf`

### DIFF
--- a/tokio/src/io/util/async_write_ext.rs
+++ b/tokio/src/io/util/async_write_ext.rs
@@ -286,8 +286,9 @@ cfg_io_util! {
         ///
         /// This method will continuously call [`write`] until
         /// [`buf.has_remaining()`](bytes::Buf::has_remaining) returns false. This method will not
-        /// return until the entire buffer has been successfully written or an error occurs. The
-        /// first error generated will be returned.
+        /// return until the entire buffer has been successfully written or an error occurs.
+        /// Errors of kind [`ErrorKind::Interrupted`] are ignored and the write is retried. The first
+        /// other error generated will be returned.
         ///
         /// The buffer is advanced after each chunk is successfully written. After failure,
         /// `src.chunk()` will return the chunk that failed to write.
@@ -331,6 +332,7 @@ cfg_io_util! {
         /// ```
         ///
         /// [`write`]: AsyncWriteExt::write
+        /// [`ErrorKind::Interrupted`]: std::io::ErrorKind::Interrupted
         fn write_all_buf<'a, B>(&'a mut self, src: &'a mut B) -> WriteAllBuf<'a, Self, B>
         where
             Self: Sized + Unpin,
@@ -349,8 +351,9 @@ cfg_io_util! {
         ///
         /// This method will continuously call [`write`] until there is no more data
         /// to be written. This method will not return until the entire buffer
-        /// has been successfully written or such an error occurs. The first
-        /// error generated from this method will be returned.
+        /// has been successfully written or such an error occurs. Errors of kind
+        /// [`ErrorKind::Interrupted`] are ignored and the write is retried. The first
+        /// other error generated from this method will be returned.
         ///
         /// # Cancel safety
         ///
@@ -362,7 +365,8 @@ cfg_io_util! {
         ///
         /// # Errors
         ///
-        /// This function will return the first error that [`write`] returns.
+        /// This function will ignore errors of kind [`ErrorKind::Interrupted`] and
+        /// will otherwise return the first error that [`write`] returns.
         ///
         /// # Examples
         ///
@@ -384,6 +388,7 @@ cfg_io_util! {
         /// ```
         ///
         /// [`write`]: AsyncWriteExt::write
+        /// [`ErrorKind::Interrupted`]: std::io::ErrorKind::Interrupted
         fn write_all<'a>(&'a mut self, src: &'a [u8]) -> WriteAll<'a, Self>
         where
             Self: Unpin,

--- a/tokio/src/io/util/write_all.rs
+++ b/tokio/src/io/util/write_all.rs
@@ -40,7 +40,13 @@ where
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let me = self.project();
         while !me.buf.is_empty() {
-            let n = ready!(Pin::new(&mut *me.writer).poll_write(cx, me.buf))?;
+            let n = loop {
+                match ready!(Pin::new(&mut *me.writer).poll_write(cx, me.buf)) {
+                    Ok(n) => break n,
+                    Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(e) => return Poll::Ready(Err(e)),
+                }
+            };
             {
                 let (_, rest) = mem::take(&mut *me.buf).split_at(n);
                 *me.buf = rest;

--- a/tokio/src/io/util/write_all_buf.rs
+++ b/tokio/src/io/util/write_all_buf.rs
@@ -46,12 +46,20 @@ where
 
         let me = self.project();
         while me.buf.has_remaining() {
-            let n = if me.writer.is_write_vectored() {
-                let mut slices = [IoSlice::new(&[]); MAX_VECTOR_ELEMENTS];
-                let cnt = me.buf.chunks_vectored(&mut slices);
-                ready!(Pin::new(&mut *me.writer).poll_write_vectored(cx, &slices[..cnt]))?
-            } else {
-                ready!(Pin::new(&mut *me.writer).poll_write(cx, me.buf.chunk())?)
+            let n = loop {
+                let result = if me.writer.is_write_vectored() {
+                    let mut slices = [IoSlice::new(&[]); MAX_VECTOR_ELEMENTS];
+                    let cnt = me.buf.chunks_vectored(&mut slices);
+                    ready!(Pin::new(&mut *me.writer).poll_write_vectored(cx, &slices[..cnt]))
+                } else {
+                    ready!(Pin::new(&mut *me.writer).poll_write(cx, me.buf.chunk()))
+                };
+
+                match result {
+                    Ok(n) => break n,
+                    Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
+                    Err(e) => return Poll::Ready(Err(e)),
+                }
             };
             me.buf.advance(n);
             if n == 0 {

--- a/tokio/tests/io_write_all.rs
+++ b/tokio/tests/io_write_all.rs
@@ -11,6 +11,7 @@
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::assert_ok;
+use tokio_test::io::Builder;
 
 use bytes::BytesMut;
 use std::cmp;
@@ -56,4 +57,14 @@ async fn write_all() {
     assert_ok!(wr.write_all(b"hello world").await);
     assert_eq!(wr.buf, b"hello world"[..]);
     assert_eq!(wr.cnt, 3);
+}
+
+#[tokio::test]
+async fn write_all_retries_interrupted() {
+    let mut mock = Builder::new()
+        .write_error(io::Error::from(io::ErrorKind::Interrupted))
+        .write(b"hello")
+        .build();
+
+    mock.write_all(b"hello").await.unwrap();
 }

--- a/tokio/tests/io_write_all.rs
+++ b/tokio/tests/io_write_all.rs
@@ -62,8 +62,9 @@ async fn write_all() {
 #[tokio::test]
 async fn write_all_retries_interrupted() {
     let mut mock = Builder::new()
+        .write(b"he")
         .write_error(io::Error::from(io::ErrorKind::Interrupted))
-        .write(b"hello")
+        .write(b"llo")
         .build();
 
     mock.write_all(b"hello").await.unwrap();

--- a/tokio/tests/io_write_all_buf.rs
+++ b/tokio/tests/io_write_all_buf.rs
@@ -10,8 +10,8 @@
 ))]
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
-use tokio_test::{assert_err, assert_ok};
 use tokio_test::io::Builder;
+use tokio_test::{assert_err, assert_ok};
 
 use bytes::{Buf, Bytes, BytesMut};
 use std::cmp;
@@ -133,9 +133,7 @@ async fn write_all_buf_vectored() {
         ) -> Poll<Result<usize, io::Error>> {
             if !self.interrupted {
                 self.interrupted = true;
-                return Poll::Ready(Err(io::Error::from(
-                    io::ErrorKind::Interrupted,
-                )));
+                return Poll::Ready(Err(io::Error::from(io::ErrorKind::Interrupted)));
             }
 
             for buf in bufs {

--- a/tokio/tests/io_write_all_buf.rs
+++ b/tokio/tests/io_write_all_buf.rs
@@ -11,6 +11,7 @@
 
 use tokio::io::{AsyncWrite, AsyncWriteExt};
 use tokio_test::{assert_err, assert_ok};
+use tokio_test::io::Builder;
 
 use bytes::{Buf, Bytes, BytesMut};
 use std::cmp;
@@ -107,6 +108,7 @@ async fn write_buf_err() {
 async fn write_all_buf_vectored() {
     struct Wr {
         buf: BytesMut,
+        interrupted: bool,
     }
     impl AsyncWrite for Wr {
         fn poll_write(
@@ -129,6 +131,13 @@ async fn write_all_buf_vectored() {
             _cx: &mut Context<'_>,
             bufs: &[io::IoSlice<'_>],
         ) -> Poll<Result<usize, io::Error>> {
+            if !self.interrupted {
+                self.interrupted = true;
+                return Poll::Ready(Err(io::Error::from(
+                    io::ErrorKind::Interrupted,
+                )));
+            }
+
             for buf in bufs {
                 self.buf.extend_from_slice(buf);
             }
@@ -143,6 +152,7 @@ async fn write_all_buf_vectored() {
 
     let mut wr = Wr {
         buf: BytesMut::with_capacity(64),
+        interrupted: false,
     };
     let mut buf = Bytes::from_static(b"hello")
         .chain(Bytes::from_static(b" "))
@@ -150,4 +160,16 @@ async fn write_all_buf_vectored() {
 
     wr.write_all_buf(&mut buf).await.unwrap();
     assert_eq!(&wr.buf[..], b"hello world");
+}
+
+#[tokio::test]
+async fn write_all_buf_retries_interrupted() {
+    let mut mock = Builder::new()
+        .write_error(io::Error::from(io::ErrorKind::Interrupted))
+        .write(b"hello")
+        .build();
+    let mut buf = Bytes::from_static(b"hello");
+
+    mock.write_all_buf(&mut buf).await.unwrap();
+    assert!(!buf.has_remaining());
 }

--- a/tokio/tests/io_write_all_buf.rs
+++ b/tokio/tests/io_write_all_buf.rs
@@ -163,8 +163,9 @@ async fn write_all_buf_vectored() {
 #[tokio::test]
 async fn write_all_buf_retries_interrupted() {
     let mut mock = Builder::new()
+        .write(b"he")
         .write_error(io::Error::from(io::ErrorKind::Interrupted))
-        .write(b"hello")
+        .write(b"llo")
         .build();
     let mut buf = Bytes::from_static(b"hello");
 


### PR DESCRIPTION
## **Why**

`write_all` currently returns `ErrorKind::Interrupted` immediately. `std::io::Write::write_all` retries this error, and Tokio's read helpers do too.

A transient interrupted write should not fail when the next write can make progress.

## **What changed**

- retry `ErrorKind::Interrupted` in `write_all`
- retry it in `write_all_buf`, including vectored writes
- document that the first non-Interrupted error is returned
- add regression tests for normal and vectored writes

Other errors and `WriteZero` keep their current behavior.
