### PR TITLE
io: reject zero copy buffer sizes

### DIFF
--- a/tokio/src/io/util/copy_bidirectional.rs
+++ b/tokio/src/io/util/copy_bidirectional.rs
@@ -105,8 +105,14 @@ where
     A: AsyncRead + AsyncWrite + Unpin + ?Sized,
     B: AsyncRead + AsyncWrite + Unpin + ?Sized,
 {
-    assert!(a_to_b_buf_size > 0, "`a_to_b_buf_size` must be greater than 0");
-    assert!(b_to_a_buf_size > 0, "`b_to_a_buf_size` must be greater than 0");
+    assert!(
+        a_to_b_buf_size > 0,
+        "`a_to_b_buf_size` must be greater than 0"
+    );
+    assert!(
+        b_to_a_buf_size > 0,
+        "`b_to_a_buf_size` must be greater than 0"
+    );
 
     copy_bidirectional_impl(
         a,

--- a/tokio/src/io/util/copy_bidirectional.rs
+++ b/tokio/src/io/util/copy_bidirectional.rs
@@ -90,6 +90,10 @@ where
 ///
 /// This method is the same as the [`copy_bidirectional()`], except that it allows you to set the
 /// size of the internal buffers used when copying data.
+///
+/// # Panics
+///
+/// Panics if either buffer size is zero.
 #[cfg_attr(docsrs, doc(cfg(feature = "io-util")))]
 pub async fn copy_bidirectional_with_sizes<A, B>(
     a: &mut A,
@@ -101,6 +105,9 @@ where
     A: AsyncRead + AsyncWrite + Unpin + ?Sized,
     B: AsyncRead + AsyncWrite + Unpin + ?Sized,
 {
+    assert!(a_to_b_buf_size > 0, "`a_to_b_buf_size` must be greater than 0");
+    assert!(b_to_a_buf_size > 0, "`b_to_a_buf_size` must be greater than 0");
+
     copy_bidirectional_impl(
         a,
         b,

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -2,7 +2,9 @@
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support bind()
 
 use std::time::Duration;
-use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{
+    self, copy_bidirectional, copy_bidirectional_with_sizes, AsyncReadExt, AsyncWriteExt,
+};
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 
@@ -137,6 +139,28 @@ async fn immediate_exit_on_read_error() {
     let mut b = tokio_test::io::Builder::new().read_error(error()).build();
 
     assert!(copy_bidirectional(&mut a, &mut b).await.is_err());
+}
+
+#[tokio::test]
+#[should_panic(expected = "`a_to_b_buf_size` must be greater than 0")]
+async fn copy_bidirectional_with_sizes_panics_on_zero_a_to_b_buffer() {
+    let mut a = tokio_test::io::Builder::new().build();
+    let mut b = tokio_test::io::Builder::new().build();
+
+    copy_bidirectional_with_sizes(&mut a, &mut b, 0, 1)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "`b_to_a_buf_size` must be greater than 0")]
+async fn copy_bidirectional_with_sizes_panics_on_zero_b_to_a_buffer() {
+    let mut a = tokio_test::io::Builder::new().build();
+    let mut b = tokio_test::io::Builder::new().build();
+
+    copy_bidirectional_with_sizes(&mut a, &mut b, 1, 0)
+        .await
+        .unwrap();
 }
 
 #[tokio::test]

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -2,9 +2,7 @@
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support bind()
 
 use std::time::Duration;
-use tokio::io::{
-    self, copy_bidirectional, copy_bidirectional_with_sizes, AsyncReadExt, AsyncWriteExt,
-};
+use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 
@@ -139,28 +137,6 @@ async fn immediate_exit_on_read_error() {
     let mut b = tokio_test::io::Builder::new().read_error(error()).build();
 
     assert!(copy_bidirectional(&mut a, &mut b).await.is_err());
-}
-
-#[tokio::test]
-#[should_panic(expected = "`a_to_b_buf_size` must be greater than 0")]
-async fn copy_bidirectional_with_sizes_panics_on_zero_a_to_b_buffer() {
-    let mut a = tokio_test::io::Builder::new().build();
-    let mut b = tokio_test::io::Builder::new().build();
-
-    copy_bidirectional_with_sizes(&mut a, &mut b, 0, 1)
-        .await
-        .unwrap();
-}
-
-#[tokio::test]
-#[should_panic(expected = "`b_to_a_buf_size` must be greater than 0")]
-async fn copy_bidirectional_with_sizes_panics_on_zero_b_to_a_buffer() {
-    let mut a = tokio_test::io::Builder::new().build();
-    let mut b = tokio_test::io::Builder::new().build();
-
-    copy_bidirectional_with_sizes(&mut a, &mut b, 1, 0)
-        .await
-        .unwrap();
 }
 
 #[tokio::test]

--- a/tokio/tests/io_copy_bidirectional.rs
+++ b/tokio/tests/io_copy_bidirectional.rs
@@ -2,7 +2,9 @@
 #![cfg(all(feature = "full", not(target_os = "wasi")))] // Wasi does not support bind()
 
 use std::time::Duration;
-use tokio::io::{self, copy_bidirectional, AsyncReadExt, AsyncWriteExt};
+use tokio::io::{
+    self, copy_bidirectional, copy_bidirectional_with_sizes, AsyncReadExt, AsyncWriteExt,
+};
 use tokio::net::TcpStream;
 use tokio::task::JoinHandle;
 
@@ -137,6 +139,24 @@ async fn immediate_exit_on_read_error() {
     let mut b = tokio_test::io::Builder::new().read_error(error()).build();
 
     assert!(copy_bidirectional(&mut a, &mut b).await.is_err());
+}
+
+#[test]
+#[should_panic(expected = "`a_to_b_buf_size` must be greater than 0")]
+fn copy_bidirectional_with_sizes_panics_on_zero_a_to_b_buffer() {
+    let mut a = tokio_test::io::Builder::new().build();
+    let mut b = tokio_test::io::Builder::new().build();
+
+    tokio_test::block_on(copy_bidirectional_with_sizes(&mut a, &mut b, 0, 1)).unwrap();
+}
+
+#[test]
+#[should_panic(expected = "`b_to_a_buf_size` must be greater than 0")]
+fn copy_bidirectional_with_sizes_panics_on_zero_b_to_a_buffer() {
+    let mut a = tokio_test::io::Builder::new().build();
+    let mut b = tokio_test::io::Builder::new().build();
+
+    tokio_test::block_on(copy_bidirectional_with_sizes(&mut a, &mut b, 1, 0)).unwrap();
 }
 
 #[tokio::test]


### PR DESCRIPTION
**What happened**

`copy_bidirectional_with_sizes` accepts zero-sized buffers, but the internal copy loop cannot make progress with one. It keeps looping instead of reading or writing.

**What changed**

- reject zero for both buffer sizes
- document the panic
- add regression tests for both directions

**Testing**

- `cargo fmt --all -- --check`
- `cargo test -p tokio --features full --tests`
- `cargo clippy -p tokio --features full --tests -- -D warnings`