### PR TITLE
io: retry interrupted writes when flushing `BufWriter`

### DIFF
--- a/tokio/src/io/util/buf_writer.rs
+++ b/tokio/src/io/util/buf_writer.rs
@@ -70,6 +70,7 @@ impl<W: AsyncWrite> BufWriter<W> {
                     break;
                 }
                 Ok(n) => *me.written += n,
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => continue,
                 Err(e) => {
                     ret = Err(e);
                     break;

--- a/tokio/tests/io_buf_writer.rs
+++ b/tokio/tests/io_buf_writer.rs
@@ -127,6 +127,21 @@ async fn buf_writer_inner_flushes() {
 }
 
 #[tokio::test]
+async fn buf_writer_flush_retries_interrupted() {
+    let inner = {
+        let mut builder = tokio_test::io::Builder::new();
+        builder
+            .write_error(io::Error::from(io::ErrorKind::Interrupted))
+            .write(b"hello");
+        builder.build()
+    };
+    let mut writer = BufWriter::with_capacity(6, inner);
+
+    assert_eq!(writer.write(b"hello").await.unwrap(), 5);
+    writer.flush().await.unwrap();
+}
+
+#[tokio::test]
 async fn buf_writer_seek() {
     let mut w = BufWriter::with_capacity(3, Cursor::new(Vec::new()));
     w.write_all(&[0, 1, 2, 3, 4, 5]).await.unwrap();


### PR DESCRIPTION
**What happened**

`BufWriter::flush` returned `ErrorKind::Interrupted` from the underlying writer instead of retrying the write.

**What changed**

- retry interrupted writes while flushing the internal buffer
- add a regression test for an interrupted write followed by success

**Testing**

- `cargo fmt --all -- --check`
- `cargo test -p tokio --features full --tests`
- `cargo clippy -p tokio --features full --tests -- -D warnings`