### PR TITLE
time: remove Timer handle reference

### DIFF
--- a/tokio/src/runtime/mod.rs
+++ b/tokio/src/runtime/mod.rs
@@ -458,10 +458,10 @@ cfg_time! {
     impl Timer {
         #[cfg_attr(not(all(tokio_unstable, feature = "rt-multi-thread")), allow(unused_variables))]
         #[track_caller]
-        pub(crate) fn new(handle: scheduler::Handle, deadline: u64) -> Self {
+        pub(crate) fn new(handle: &scheduler::Handle, deadline: u64) -> Self {
             match handle.timer_flavor() {
                 TimerFlavor::Traditional => {
-                    Timer::Traditional(time::TimerEntry::new(handle))
+                    Timer::Traditional(time::TimerEntry::new())
                 }
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
                 TimerFlavor::Alternative => {
@@ -470,13 +470,13 @@ cfg_time! {
             }
         }
 
-        pub(crate) fn init(self: Pin<&mut Self>, deadline: u64) {
+        pub(crate) fn init(self: Pin<&mut Self>, handle: &scheduler::Handle, deadline: u64) {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {
                 // Safety: we never move the inner entries.
                 Timer::Traditional(entry) => unsafe {
-                    Pin::new_unchecked(entry).init(deadline)
+                    Pin::new_unchecked(entry).init(handle, deadline);
                 }
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
                 Timer::Alternative(_) => {},
@@ -491,19 +491,36 @@ cfg_time! {
             }
         }
 
-        #[cfg_attr(not(all(tokio_unstable, feature = "rt-multi-thread")), allow(unused_variables))]
-        pub(crate) fn reset(self: Pin<&mut Self>, handle: scheduler::Handle, deadline: u64) {
+        pub(crate) fn cancel(self: Pin<&mut Self>, handle: &scheduler::Handle) {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {
                 // Safety: we never move the inner entries.
                 Timer::Traditional(entry) => unsafe {
-                    Pin::new_unchecked(entry).reset(deadline)
+                    Pin::new_unchecked(entry).cancel(handle);
                 }
                 // Safety: we never move the inner entries.
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
                 Timer::Alternative(entry) => unsafe {
-                    Pin::new_unchecked(entry).set(time_alt::Timer::new(handle, deadline))
+                    Pin::new_unchecked(entry).cancel();
+                }
+            }
+        }
+
+        pub(crate) fn reset(self: Pin<&mut Self>, handle: &scheduler::Handle, deadline: u64) {
+            // Safety: we never move the inner entries.
+            let this = unsafe { self.get_unchecked_mut() };
+            match this {
+                // Safety: we never move the inner entries.
+                Timer::Traditional(entry) => unsafe {
+                    Pin::new_unchecked(entry).reset(handle, deadline);
+                }
+                // Safety: we never move the inner entries.
+                #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]
+                Timer::Alternative(entry) => unsafe {
+                    let mut entry = Pin::new_unchecked(entry);
+                    entry.cancel();
+                    entry.set(time_alt::Timer::new(handle, deadline));
                 },
             }
         }
@@ -511,13 +528,14 @@ cfg_time! {
         pub(crate) fn poll_elapsed(
             self: Pin<&mut Self>,
             cx: &mut Context<'_>,
+            handle: &scheduler::Handle,
         ) -> Poll<Result<(), crate::time::error::Error>> {
             // Safety: we never move the inner entries.
             let this = unsafe { self.get_unchecked_mut() };
             match this {
                 // Safety: we never move the inner entries.
                 Timer::Traditional(entry) => unsafe {
-                    Pin::new_unchecked(entry).poll_elapsed(cx)
+                    Pin::new_unchecked(entry).poll_elapsed(cx, handle)
                 }
                 // Safety: we never move the inner entries.
                 #[cfg(all(tokio_unstable, feature = "rt-multi-thread"))]

--- a/tokio/src/runtime/time/entry.rs
+++ b/tokio/src/runtime/time/entry.rs
@@ -284,9 +284,6 @@ pin_project! {
     // before polling.
     #[derive(Debug)]
     pub(crate) struct TimerEntry {
-        // Arc reference to the runtime handle. We can only free the driver after
-        // deregistering everything from their respective timer wheels.
-        driver: scheduler::Handle,
         // Shared inner structure; this is part of an intrusive linked list, and
         // therefore other references can exist to it while mutable references to
         // Entry exist.
@@ -294,12 +291,6 @@ pin_project! {
         // This is manipulated only under the inner mutex.
         #[pin]
         inner: TimerShared,
-    }
-
-    impl PinnedDrop for TimerEntry {
-        fn drop(this: Pin<&mut Self>) {
-            this.cancel();
-        }
     }
 }
 
@@ -470,17 +461,18 @@ unsafe impl linked_list::Link for TimerShared {
 // ===== impl Entry =====
 
 impl TimerEntry {
-    pub(crate) fn new(handle: scheduler::Handle) -> Self {
+    pub(crate) fn new() -> Self {
         Self {
-            driver: handle,
             inner: TimerShared::new(),
         }
     }
 
-    pub(crate) fn init(self: Pin<&mut Self>, deadline: u64) {
+    pub(crate) fn init(self: Pin<&mut Self>, handle: &scheduler::Handle, deadline: u64) {
         unsafe {
-            self.driver()
-                .reregister(&self.driver.driver().io, deadline, (&self.inner).into());
+            handle
+                .driver()
+                .time()
+                .reregister(&handle.driver().io, deadline, (&self.inner).into());
         }
     }
 
@@ -490,7 +482,7 @@ impl TimerEntry {
     }
 
     /// Cancels and deregisters the timer. This operation is irreversible.
-    pub(crate) fn cancel(self: Pin<&mut Self>) {
+    pub(crate) fn cancel(self: Pin<&mut Self>, handle: &scheduler::Handle) {
         // We need to perform an acq/rel fence with the driver thread, and the
         // simplest way to do so is to grab the driver lock.
         //
@@ -513,35 +505,34 @@ impl TimerEntry {
         // driver did so far and happens-before everything the driver does in
         // the future. While we have the lock held, we also go ahead and
         // deregister the entry if necessary.
-        unsafe { self.driver().clear_entry(NonNull::from(&self.inner)) };
+        unsafe { handle.driver().time().clear_entry((&self.inner).into()) };
     }
 
-    pub(crate) fn reset(self: Pin<&mut Self>, deadline: u64) {
+    pub(crate) fn reset(self: Pin<&mut Self>, handle: &scheduler::Handle, deadline: u64) {
         if self.inner.extend_expiration(deadline).is_ok() {
             return;
         }
 
         unsafe {
-            self.driver()
-                .reregister(&self.driver.driver().io, deadline, (&self.inner).into());
+            handle
+                .driver()
+                .time()
+                .reregister(&handle.driver().io, deadline, (&self.inner).into());
         }
     }
 
     pub(crate) fn poll_elapsed(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
+        handle: &scheduler::Handle,
     ) -> Poll<Result<(), super::Error>> {
         assert!(
-            !self.driver().is_shutdown(),
+            !handle.driver().time().is_shutdown(),
             "{}",
             crate::util::error::RUNTIME_SHUTTING_DOWN_ERROR
         );
 
         self.inner.state.poll(cx.waker())
-    }
-
-    fn driver(&self) -> &super::Handle {
-        self.driver.driver().time()
     }
 }
 

--- a/tokio/src/runtime/time/tests/mod.rs
+++ b/tokio/src/runtime/time/tests/mod.rs
@@ -48,11 +48,15 @@ fn single_timer() {
 
         let inner = handle.inner.clone();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(inner.clone());
+            let entry = TimerEntry::new();
             pin!(entry);
-            entry.as_mut().init(inner.driver().now() + 1000);
+            entry.as_mut().init(&inner, inner.driver().now() + 1000);
 
-            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
+            block_on(std::future::poll_fn(|cx| {
+                entry.as_mut().poll_elapsed(cx, &inner)
+            }))
+            .unwrap();
+            entry.cancel(&inner);
         });
 
         thread::yield_now();
@@ -75,16 +79,19 @@ fn drop_timer() {
 
         let inner = handle.inner.clone();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(inner.clone());
+            let entry = TimerEntry::new();
             pin!(entry);
-            entry.as_mut().init(inner.driver().now() + 1000);
+            entry.as_mut().init(&inner, inner.driver().now() + 1000);
 
-            let _ = entry
-                .as_mut()
-                .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
-            let _ = entry
-                .as_mut()
-                .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
+            let _ = entry.as_mut().poll_elapsed(
+                &mut Context::from_waker(futures::task::noop_waker_ref()),
+                &inner,
+            );
+            let _ = entry.as_mut().poll_elapsed(
+                &mut Context::from_waker(futures::task::noop_waker_ref()),
+                &inner,
+            );
+            entry.cancel(&inner);
         });
 
         thread::yield_now();
@@ -107,15 +114,20 @@ fn change_waker() {
 
         let inner = handle.inner.clone();
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(inner.clone());
+            let entry = TimerEntry::new();
             pin!(entry);
-            entry.as_mut().init(inner.driver().now() + 1000);
+            entry.as_mut().init(&inner, inner.driver().now() + 1000);
 
-            let _ = entry
-                .as_mut()
-                .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
+            let _ = entry.as_mut().poll_elapsed(
+                &mut Context::from_waker(futures::task::noop_waker_ref()),
+                &inner,
+            );
 
-            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
+            block_on(std::future::poll_fn(|cx| {
+                entry.as_mut().poll_elapsed(cx, &inner)
+            }))
+            .unwrap();
+            entry.cancel(&inner);
         });
 
         thread::yield_now();
@@ -143,20 +155,25 @@ fn reset_future() {
         let start = handle.inner.driver().now();
 
         let jh = thread::spawn(move || {
-            let entry = TimerEntry::new(inner.clone());
+            let entry = TimerEntry::new();
             pin!(entry);
-            entry.as_mut().init(start + 1000);
+            entry.as_mut().init(&inner, start + 1000);
 
-            let _ = entry
-                .as_mut()
-                .poll_elapsed(&mut Context::from_waker(futures::task::noop_waker_ref()));
+            let _ = entry.as_mut().poll_elapsed(
+                &mut Context::from_waker(futures::task::noop_waker_ref()),
+                &inner,
+            );
 
-            entry.as_mut().reset(start + 2000);
+            entry.as_mut().reset(&inner, start + 2000);
 
             // shouldn't complete before 2s
-            block_on(std::future::poll_fn(|cx| entry.as_mut().poll_elapsed(cx))).unwrap();
+            block_on(std::future::poll_fn(|cx| {
+                entry.as_mut().poll_elapsed(cx, &inner)
+            }))
+            .unwrap();
 
             finished_early_.store(true, Ordering::Relaxed);
+            entry.cancel(&inner);
         });
 
         thread::yield_now();
@@ -193,12 +210,14 @@ fn poll_process_levels() {
     let mut entries = vec![];
 
     for i in 0..normal_or_miri(1024, 64) {
-        let mut entry = Box::pin(TimerEntry::new(handle.inner.clone()));
-        entry.as_mut().init(handle.inner.driver().now() + i);
+        let mut entry = Box::pin(TimerEntry::new());
+        entry
+            .as_mut()
+            .init(&handle.inner, handle.inner.driver().now() + i);
 
         let _ = entry
             .as_mut()
-            .poll_elapsed(&mut Context::from_waker(noop_waker_ref()));
+            .poll_elapsed(&mut Context::from_waker(noop_waker_ref()), &handle.inner);
 
         entries.push(entry);
     }
@@ -209,9 +228,15 @@ fn poll_process_levels() {
         for (deadline, future) in entries.iter_mut().enumerate() {
             let mut context = Context::from_waker(noop_waker_ref());
             if deadline <= t {
-                assert!(future.as_mut().poll_elapsed(&mut context).is_ready());
+                assert!(future
+                    .as_mut()
+                    .poll_elapsed(&mut context, &handle.inner)
+                    .is_ready());
             } else {
-                assert!(future.as_mut().poll_elapsed(&mut context).is_pending());
+                assert!(future
+                    .as_mut()
+                    .poll_elapsed(&mut context, &handle.inner)
+                    .is_pending());
             }
         }
     }
@@ -225,16 +250,21 @@ fn poll_process_levels_targeted() {
     let rt = rt(true);
     let handle = rt.handle();
 
-    let e1 = TimerEntry::new(handle.inner.clone());
+    let e1 = TimerEntry::new();
     pin!(e1);
-    e1.as_mut().init(handle.inner.driver().now() + 193);
+    e1.as_mut()
+        .init(&handle.inner, handle.inner.driver().now() + 193);
 
-    let handle = handle.inner.driver().time();
+    let time = handle.inner.driver().time();
 
-    handle.process_at_time(62);
-    assert!(e1.as_mut().poll_elapsed(&mut context).is_pending());
-    handle.process_at_time(192);
-    handle.process_at_time(192);
+    time.process_at_time(62);
+    assert!(e1
+        .as_mut()
+        .poll_elapsed(&mut context, &handle.inner)
+        .is_pending());
+    time.process_at_time(192);
+    time.process_at_time(192);
+    e1.cancel(&handle.inner);
 }
 
 #[test]

--- a/tokio/src/runtime/time_alt/timer.rs
+++ b/tokio/src/runtime/time_alt/timer.rs
@@ -18,16 +18,10 @@ impl std::fmt::Debug for Timer {
     }
 }
 
-impl Drop for Timer {
-    fn drop(&mut self) {
-        self.entry.cancel();
-    }
-}
-
 impl Timer {
     #[track_caller]
-    pub(crate) fn new(handle: scheduler::Handle, deadline: u64) -> Self {
-        let entry = with_current_temp_local_context(&handle, |ctx| match ctx {
+    pub(crate) fn new(handle: &scheduler::Handle, deadline: u64) -> Self {
+        let entry = with_current_temp_local_context(handle, |ctx| match ctx {
             Some(TempLocalContext::Running { registration_queue }) => {
                 let entry = EntryHandle::new(deadline);
                 unsafe { registration_queue.push_front(entry.clone()) }
@@ -38,12 +32,16 @@ impl Timer {
 
             _ => {
                 let entry = EntryHandle::new(deadline);
-                push_from_remote(&handle, entry.clone());
+                push_from_remote(handle, entry.clone());
                 entry
             }
         });
 
         Timer { entry }
+    }
+
+    pub(crate) fn cancel(&self) {
+        self.entry.cancel();
     }
 
     pub(crate) fn is_elapsed(&self) -> bool {

--- a/tokio/src/time/sleep.rs
+++ b/tokio/src/time/sleep.rs
@@ -225,6 +225,15 @@ pin_project! {
         #[pin]
         timer: Option<Timer>,
     }
+
+    impl PinnedDrop for Sleep {
+        fn drop(this: Pin<&mut Self>) {
+            let this = this.project();
+            if let Some(timer) = this.timer.as_pin_mut() {
+                timer.cancel(this.driver);
+            }
+        }
+    }
 }
 
 cfg_trace! {
@@ -362,11 +371,11 @@ impl Sleep {
         }
 
         match this.timer.as_mut().as_pin_mut() {
-            Some(timer) => timer.reset(handle.clone(), deadline),
+            Some(timer) => timer.reset(handle, deadline),
             None => {
-                let timer = Timer::new(handle.clone(), deadline);
+                let timer = Timer::new(handle, deadline);
                 this.timer.set(Some(timer));
-                this.timer.as_pin_mut().unwrap().init(deadline);
+                this.timer.as_pin_mut().unwrap().init(handle, deadline);
             }
         }
     }
@@ -401,10 +410,10 @@ impl Sleep {
         #[cfg(any(not(tokio_unstable), not(feature = "tracing")))]
         let coop = ready!(crate::task::coop::poll_proceed(cx));
 
+        let handle = this.driver;
         let timer = match this.timer.as_mut().as_pin_mut() {
             Some(timer) => timer,
             None => {
-                let handle = this.driver;
                 let time_source = handle.driver().time().time_source();
                 let deadline = time_source.deadline_to_tick(*this.deadline);
 
@@ -420,15 +429,15 @@ impl Sleep {
                     );
                 }
 
-                let timer = Timer::new(handle.clone(), deadline);
+                let timer = Timer::new(handle, deadline);
                 this.timer.set(Some(timer));
                 let mut timer = this.timer.as_pin_mut().unwrap();
-                timer.as_mut().init(deadline);
+                timer.as_mut().init(handle, deadline);
                 timer
             }
         };
 
-        let result = timer.poll_elapsed(cx).map(move |r| {
+        let result = timer.poll_elapsed(cx, handle).map(move |r| {
             coop.made_progress();
             r
         });


### PR DESCRIPTION
## Motivation

Both timers and `Sleep` store a driver handle reference. The handle can be passed as necessary to timers from `Sleep`, however.

## Solution

Don't cancel timers on `drop`. Have `Sleep` cancel its timer on `drop`.

Depends upon #8457