### PR TITLE
time: use ticks instead of Instant in internal timer APIs

### DIFF
--- a/tokio/src/runtime/driver.rs
+++ b/tokio/src/runtime/driver.rs
@@ -128,6 +128,11 @@ impl Handle {
         pub(crate) fn clock(&self) -> &Clock {
             &self.clock
         }
+
+        #[cfg(test)]
+        pub(crate) fn now(&self) -> u64 {
+           self.time().time_source().deadline_to_tick(self.clock.now())
+        }
     }
 }
 

--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -444,8 +444,6 @@ cfg_time! {
     #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
     pub(crate) mod time_alt;
 
-    use crate::time::Instant;
-
     use std::task::{Context, Poll};
     use std::pin::Pin;
 
@@ -460,7 +458,7 @@ cfg_time! {
     impl Timer {
         #[cfg_attr(not(all(tokio_unstable, feature = "rt-multi-thread")), allow(unused_variables))]
         #[track_caller]
-        pub(crate) fn new(handle: scheduler::Handle, deadline: Instant) -> Self {
+        pub(crate) fn new(handle: scheduler::Handle, deadline: u64) -> Self {
             match handle.timer_flavor() {
                 TimerFlavor::Traditional => {
                     Timer::Traditional(time::TimerEntry::new(handle))
@@ -472,7 +470,7 @@ cfg_time! {
             }
         }
 
-        pub(crate) fn init(self: Pin<&mut Self>, deadline: Instant) {
+        pub(crate) fn init(self: Pin<&mut Self>, deadline: u64) {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {
@@ -494,7 +492,7 @@ cfg_time! {
         }
 
         #[cfg_attr(not(all(tokio_unstable, feature = "rt-multi-thread")), allow(unused_variables))]
-        pub(crate) fn reset(self: Pin<&mut Self>, handle: scheduler::Handle, deadline: Instant) {
+        pub(crate) fn reset(self: Pin<&mut Self>, handle: scheduler::Handle, deadline: u64) {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -60,7 +60,6 @@ use crate::loom::sync::atomic::Ordering;
 
 use crate::runtime::scheduler;
 use crate::sync::AtomicWaker;
-use crate::time::Instant;
 use crate::util::linked_list;
 
 use pin_project_lite::pin_project;
@@ -478,12 +477,10 @@ impl TimerEntry {
         }
     }
 
-    pub(crate) fn init(self: Pin<&mut Self>, deadline: Instant) {
-        let tick = self.driver().time_source().deadline_to_tick(deadline);
-
+    pub(crate) fn init(self: Pin<&mut Self>, deadline: u64) {
         unsafe {
             self.driver()
-                .reregister(&self.driver.driver().io, tick, (&self.inner).into());
+                .reregister(&self.driver.driver().io, deadline, (&self.inner).into());
         }
     }
 
@@ -519,16 +516,14 @@ impl TimerEntry {
         unsafe { self.driver().clear_entry(NonNull::from(&self.inner)) };
     }
 
-    pub(crate) fn reset(self: Pin<&mut Self>, deadline: Instant) {
-        let tick = self.driver().time_source().deadline_to_tick(deadline);
-
-        if self.inner.extend_expiration(tick).is_ok() {
+    pub(crate) fn reset(self: Pin<&mut Self>, deadline: u64) {
+        if self.inner.extend_expiration(deadline).is_ok() {
             return;
         }
 
         unsafe {
             self.driver()
-                .reregister(&self.driver.driver().io, tick, (&self.inner).into());
+                .reregister(&self.driver.driver().io, deadline, (&self.inner).into());
         }
     }
 

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -1,6 +1,6 @@
 #![cfg(all(not(target_os = "wasi"), not(target_os = "emscripten")))]
 
-use std::{task::Context, time::Duration};
+use std::task::Context;
 
 #[cfg(not(loom))]
 use futures::task::noop_waker_ref;
@@ -46,13 +46,11 @@ fn single_timer() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
+        let inner = handle.inner.clone();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
+            let entry = TimerEntry::new(inner.clone());
             pin!(entry);
-            entry
-                .as_mut()
-                .init(handle_.inner.driver().clock().now() + Duration::from_secs(1));
+            entry.as_mut().init(inner.driver().now() + 1000);
 
             block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
         });
@@ -75,13 +73,11 @@ fn drop_timer() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
+        let inner = handle.inner.clone();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
+            let entry = TimerEntry::new(inner.clone());
             pin!(entry);
-            entry
-                .as_mut()
-                .init(handle_.inner.driver().clock().now() + Duration::from_secs(1));
+            entry.as_mut().init(inner.driver().now() + 1000);
 
             let _ = entry
                 .as_mut()
@@ -109,13 +105,11 @@ fn change_waker() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
+        let inner = handle.inner.clone();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
+            let entry = TimerEntry::new(inner.clone());
             pin!(entry);
-            entry
-                .as_mut()
-                .init(handle_.inner.driver().clock().now() + Duration::from_secs(1));
+            entry.as_mut().init(inner.driver().now() + 1000);
 
             let _ = entry
                 .as_mut()
@@ -144,20 +138,20 @@ fn reset_future() {
         let rt = rt(false);
         let handle = rt.handle();
 
-        let handle_ = handle.clone();
+        let inner = handle.clone().inner;
         let finished_early_ = finished_early.clone();
-        let start = handle.inner.driver().clock().now();
+        let start = handle.inner.driver().now();
 
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(handle_.inner.clone());
+            let entry = TimerEntry::new(inner.clone());
             pin!(entry);
-            entry.as_mut().init(start + Duration::from_secs(1));
+            entry.as_mut().init(start + 1000);
 
             let _ = entry
                 .as_mut()
                 .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
 
-            entry.as_mut().reset(start + Duration::from_secs(2));
+            entry.as_mut().reset(start + 2000);
 
             // shouldn't complete before 2s
             block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
@@ -169,19 +163,11 @@ fn reset_future() {
 
         let handle = handle.inner.driver().time();
 
-        handle.process_at_time(
-            handle
-                .time_source()
-                .instant_to_tick(start + Duration::from_millis(1500)),
-        );
+        handle.process_at_time(start + 1500);
 
         assert!(!finished_early.load(Ordering::Relaxed));
 
-        handle.process_at_time(
-            handle
-                .time_source()
-                .instant_to_tick(start + Duration::from_millis(2500)),
-        );
+        handle.process_at_time(start + 2500);
 
         jh.join().unwrap();
 
@@ -208,9 +194,7 @@ fn poll_process_levels() {
 
     for i in 0..normal_or_miri(1024, 64) {
         let mut entry = Box::pin(TimerEntry::new(handle.inner.clone()));
-        entry
-            .as_mut()
-            .init(handle.inner.driver().clock().now() + Duration::from_millis(i));
+        entry.as_mut().init(handle.inner.driver().now() + i);
 
         let _ = entry
             .as_mut()
@@ -243,8 +227,7 @@ fn poll_process_levels_targeted() {
 
     let e1 = TimerEntry::new(handle.inner.clone());
     pin!(e1);
-    e1.as_mut()
-        .init(handle.inner.driver().clock().now() + Duration::from_millis(193));
+    e1.as_mut().init(handle.inner.driver().now() + 193);
 
     let handle = handle.inner.driver().time();
 

--- a/tokio/src/runtime/time_alt/timer.rs
+++ b/tokio/src/runtime/time_alt/timer.rs
@@ -1,6 +1,5 @@
 use super::{EntryHandle, TempLocalContext};
 use crate::runtime::scheduler;
-use crate::time::Instant;
 
 use std::pin::Pin;
 use std::task::{Context, Poll};
@@ -27,11 +26,10 @@ impl Drop for Timer {
 
 impl Timer {
     #[track_caller]
-    pub(crate) fn new(handle: scheduler::Handle, deadline: Instant) -> Self {
-        let tick = deadline_to_tick(&handle, deadline);
+    pub(crate) fn new(handle: scheduler::Handle, deadline: u64) -> Self {
         let entry = with_current_temp_local_context(&handle, |ctx| match ctx {
             Some(TempLocalContext::Running { registration_queue }) => {
-                let entry = EntryHandle::new(tick);
+                let entry = EntryHandle::new(deadline);
                 unsafe { registration_queue.push_front(entry.clone()) }
                 entry
             }
@@ -39,7 +37,7 @@ impl Timer {
             Some(TempLocalContext::Shutdown) => panic!("{RUNTIME_SHUTTING_DOWN_ERROR}"),
 
             _ => {
-                let entry = EntryHandle::new(tick);
+                let entry = EntryHandle::new(deadline);
                 push_from_remote(&handle, entry.clone());
                 entry
             }
@@ -121,9 +119,4 @@ fn push_from_remote(sched_hdl: &scheduler::Handle, entry_hdl: EntryHandle) {
         assert!(!sched_hdl.is_shutdown(), "{RUNTIME_SHUTTING_DOWN_ERROR}");
         sched_hdl.push_remote_timer(entry_hdl);
     }
-}
-
-fn deadline_to_tick(sched_hdl: &scheduler::Handle, deadline: Instant) -> u64 {
-    let time_hdl = sched_hdl.driver().time();
-    time_hdl.time_source().deadline_to_tick(deadline)
 }

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -338,6 +338,8 @@ impl Sleep {
         *this.deadline = deadline;
 
         let handle = this.driver;
+        let time_source = handle.driver().time().time_source();
+        let deadline = time_source.deadline_to_tick(deadline);
 
         #[cfg(all(tokio_unstable, feature = "tracing"))]
         {
@@ -350,12 +352,10 @@ impl Sleep {
                 tracing::trace_span!("runtime.resource.async_op.poll");
 
             let clock = handle.driver().clock();
-            let time_source = handle.driver().time().time_source();
             let now = time_source.now(clock);
-            let tick = time_source.deadline_to_tick(deadline);
             tracing::trace!(
                 target: "runtime::resource::state_update",
-                duration = tick.saturating_sub(now),
+                duration = deadline.saturating_sub(now),
                 duration.unit = "ms",
                 duration.op = "override",
             );
@@ -405,25 +405,25 @@ impl Sleep {
             Some(timer) => timer,
             None => {
                 let handle = this.driver;
+                let time_source = handle.driver().time().time_source();
+                let deadline = time_source.deadline_to_tick(*this.deadline);
 
                 #[cfg(all(tokio_unstable, feature = "tracing"))]
                 {
                     let clock = handle.driver().clock();
-                    let time_source = handle.driver().time().time_source();
                     let now = time_source.now(clock);
-                    let tick = time_source.deadline_to_tick(*this.deadline);
                     tracing::trace!(
                         target: "runtime::resource::state_update",
-                        duration = tick.saturating_sub(now),
+                        duration = deadline.saturating_sub(now),
                         duration.unit = "ms",
                         duration.op = "override",
                     );
                 }
 
-                let timer = Timer::new(handle.clone(), *this.deadline);
+                let timer = Timer::new(handle.clone(), deadline);
                 this.timer.set(Some(timer));
                 let mut timer = this.timer.as_pin_mut().unwrap();
-                timer.as_mut().init(*this.deadline);
+                timer.as_mut().init(deadline);
                 timer
             }
         };


### PR DESCRIPTION
## Motivation

The timer implementations use ticks, but use `Instant` in their API. Let callers pass the correct unit for a "cleaner" API.

## Solution

Have `Sleep` convert its deadline from `Instant` to ticks.